### PR TITLE
Improve `createWidgetBase` internal instance cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@dojo/compose": "2.0.0-beta.21",
-    "@dojo/core": "2.0.0-alpha.20",
+    "@dojo/core": "2.0.0-alpha.21",
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/i18n": "2.0.0-alpha.5",
     "@dojo/shim": "2.0.0-beta.8",
@@ -60,13 +60,5 @@
     "sinon": "^1.17.6",
     "tslint": "^3.11.0",
     "typescript": "~2.1.4"
-  },
-  "dependencies": {
-    "@dojo/compose": "2.0.0-beta.21",
-    "@dojo/core": "2.0.0-alpha.20",
-    "@dojo/has": "2.0.0-alpha.7",
-    "@dojo/i18n": "2.0.0-alpha.5",
-    "@dojo/shim": "2.0.0-beta.8",
-    "maquette": ">=2.3.7 <=2.4.1"
   }
 }

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -479,7 +479,7 @@ registerSuite({
 
 			const consoleStub = stub(console, 'error');
 			widgetBase.__render__();
-			assert.isTrue(consoleStub.calledWith('must provide unique keys when using the same widget factory multiple times'));
+			assert.isTrue(consoleStub.calledWith('It is recommended to provide unique keys when using the same widget factory multiple times'));
 			consoleStub.restore();
 		},
 		'render with updated properties'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

As per the associated issue, support `factory` changing for a child with an `id` and intelligently cache child widgets using the same `factory` without an explicit `id`.

Resolves #276 
