### PR TITLE
Call invalidate on state change in store mixin

### DIFF
--- a/src/mixins/storeMixin.ts
+++ b/src/mixins/storeMixin.ts
@@ -50,6 +50,7 @@ export interface StoreMixinApi extends StatefulMixin<State> {
  */
 export interface StoreMixin extends StoreMixinApi {
 	readonly properties: StoreMixinProperties;
+	invalidate(): void;
 }
 
 /**
@@ -159,6 +160,9 @@ const storeMixinFactory: StoreMixinFactory = createEvented.mixin({
 	initialize(instance: StoreMixin) {
 		instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<StoreMixin, StoreMixinProperties>) => {
 			onPropertiesChanged(instance, evt.properties, evt.changedPropertyKeys);
+		}));
+		instance.own(instance.on(stateChangedEventType, () => {
+			instance.invalidate();
 		}));
 		stateMap.set(instance, { state: Object.create(null) });
 		instance.observe();

--- a/tests/unit/mixins/storeMixin.ts
+++ b/tests/unit/mixins/storeMixin.ts
@@ -9,6 +9,7 @@ let store: ObservableStore<{}, {}, any>;
 
 const storeMixinWithProperties = compose({
 	properties: <any> {},
+	invalidate() {},
 	diffProperties(this: any, previousProperties: any, newProperties: any) {}
 }, (instance, options: any) => {
 	if (options) {
@@ -156,6 +157,19 @@ registerSuite({
 			storeMixin.observe();
 			assert.throws(() => storeMixin.setState({ foo: 'baz', baz: 'qux' }), Error);
 		}
+	},
+	'on "state:changed event'() {
+		let invalidateCalled = false;
+		const storeMixin = storeMixinWithProperties.mixin({
+			mixin: {
+				invalidate(): void {
+					invalidateCalled = true;
+				}
+			}
+		})({ properties: { id: '1', store } });
+
+		storeMixin.emit({ type: 'state:changed' });
+		assert.isTrue(invalidateCalled);
 	},
 	'on "properties:changed" event': {
 		'initial properties'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Calls `widget.invalidate()` on the `state:changed` event

Resolves #285 
