### PR TITLE
Adding web components utilities, meta-120

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -1,0 +1,254 @@
+import { w } from './d';
+import { WidgetProperties, WidgetFactory, Widget, DNode } from './interfaces';
+import createProjectorMixin from './mixins/createProjectorMixin';
+import createDomWrapper from './util/createDomWrapper';
+import { assign } from '@dojo/core/lang';
+import { Projector } from './mixins/createProjectorMixin';
+import { from as arrayFrom } from '@dojo/shim/array';
+/**
+ * @type CustomElementAttributeDescriptor
+ *
+ * Describes a custom element attribute
+ *
+ * @property {string}       attributeName   The name of the attribute on the DOM element
+ * @property {string?}      propertyName    The name of the property on the widget
+ * @property {Function?}    value           A function that takes a string or null value, and returns a new value. The widget's property will be set to the new value.
+ */
+export interface CustomElementAttributeDescriptor {
+	attributeName: string;
+	propertyName?: string;
+	value?: (value: string | null) => any;
+}
+
+/**
+ * @type CustomElementPropertyDescriptor
+ *
+ * Describes a widget property exposed via a custom element
+ *
+ * @property {string}       propertyName        The name of the property on the DOM element
+ * @property {string?}      widgetPropertyName  The name of the property on the widget
+ * @property {Function?}    getValue            A transformation function on the widget's property value
+ * @property {Function?}    setValue            A transformation function on the DOM elements property value
+ */
+export interface CustomElementPropertyDescriptor {
+	propertyName: string;
+	widgetPropertyName?: string;
+	getValue?: (value: any) => any;
+	setValue?: (value: any) => any;
+}
+
+/**
+ * @type CustomElementEventDescriptor
+ *
+ * Describes a custom element event
+ *
+ * @property    {string}    propertyName    The name of the property on the widget that takes a function
+ * @property    {string}    eventName       The type of the event to emit (it will be a CustomEvent object of this type)
+ */
+export interface CustomElementEventDescriptor {
+	propertyName: string;
+	eventName: string;
+}
+
+/**
+ * Defines a custom element intializing function. Passes in initial properties so they can be extended
+ * by the initializer.
+ */
+export interface CustomElementInitializer {
+	(properties: WidgetProperties): void;
+}
+
+/**
+ * @type CustomElementDescriptor
+ *
+ * Describes a custom element.
+ *
+ * @property    {string}                                tagName         The tag name to register this widget under. Tag names must contain a "-"
+ * @property    {WidgetFactory}                         widgetFactory   A widget factory that will return the widget to be wrapped in a custom element
+ * @property    {CustomElementAttributeDescriptor[]?}   attributes      A list of attributes to define on this element
+ * @property    {CustomElementPropertyDescriptor[]?}    properties      A list of properties to define on this element
+ * @property    {CustomElementEventDescriptor[]?}       events          A list of events to expose on this element
+ * @property    {CustomElementInitializer?}             initialization  A method to run to set custom properties on the wrapped widget
+ */
+export interface CustomElementDescriptor {
+	/**
+	 * The name of the custom element tag
+	 */
+	tagName: string;
+
+	/**
+	 * Widget factory that will create the widget
+	 */
+	widgetFactory: WidgetFactory<any, any>;
+
+	/**
+	 * List of attributes on the custom element to map to widget properties
+	 */
+	attributes?: CustomElementAttributeDescriptor[];
+
+	/**
+	 * List of widget properties to expose as properties on the custom element
+	 */
+	properties?: CustomElementPropertyDescriptor[];
+
+	/**
+	 * List of events to expose
+	 */
+	events?: CustomElementEventDescriptor[];
+
+	/**
+	 * Initialization function called before the widget is created (for custom property setting)
+	 */
+	initialization?: CustomElementInitializer;
+}
+
+/**
+ * @type CustomElement
+ *
+ * A custom element extends upon a regular HTMLElement but adds fields for describing and wrapping a widget factory.
+ *
+ * @property    {WidgetFactory}             getWidgetFactory    Return the widget factory for this element
+ * @property    {CustomElementDescriptor}   getDescriptor       Return the element descriptor for this element
+ * @property    {Widget}                    getWidgetInstance   Return the widget instance that this element wraps
+ * @property                                setWidgetInstance   Set the widget instance for this element
+ */
+export interface CustomElement extends HTMLElement {
+	getWidgetFactory(): WidgetFactory<any, any>;
+	getDescriptor(): CustomElementDescriptor;
+	getWidgetInstance(): Widget<any>;
+	setWidgetInstance(instance: Widget<any>): void;
+}
+
+function getWidgetPropertyFromAttribute(attributeName: string, attributeValue: string | null, descriptor: CustomElementAttributeDescriptor): [ string, any ] {
+	let { propertyName = attributeName, value = attributeValue } = descriptor;
+
+	if (typeof value === 'function') {
+		value = value(attributeValue);
+	}
+
+	return [ propertyName, value ];
+}
+
+/**
+ * Called by HTMLElement subclass to initialize itself with the appropriate attributes/properties/events.
+ *
+ * @param {CustomElement} element
+ */
+export function initializeElement(element: CustomElement) {
+	let initialProperties: any = {};
+
+	const { attributes = [], events = [], properties = [], initialization } = element.getDescriptor();
+
+	attributes.forEach(attribute => {
+		const attributeName = attribute.attributeName;
+
+		const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attributeName, element.getAttribute(attributeName), attribute);
+		initialProperties[ propertyName ] = propertyValue;
+	});
+
+	let customProperties: PropertyDescriptorMap = {};
+
+	attributes.reduce((properties, attribute) => {
+		const { propertyName = attribute.attributeName } = attribute;
+
+		properties[ propertyName ] = {
+			get() {
+				return element.getWidgetInstance().properties[ propertyName ];
+			},
+			set(value: any) {
+				const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attribute.attributeName, value, attribute);
+				element.getWidgetInstance().setProperties(assign({}, element.getWidgetInstance().properties, {
+					[propertyName]: propertyValue
+				}));
+			}
+		};
+
+		return properties;
+	}, customProperties);
+
+	properties.reduce((properties, property) => {
+		const { propertyName, getValue, setValue } = property;
+		const { widgetPropertyName = propertyName } = property;
+
+		properties[ propertyName ] = {
+			get() {
+				const value = element.getWidgetInstance().properties[ widgetPropertyName ];
+				return getValue ? getValue(value) : value;
+			},
+
+			set(value: any) {
+				element.getWidgetInstance().setProperties(assign(
+					{},
+					element.getWidgetInstance().properties,
+					{ [widgetPropertyName]: setValue ? setValue(value) : value }
+				));
+			}
+		};
+
+		return properties;
+	}, customProperties);
+
+	Object.defineProperties(element, customProperties);
+
+	// define events
+	events.forEach((event) => {
+		const { propertyName, eventName } = event;
+
+		initialProperties[ propertyName ] = (event: any) => {
+			element.dispatchEvent(new CustomEvent(eventName, {
+				bubbles: false,
+				detail: event
+			}));
+		};
+	});
+
+	// find children
+	let children: DNode[] = [];
+
+	arrayFrom(element.children).forEach((childNode: HTMLElement, index: number) => {
+		children.push(w(createDomWrapper, {
+			key: `child-${index}`,
+			domNode: childNode
+		}));
+	});
+
+	if (initialization) {
+		initialization.call(element, initialProperties);
+	}
+
+	arrayFrom(element.children).forEach((childNode: HTMLElement) => {
+		element.removeChild(childNode);
+	});
+
+	const widgetInstance: Projector = element.getWidgetFactory().mixin(createProjectorMixin)({
+		root: element
+	});
+	widgetInstance.setProperties(initialProperties);
+	widgetInstance.setChildren(children);
+	element.setWidgetInstance(widgetInstance);
+
+	widgetInstance.append();
+}
+
+/**
+ * Called by HTMLElement subclass when an HTML attribute has changed.
+ *
+ * @param {CustomElement}   element     The element whose attributes are being watched
+ * @param {string}          name        The name of the attribute
+ * @param {string?}         newValue    The new value of the attribute
+ * @param {string?}         oldValue    The old value of the attribute
+ */
+export function handleAttributeChanged(element: CustomElement, name: string, newValue: string | null, oldValue: string | null) {
+	const attributes = element.getDescriptor().attributes || [];
+
+	attributes.forEach((attribute) => {
+		if (attribute.attributeName === name) {
+			const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(name, newValue, attribute);
+			element.getWidgetInstance().setProperties(assign(
+				{},
+				element.getWidgetInstance().properties,
+				{ [propertyName]: propertyValue }
+			));
+		}
+	});
+}

--- a/src/util/createDomWrapper.ts
+++ b/src/util/createDomWrapper.ts
@@ -1,0 +1,84 @@
+import createWidget from '../createWidgetBase';
+import { isHNode } from '../d';
+import { Widget, WidgetProperties, DNode } from '../interfaces';
+import { ComposeFactory } from '@dojo/compose/compose';
+import { assign } from '@dojo/core/lang';
+import { VNode } from '@dojo/interfaces/vdom';
+import WeakMap from '@dojo/shim/WeakMap';
+
+export interface DomWrapperProperties extends WidgetProperties {
+	domNode: Node;
+}
+
+export type DomWrapperFactory = ComposeFactory<Widget<DomWrapperProperties>, DomWrapperProperties>;
+
+interface DomWrapperPrivates {
+	vNode: VNode;
+}
+
+const domWrapperData = new WeakMap<Widget<DomWrapperProperties>, DomWrapperPrivates>();
+
+function handleDomInsertion(instance: Widget<DomWrapperProperties>, newNode: Node | null | undefined) {
+	let notNullNode = newNode;
+
+	if (!notNullNode) {
+		notNullNode = document.createElement('div'); // placeholder element
+	}
+
+	const data = domWrapperData.get(instance);
+
+	if (data) {
+		const domNode = data.vNode.domNode!;
+
+		// replace the vNode domElement with our new element...
+		if (domNode.parentNode) {
+			domNode.parentNode.replaceChild(notNullNode, domNode);
+		}
+
+		// and update the reference to our vnode
+		data.vNode.domNode = notNullNode;
+	}
+}
+
+const createDomWrapper: DomWrapperFactory = createWidget.mixin({
+	mixin: {
+		afterCreate(this: Widget<DomWrapperProperties>) {
+			handleDomInsertion(this, this.properties.domNode);
+		},
+		afterUpdate(this: Widget<DomWrapperProperties>) {
+			handleDomInsertion(this, this.properties.domNode);
+		}
+	}
+}).aspect({
+	after: {
+		render(this: Widget<DomWrapperProperties>, dNode: DNode) {
+			if (isHNode(dNode)) {
+				const { afterCreate, afterUpdate } = this;
+
+				assign(dNode.properties, {
+					afterCreate,
+					afterUpdate
+				});
+			}
+
+			return dNode;
+		},
+		__render__(this: Widget<DomWrapperProperties>, vNode: VNode) {
+			if (vNode && typeof vNode !== 'string') {
+				if (vNode.domNode !== null) {
+					// we need to hold on to our vNode for future updates
+					domWrapperData.set(this, {
+						vNode: vNode
+					});
+				}
+			}
+			else {
+				domWrapperData.delete(this);
+			}
+
+			return vNode;
+		}
+	}
+});
+
+export default createDomWrapper;

--- a/src/util/createDomWrapper.ts
+++ b/src/util/createDomWrapper.ts
@@ -28,11 +28,9 @@ function handleDomInsertion(instance: Widget<DomWrapperProperties>, newNode: Nod
 	const data = domWrapperData.get(instance);
 
 	if (data) {
-		const domNode = data.vNode.domNode!;
-
 		// replace the vNode domElement with our new element...
-		if (domNode.parentNode) {
-			domNode.parentNode.replaceChild(notNullNode, domNode);
+		if (data.vNode.domNode && data.vNode.domNode.parentNode) {
+			data.vNode.domNode.parentNode.replaceChild(notNullNode, data.vNode.domNode);
 		}
 
 		// and update the reference to our vnode
@@ -65,8 +63,7 @@ const createDomWrapper: DomWrapperFactory = createWidget.mixin({
 		},
 		__render__(this: Widget<DomWrapperProperties>, vNode: VNode) {
 			if (vNode && typeof vNode !== 'string') {
-				if (vNode.domNode !== null) {
-					// we need to hold on to our vNode for future updates
+				if (!domWrapperData.has(this)) {
 					domWrapperData.set(this, {
 						vNode: vNode
 					});

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,7 +1,9 @@
 import './createProjector'; // projector should load before integrations, because it loads a shim
 import './createWidgetBase';
+import './customElements';
 import './d';
 import './integrations';
 import './main';
 import './FactoryRegistry';
 import './mixins/all';
+import './util/all';

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -1,0 +1,321 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { initializeElement, handleAttributeChanged, CustomElementDescriptor } from '../../src/customElements';
+import { Widget } from '../../src/interfaces';
+import createWidget from '../../src/createWidgetBase';
+import global from '@dojo/core/global';
+import { assign } from '@dojo/core/lang';
+
+function createFakeElement(attributes: any, descriptor: CustomElementDescriptor): any {
+	let widgetInstance: Widget<any> | null;
+	let events: Event[] = [];
+	let removedChildren: any[] = [];
+
+	return {
+		getWidgetInstance: () => widgetInstance!,
+		setWidgetInstance(instance: Widget<any>) {
+			widgetInstance = instance;
+		},
+		getWidgetFactory: () => createWidget,
+		getDescriptor: () => descriptor,
+		children: [],
+		getAttribute(name: string) {
+			return attributes[ name ] || null;
+		},
+		dispatchEvent(event: Event) {
+			events.push(event);
+		},
+		appendChild: function () {
+		},
+		getEvents() {
+			return events;
+		},
+		removeChild(child: any) {
+			removedChildren.push(child);
+		},
+		removedChildren() {
+			return removedChildren;
+		}
+	};
+}
+
+let oldCustomEvent: any;
+
+registerSuite({
+	name: 'customElements',
+
+	'attributes': {
+		'attributes are set as properties'() {
+			let element = createFakeElement({
+				'a': '1',
+				'my-attribute': '2',
+				'convert': '4'
+			}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				attributes: [
+					{
+						attributeName: 'a'
+					},
+					{
+						attributeName: 'my-attribute',
+						propertyName: 'b'
+					},
+					{
+						attributeName: 'convert',
+						value: (value: string | null) => {
+							return parseInt(value || '0', 10) * 2;
+						}
+					}
+				]
+			});
+
+			initializeElement(element);
+
+			assert.deepEqual(element.getWidgetInstance().properties, {
+				'a': '1',
+				'b': '2',
+				'convert': 8
+			});
+		},
+
+		'attributes also create properties'() {
+			let element = createFakeElement({
+				'a': '1',
+				'my-attribute': '2'
+			}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				attributes: [
+					{
+						attributeName: 'a'
+					},
+					{
+						attributeName: 'my-attribute',
+						propertyName: 'b'
+					}
+				]
+			});
+
+			initializeElement(element);
+
+			assert.strictEqual(element.a, '1');
+			assert.strictEqual(element.b, '2');
+		},
+
+		'setting attribute properties sets the widget properties'() {
+			let element = createFakeElement({
+				'a': '1',
+				'my-attribute': '2'
+			}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				attributes: [
+					{
+						attributeName: 'a'
+					},
+					{
+						attributeName: 'my-attribute',
+						propertyName: 'b'
+					}
+				]
+			});
+
+			initializeElement(element);
+
+			element.a = 4;
+
+			assert.strictEqual(element.getWidgetInstance().properties.a, 4);
+		},
+
+		'attribute changes are sent to widget'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				attributes: [
+					{
+						attributeName: 'a'
+					}
+				]
+			});
+
+			initializeElement(element);
+
+			handleAttributeChanged(element, 'a', 'test', null);
+			handleAttributeChanged(element, 'b', 'test', null);
+
+			assert.strictEqual(element.getWidgetInstance().properties.a, 'test');
+			assert.isUndefined(element.getWidgetInstance().properties.b);
+		},
+
+		'unregistered attribute changes do nothing'() {
+			let element = createFakeElement({}, {
+				widgetFactory: createWidget,
+				tagName: 'test'
+			});
+
+			initializeElement(element);
+
+			handleAttributeChanged(element, 'b', 'test', null);
+
+			assert.isUndefined(element.getWidgetInstance().properties.b);
+		}
+	},
+	'properties': {
+		'property names default to provided name'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				properties: [
+					{
+						propertyName: 'a'
+					}
+				]
+			});
+
+			initializeElement(element);
+			element.getWidgetInstance().setProperties({
+				a: 'test'
+			});
+
+			assert.deepEqual(element.a, 'test');
+
+			element.a = 'blah';
+			assert.deepEqual(element.getWidgetInstance().properties.a, 'blah');
+		},
+		'widget property names can be specified'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				properties: [
+					{
+						propertyName: 'a',
+						widgetPropertyName: 'test'
+					}
+				]
+			});
+
+			initializeElement(element);
+			element.getWidgetInstance().setProperties({
+				test: 'test'
+			});
+
+			assert.deepEqual(element.a, 'test');
+		},
+		'properties can transform with getter'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				properties: [
+					{
+						propertyName: 'a',
+						getValue: (value: any) => {
+							return value * 2;
+						}
+					}
+				]
+			});
+
+			initializeElement(element);
+			element.getWidgetInstance().setProperties({
+				a: 4
+			});
+
+			assert.deepEqual(element.a, 8);
+		},
+		'properties can transform with a setter'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				properties: [
+					{
+						propertyName: 'a',
+						setValue: (value: any) => {
+							return value * 2;
+						}
+					}
+				]
+			});
+
+			initializeElement(element);
+			element.a = 4;
+
+			assert.deepEqual(element.getWidgetInstance().properties.a, 8);
+		}
+	},
+	'events': {
+		beforeEach() {
+			oldCustomEvent = global.CustomEvent;
+			global.CustomEvent = function (this: any, type: string, args: any) {
+				args.type = type;
+				assign(this, args);
+			};
+		},
+
+		afterEach() {
+			global.CustomEvent = oldCustomEvent;
+		},
+
+		'events are created'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				events: [
+					{
+						propertyName: 'onTest',
+						eventName: 'test'
+					}
+				]
+			});
+
+			initializeElement(element);
+
+			assert.isFunction(element.getWidgetInstance().properties.onTest);
+			element.getWidgetInstance().properties.onTest('detail here');
+
+			assert.lengthOf(element.getEvents(), 1);
+			assert.strictEqual(element.getEvents()[ 0 ].type, 'test');
+			assert.strictEqual(element.getEvents()[ 0 ].detail, 'detail here');
+		}
+	},
+
+	'children': {
+		'children get wrapped in dom wrappers'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget
+			});
+			element.children = [ {
+				key: 'test',
+				parentNode: element
+			} ];
+
+			// so.. this is going to fail in maquette, since we don't have a DOM, but,
+			// it's ok because all of our code has already run by now
+			try {
+				initializeElement(element);
+			}
+			catch (e) {
+			}
+
+			assert.lengthOf(element.removedChildren(), 1);
+			assert.lengthOf(element.getWidgetInstance().children, 1);
+		}
+	},
+
+	'initialization': {
+		'properties are sent to widget'() {
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetFactory: createWidget,
+				initialization(properties: any) {
+					properties.prop1 = 'test';
+				}
+			});
+
+			initializeElement(element);
+
+			assert.strictEqual(element.getWidgetInstance().properties.prop1, 'test');
+		}
+	}
+});

--- a/tests/unit/util/all.ts
+++ b/tests/unit/util/all.ts
@@ -1,0 +1,1 @@
+import './createDomWrapper';

--- a/tests/unit/util/createDomWrapper.ts
+++ b/tests/unit/util/createDomWrapper.ts
@@ -1,0 +1,148 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { isHNode } from '../../../src/d';
+import { HNode, Widget } from '../../../src/interfaces';
+import createDomWrapper from '../../../src/util/createDomWrapper';
+
+function callCreate(widget: Widget<any>, includeUpdate = false) {
+	const hNode: HNode = <HNode> widget.render();
+
+	assert.isTrue(isHNode(hNode));
+
+	assert.isFunction(hNode.properties.afterCreate);
+
+	if (includeUpdate) {
+		assert.isFunction(hNode.properties.afterUpdate);
+	}
+
+	widget.__render__();
+	(<any> hNode.properties).afterCreate.call(widget);
+
+	if (includeUpdate) {
+		(<any> hNode.properties).afterUpdate.call(widget);
+	}
+}
+
+registerSuite({
+	name: 'createDomWrapper',
+
+	'DOM element is added as a child'() {
+		let mock = {};
+		let parentNode = {
+			child: null,
+
+			parentNode: {
+				replaceChild: function (newNode: any) {
+					parentNode.child = newNode;
+				}
+			}
+		};
+
+		let domWrapper = createDomWrapper.mixin({
+			mixin: {
+				__render__() {
+					return <any> {
+						domNode: parentNode
+					};
+				}
+			}
+		})();
+		domWrapper.setProperties({
+			domNode: <any> mock
+		});
+
+		callCreate(domWrapper);
+
+		assert.equal(domWrapper.properties.domNode, mock);
+		assert.equal(parentNode.child, mock);
+	},
+
+	'Nothing bad happens if there is no node'() {
+		let parentNode = {
+			child: null,
+
+			appendChild: function (argument: any) {
+				parentNode.child = argument;
+			}
+		};
+
+		let domWrapper = createDomWrapper.mixin({
+			mixin: {
+				__render__() {
+					return <any> {
+						domNode: null
+					};
+				}
+			}
+		})();
+		domWrapper.setProperties({
+			domNode: <any> 'test'
+		});
+
+		callCreate(domWrapper);
+	},
+
+	'Nothing bad happens if there if node is a string'() {
+		let domWrapper = createDomWrapper.mixin({
+			mixin: {
+				__render__() {
+					return 'test';
+				}
+			}
+		})();
+
+		domWrapper.setProperties({
+			domNode: <any> 'test'
+		});
+
+		callCreate(domWrapper);
+	},
+
+	'updates with no renders don\'t do anything'() {
+		let domWrapper = createDomWrapper.mixin({
+			mixin: {
+				__render__() {
+					return <any> {
+						domNode: null
+					};
+				}
+			}
+		})();
+
+		callCreate(domWrapper, true);
+	},
+
+	'nothing bad happens if our vnode doesn\'t have a parent'() {
+		let parentNode = {
+			child: null,
+
+			appendChild: function (argument: any) {
+				parentNode.child = argument;
+			}
+		};
+
+		let domWrapper = createDomWrapper.mixin({
+			mixin: {
+				__render__() {
+					return <any> {
+						domNode: parentNode
+					};
+				}
+			}
+		})();
+
+		callCreate(domWrapper, true);
+	},
+
+	'render aspect is ok if we dont return an hnode'() {
+		let domWrapper = createDomWrapper.mixin({
+			mixin: {
+				render() {
+					return 'test';
+				}
+			}
+		})();
+
+		domWrapper.render();
+	}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

First step towards custom elements. This PR contains two things,

* General purpose DOM element wrapping widget (`src/util/createDomWrapper`). Effectively this widget will just append a DOM element to itself..
* Methods to decorate a custom HTMLElement and tie it to a widget. The initializer will turn the HTML element into a projector with the widget as a child (see README for details).

What this PR does *not* contain is anything to perform the actual custom element registration. That will be somewhere....else.

Resolves: https://github.com/dojo/meta/issues/120
