### PR TITLE
Use 'key' for instance management instead of 'id'

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -60,7 +60,7 @@ function dNodeToVNode(instance: Widget<WidgetProperties>, dNode: DNode): VNode |
 
 	if (isWNode(dNode)) {
 		const { children, properties } = dNode;
-		const { id } = properties;
+		const { key } = properties;
 
 		let { factory } = dNode;
 		let child: Widget<WidgetProperties>;
@@ -83,7 +83,7 @@ function dNodeToVNode(instance: Widget<WidgetProperties>, dNode: DNode): VNode |
 			}
 		}
 
-		const childrenMapKey = id || factory;
+		const childrenMapKey = key || factory;
 		let cachedChildren = internalState.cachedChildrenMap.get(childrenMapKey) || [];
 		let cachedChild: WidgetCacheWrapper | undefined;
 		cachedChildren.some((cachedChildWrapper) => {
@@ -110,8 +110,8 @@ function dNodeToVNode(instance: Widget<WidgetProperties>, dNode: DNode): VNode |
 			internalState.cachedChildrenMap.set(childrenMapKey, cachedChildren);
 			instance.own(child);
 		}
-		if (!id && cachedChildren.length > 1) {
-			const errorMsg = 'It is recommended to provide unique keys when using the same widget factory multiple times';
+		if (!key && cachedChildren.length > 1) {
+			const errorMsg = 'It is recommended to provide a unique `key` property when using the same widget factory multiple times';
 			console.warn(errorMsg);
 			instance.emit({ type: 'error', target: instance, error: new Error(errorMsg) });
 		}

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -273,6 +273,7 @@ export interface WidgetOptions<P extends WidgetProperties> extends EventedOption
 export interface WidgetProperties {
 	[index: string]: any;
 	id?: string;
+	key?: string;
 	classes?: string[];
 }
 

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -465,7 +465,7 @@ registerSuite({
 			assert.strictEqual(lastRenderChild.vnodeSelector, 'footer');
 		},
 		'render with multiple children of the same type without an id'() {
-
+			const warnMsg = 'It is recommended to provide a unique `key` property when using the same widget factory multiple times';
 			const createWidgetOne = createWidgetBase.mixin({});
 			const createWidgetTwo = createWidgetBase.mixin({});
 
@@ -485,11 +485,11 @@ registerSuite({
 			const consoleStub = stub(console, 'warn');
 			widgetBase.__render__();
 			assert.isTrue(consoleStub.calledOnce);
-			assert.isTrue(consoleStub.calledWith('It is recommended to provide unique keys when using the same widget factory multiple times'));
+			assert.isTrue(consoleStub.calledWith(warnMsg));
 			widgetBase.invalidate();
 			widgetBase.__render__();
 			assert.isTrue(consoleStub.calledThrice);
-			assert.isTrue(consoleStub.calledWith('It is recommended to provide unique keys when using the same widget factory multiple times'));
+			assert.isTrue(consoleStub.calledWith(warnMsg));
 			consoleStub.restore();
 		},
 		'render with updated properties'() {
@@ -616,7 +616,7 @@ registerSuite({
 
 			assert.equal(childWidgetInstantiatedCount, 5);
 		},
-		'support updating factories for children with an `id`'() {
+		'support updating factories for children with an `key`'() {
 			let renderWidgetOne = true;
 			let widgetOneInstantiated = false;
 			let widgetTwoInstantiated = false;
@@ -634,7 +634,7 @@ registerSuite({
 				mixin: {
 					getChildrenNodes(): DNode[] {
 						return [
-							renderWidgetOne ? w(createWidgetOne, { id: '1' }) : w(createWidgetTwo, { id: '1' })
+							renderWidgetOne ? w(createWidgetOne, { key: '1' }) : w(createWidgetTwo, { key: '1' })
 						];
 					}
 				}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

`id` is overloaded and therefore a key might be required for a widget but not be the `id` of the widget which could cause issues. Also aligns with Maquette's terminology.

Resolves #288 
