### PR TITLE
Improve `createWidgetBase` internal instance cache

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -19,6 +19,12 @@ import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
 import { v, registry, isWNode } from './d';
 
+interface WidgetCacheWrapper {
+	child: Widget<WidgetProperties>;
+	factory: WidgetBaseFactory;
+	used: boolean;
+}
+
 interface WidgetInternalState {
 	children: DNode[];
 	dirty: boolean;
@@ -27,8 +33,7 @@ interface WidgetInternalState {
 	initializedFactoryMap: Map<string, Promise<WidgetBaseFactory>>;
 	properties: WidgetProperties;
 	previousProperties: WidgetProperties;
-	historicChildrenMap: Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>;
-	currentChildrenMap: Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>;
+	cachedChildrenMap: Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, WidgetCacheWrapper[]>;
 	diffPropertyFunctionMap: Map<string, string>;
 };
 
@@ -79,31 +84,33 @@ function dNodeToVNode(instance: Widget<WidgetProperties>, dNode: DNode): VNode |
 		}
 
 		const childrenMapKey = id || factory;
-		const cachedChild = internalState.historicChildrenMap.get(childrenMapKey);
+		const cachedChildren = internalState.cachedChildrenMap.get(childrenMapKey) || [];
+		const [ cachedChild ] = cachedChildren.filter((cachedChildWrapper) => {
+			return cachedChildWrapper.factory === factory && !cachedChildWrapper.used;
+		});
 
 		if (cachedChild) {
-			child = cachedChild;
+			child = cachedChild.child;
 			if (properties) {
 				child.setProperties(properties);
 			}
+			cachedChild.used = true;
 		}
 		else {
 			child = factory({ properties });
 			child.own(child.on('invalidated', () => {
 				instance.invalidate();
 			}));
-			internalState.historicChildrenMap.set(childrenMapKey, child);
+			internalState.cachedChildrenMap.set(childrenMapKey, [...cachedChildren, { child, factory, used: true }]);
 			instance.own(child);
 		}
-		if (!id && internalState.currentChildrenMap.has(factory)) {
+		if (!id && cachedChildren.length > 0) {
 			const errorMsg = 'must provide unique keys when using the same widget factory multiple times';
 			console.error(errorMsg);
 			instance.emit({ type: 'error', target: instance, error: new Error(errorMsg) });
 		}
 
 		child.setChildren(children);
-		internalState.currentChildrenMap.set(childrenMapKey, child);
-
 		return child.__render__();
 	}
 
@@ -119,13 +126,17 @@ function dNodeToVNode(instance: Widget<WidgetProperties>, dNode: DNode): VNode |
 function manageDetachedChildren(instance: Widget<WidgetProperties>): void {
 	const internalState = widgetInternalStateMap.get(instance);
 
-	internalState.historicChildrenMap.forEach((child, key) => {
-		if (!internalState.currentChildrenMap.has(key) && internalState.historicChildrenMap.has(key)) {
-			internalState.historicChildrenMap.delete(key);
-			child.destroy();
-		}
+	internalState.cachedChildrenMap.forEach((cachedChildren, key) => {
+		const filterCachedChildren = cachedChildren.filter((cachedChild) => {
+			if (cachedChild.used) {
+				cachedChild.used = false;
+				return true;
+			}
+			cachedChild.child.destroy();
+			return false;
+		});
+		internalState.cachedChildrenMap.set(key, filterCachedChildren);
 	});
-	internalState.currentChildrenMap.clear();
 }
 
 function formatTagNameAndClasses(tagName: string, classes: string[]) {
@@ -299,8 +310,7 @@ const createWidget: WidgetBaseFactory = createEvented
 				properties: {},
 				previousProperties: {},
 				initializedFactoryMap: new Map<string, Promise<WidgetBaseFactory>>(),
-				historicChildrenMap: new Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>(),
-				currentChildrenMap: new Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>(),
+				cachedChildrenMap: new Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, WidgetCacheWrapper[]>(),
 				diffPropertyFunctionMap,
 				children: []
 			});

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -465,21 +465,31 @@ registerSuite({
 			assert.strictEqual(lastRenderChild.vnodeSelector, 'footer');
 		},
 		'render with multiple children of the same type without an id'() {
+
+			const createWidgetOne = createWidgetBase.mixin({});
+			const createWidgetTwo = createWidgetBase.mixin({});
+
 			const widgetBase = createWidgetBase
 				.mixin({
 					mixin: {
 						getChildrenNodes: function(this: any): (DNode | null)[] {
 							return [
-								w(createWidgetBase, {}),
-								w(createWidgetBase, {})
+								w(createWidgetOne, {}),
+								w(createWidgetTwo, {}),
+								w(createWidgetTwo, {})
 							];
 						}
 					}
 				})();
 
-			const consoleStub = stub(console, 'error');
+			const consoleStub = stub(console, 'warn');
 			widgetBase.__render__();
-			assert.isTrue(consoleStub.calledWith('must provide unique keys when using the same widget factory multiple times'));
+			assert.isTrue(consoleStub.calledOnce);
+			assert.isTrue(consoleStub.calledWith('It is recommended to provide unique keys when using the same widget factory multiple times'));
+			widgetBase.invalidate();
+			widgetBase.__render__();
+			assert.isTrue(consoleStub.calledThrice);
+			assert.isTrue(consoleStub.calledWith('It is recommended to provide unique keys when using the same widget factory multiple times'));
 			consoleStub.restore();
 		},
 		'render with updated properties'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

An alternative to #278 based on suggestions from @matt-gadd.

As per the associated issue, support factory changing for a child with an id and intelligently cache child widgets using the same factory without an explicit id.

Resolves #276 
