### PR TITLE
Fix generics for the themeable mixin and make applied classes keys non-optional

### DIFF
--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -42,15 +42,15 @@ export interface ThemeableOptions {
 /**
  * Themeable Mixin
  */
-export interface ThemeableMixin<P> extends Evented {
-	theme: AppliedClasses<P>;
+export interface ThemeableMixin<T> extends Evented {
+	theme: AppliedClasses<T>;
 }
 
 /**
  * Themeable
  */
-export interface Themeable<P> extends ThemeableMixin<P> {
-	baseTheme: P;
+export interface Themeable<T> extends ThemeableMixin<T> {
+	baseTheme: T;
 	properties: ThemeableProperties;
 }
 
@@ -95,7 +95,7 @@ function negatePreviousClasses<T>(previousClasses: AppliedClasses<T>, newClasses
 	}, <AppliedClasses<T>> {});
 }
 
-function generateThemeClasses<I, T>(instance: Themeable<I>, baseTheme: T, theme: {} = {}, overrideClasses: {} = {}) {
+function generateThemeClasses<T>(instance: Themeable<T>, baseTheme: T, theme: {} = {}, overrideClasses: {} = {}) {
 	return Object.keys(baseTheme).reduce((newAppliedClasses, className: keyof T) => {
 		const newCSSModuleClassNames: CSSModuleClassNames = {};
 		const themeClassSource = theme.hasOwnProperty(className) ? theme : baseTheme;
@@ -108,7 +108,7 @@ function generateThemeClasses<I, T>(instance: Themeable<I>, baseTheme: T, theme:
 	}, <AppliedClasses<T>> {});
 }
 
-function updateThemeClassesMap<I, T>(instance: Themeable<I>, newThemeClasses: AppliedClasses<T>) {
+function updateThemeClassesMap<T>(instance: Themeable<T>, newThemeClasses: AppliedClasses<T>) {
 	if (themeClassesMap.has(instance)) {
 		const previousThemeClasses = themeClassesMap.get(instance);
 		themeClassesMap.set(instance, negatePreviousClasses(previousThemeClasses, newThemeClasses));
@@ -117,7 +117,7 @@ function updateThemeClassesMap<I, T>(instance: Themeable<I>, newThemeClasses: Ap
 	}
 }
 
-function onPropertiesChanged<I>(instance: Themeable<I>, { theme, overrideClasses }: ThemeableProperties, changedPropertyKeys: string[]) {
+function onPropertiesChanged<T>(instance: Themeable<T>, { theme, overrideClasses }: ThemeableProperties, changedPropertyKeys: string[]) {
 	const themeChanged = includes(changedPropertyKeys, 'theme');
 	const overrideClassesChanged = includes(changedPropertyKeys, 'overrideClasses');
 
@@ -136,8 +136,8 @@ const themeableFactory: ThemeableFactory = createEvented.mixin({
 			return themeClassesMap.get(this);
 		}
 	},
-	initialize<I>(instance: Themeable<I>) {
-		instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<ThemeableMixin<I>, ThemeableProperties>) => {
+	initialize<T>(instance: Themeable<T>) {
+		instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<ThemeableMixin<T>, ThemeableProperties>) => {
 			onPropertiesChanged(instance, evt.properties, evt.changedPropertyKeys);
 		}));
 		onPropertiesChanged(instance, instance.properties, [ 'theme' ]);

--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -19,7 +19,7 @@ export type CSSModuleClassNames = {
  * The object returned by getClasses.
  */
 export type AppliedClasses<T> = {
-	[P in keyof T]?: CSSModuleClassNames;
+	[P in keyof T]: CSSModuleClassNames;
 };
 
 type StringIndexedObject = { [key: string]: string; };
@@ -57,7 +57,7 @@ export interface Themeable<T> extends ThemeableMixin<T> {
 /**
  * Compose Themeable Factory interface
  */
-export interface ThemeableFactory extends ComposeFactory<ThemeableMixin<{}>, ThemeableOptions> {}
+export interface ThemeableFactory extends ComposeFactory<ThemeableMixin<any>, ThemeableOptions> {}
 
 /**
  * Private map for the widgets themeClasses.

--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -62,7 +62,7 @@ export interface ThemeableFactory extends ComposeFactory<ThemeableMixin<any>, Th
 /**
  * Private map for the widgets themeClasses.
  */
-const themeClassesMap = new WeakMap<ThemeableMixin<{}>, AppliedClasses<any>>();
+const themeClassesMap = new WeakMap<Themeable<any>, AppliedClasses<any>>();
 
 function addClassNameToCSSModuleClassNames(cssModuleClassNames: CSSModuleClassNames, classList: StringIndexedObject, className: string) {
 	if (classList.hasOwnProperty(className)) {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
- Make applied classes keys non-optional
- Change all generics to `<T>` (for Theme) and remove / fix incorrect generics
- Change factory generic from `<{}>` to `<any>` as we do know know until it is initialized / used what the type will be.

Resolves #291 
