### PR TITLE
Add store data to data property on state when observing a store without an id

### DIFF
--- a/src/mixins/storeMixin.ts
+++ b/src/mixins/storeMixin.ts
@@ -124,7 +124,7 @@ const storeMixinFactory: StoreMixinFactory = createEvented.mixin({
 			const observer = id ? store.observe(id) : store.observe();
 			const subscription = observer.subscribe(
 				(state) => {
-					replaceState(this, state['afterAll'] ? state['afterAll'] : state);
+					replaceState(this, state['afterAll'] ? { data: state['afterAll'] } : state);
 				},
 				(err) => {
 					throw err;

--- a/tests/unit/mixins/storeMixin.ts
+++ b/tests/unit/mixins/storeMixin.ts
@@ -127,17 +127,17 @@ registerSuite({
 						if (intialStateChange) {
 							intialStateChange = false;
 							assert.isOk(storeMixin.state);
-							assert.lengthOf(storeMixin.state, 2);
-							assert.deepEqual(storeMixin.state, [
+							assert.lengthOf(storeMixin.state['data'], 2);
+							assert.deepEqual(storeMixin.state, { data: [
 								{ id: '1', foo: 'bar'}, { id: '2', foo: 'bar' }
-							]);
+							] });
 						}
 						else {
 							assert.isOk(storeMixin.state);
-							assert.lengthOf(storeMixin.state, 2);
-							assert.deepEqual(storeMixin.state, [
+							assert.lengthOf(storeMixin.state['data'], 2);
+							assert.deepEqual(storeMixin.state, { data: [
 								{ id: '1', foo: 'baz', baz: 'qux'}, { id: '2', foo: 'bar' }
-							]);
+							]});
 							resolve();
 						}
 					} catch (err) {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add store data to data property on state rather than replacing state.

Resolves #284
