### PR TITLE
Partial P for return of diff properties to allow Mandatory properties

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -156,7 +156,7 @@ export interface PropertyComparison<P extends WidgetProperties> {
 	/**
 	 * Determine changed or new property keys on setProperties and assign them on return.
 	 */
-	diffProperties<S>(this: S, previousProperties: P, newProperties: P): PropertiesChangeRecord<P>;
+	diffProperties<S>(this: S, previousProperties: P, newProperties: P): PropertiesChangeRecord<Partial<P>>;
 }
 
 export interface WidgetMixin<P extends WidgetProperties> extends PropertyComparison<P> {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Allow mandatory properties
