### PR TITLE
Use baseTheme.path to apply applicable theme classes and enable locally scoped classnames

### DIFF
--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -28,9 +28,14 @@ type StringIndexedObject = { [key: string]: string; };
  * Properties required for the themeable mixin
  */
 export interface ThemeableProperties {
-	theme?: {};
+	theme?: Theme<any, any>;
 	overrideClasses?: {};
 }
+
+export interface Theme<T, K extends string> {
+	K?: T;
+	[key: string]: any;
+};
 
 /**
  * Themeable Options
@@ -50,8 +55,13 @@ export interface ThemeableMixin<T> extends Evented {
  * Themeable
  */
 export interface Themeable<T> extends ThemeableMixin<T> {
-	baseTheme: T;
+	baseTheme: BaseTheme<T>;
 	properties: ThemeableProperties;
+}
+
+export interface BaseTheme<T> {
+	classes: T;
+	path: string;
 }
 
 /**
@@ -95,10 +105,12 @@ function negatePreviousClasses<T>(previousClasses: AppliedClasses<T>, newClasses
 	}, <AppliedClasses<T>> {});
 }
 
-function generateThemeClasses<T>(instance: Themeable<T>, baseTheme: T, theme: {} = {}, overrideClasses: {} = {}) {
-	return Object.keys(baseTheme).reduce((newAppliedClasses, className: keyof T) => {
+function generateThemeClasses<T>(instance: Themeable<T>, { classes: baseThemeClasses, path }: BaseTheme<T>, theme: Theme<T, any> = {}, overrideClasses: {} = {}) {
+	const applicableThemeClasses = theme.hasOwnProperty(path) ? theme[path] : {};
+
+	return Object.keys(baseThemeClasses).reduce((newAppliedClasses, className: keyof T) => {
 		const newCSSModuleClassNames: CSSModuleClassNames = {};
-		const themeClassSource = theme.hasOwnProperty(className) ? theme : baseTheme;
+		const themeClassSource = applicableThemeClasses.hasOwnProperty(className) ? applicableThemeClasses : baseThemeClasses;
 
 		addClassNameToCSSModuleClassNames(newCSSModuleClassNames, themeClassSource, className);
 		overrideClasses && addClassNameToCSSModuleClassNames(newCSSModuleClassNames, overrideClasses, className);

--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -28,14 +28,9 @@ type StringIndexedObject = { [key: string]: string; };
  * Properties required for the themeable mixin
  */
 export interface ThemeableProperties {
-	theme?: Theme<any, any>;
+	theme?: {};
 	overrideClasses?: {};
 }
-
-export interface Theme<T, K extends string> {
-	K?: T;
-	[key: string]: any;
-};
 
 /**
  * Themeable Options
@@ -105,7 +100,7 @@ function negatePreviousClasses<T>(previousClasses: AppliedClasses<T>, newClasses
 	}, <AppliedClasses<T>> {});
 }
 
-function generateThemeClasses<T>(instance: Themeable<T>, { classes: baseThemeClasses, path }: BaseTheme<T>, theme: Theme<T, any> = {}, overrideClasses: {} = {}) {
+function generateThemeClasses<T>(instance: Themeable<T>, { classes: baseThemeClasses, path }: BaseTheme<T>, theme: any = {}, overrideClasses: {} = {}) {
 	const applicableThemeClasses = theme.hasOwnProperty(path) ? theme[path] : {};
 
 	return Object.keys(baseThemeClasses).reduce((newAppliedClasses, className: keyof T) => {

--- a/tests/unit/mixins/themeable.ts
+++ b/tests/unit/mixins/themeable.ts
@@ -2,26 +2,37 @@ import compose from '@dojo/compose/compose';
 import { VNode } from '@dojo/interfaces/vdom';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import themeable, { Themeable } from '../../../src/mixins/themeable';
+import themeable, { Themeable, BaseTheme } from '../../../src/mixins/themeable';
 import createWidgetBase from '../../../src/createWidgetBase';
 import { v } from '../../../src/d';
 import { Widget, WidgetProperties, DNode } from '../../../src/interfaces';
 
-const baseTheme = {
+const baseThemeClasses = {
 	class1: 'baseClass1',
 	class2: 'baseClass2'
 };
 
+const baseTheme: BaseTheme<typeof baseThemeClasses> = {
+	path: 'testPath',
+	classes: baseThemeClasses
+};
+
 const testTheme = {
-	class1: 'themeClass1'
+	testPath: {
+		class1: 'themeClass1'
+	}
 };
 
 const testTheme2 = {
-	class2: 'theme2Class2'
+	testPath: {
+		class2: 'theme2Class2'
+	}
 };
 
 const testTheme3 = {
-	class1: 'theme3Class1'
+	testPath: {
+		class1: 'theme3Class1'
+	}
 };
 
 const overrideClasses = {
@@ -41,7 +52,7 @@ const themeableFactory = compose({
 	}
 }).mixin(themeable);
 
-let themeableInstance: Themeable<typeof baseTheme>;
+let themeableInstance: Themeable<typeof baseThemeClasses>;
 
 registerSuite({
 	name: 'themeManager',
@@ -51,8 +62,8 @@ registerSuite({
 		},
 		'should return only base classes when no theme is set'() {
 			assert.deepEqual(themeableInstance.theme, {
-				class1: { [ baseTheme.class1 ]: true },
-				class2: { [ baseTheme.class2 ]: true }
+				class1: { [ baseTheme.classes.class1 ]: true },
+				class2: { [ baseTheme.classes.class2 ]: true }
 			});
 		}
 	},
@@ -62,8 +73,8 @@ registerSuite({
 		},
 		'should return theme class instead of base class when a theme is set'() {
 			assert.deepEqual(themeableInstance.theme, {
-				class1: { [ testTheme.class1 ]: true },
-				class2: { [ baseTheme.class2 ]: true }
+				class1: { [ testTheme.testPath.class1 ]: true },
+				class2: { [ baseTheme.classes.class2 ]: true }
 			});
 		},
 		'should regenerate and negate class names on theme change'() {
@@ -75,8 +86,8 @@ registerSuite({
 				changedPropertyKeys: [ 'theme' ]
 			});
 			assert.deepEqual(themeableInstance.theme, {
-				class1: { [ baseTheme.class1 ]: true, [ testTheme.class1 ]: false },
-				class2: { [ baseTheme.class2 ]: false, [ testTheme2.class2 ]: true }
+				class1: { [ baseTheme.classes.class1 ]: true, [ testTheme.testPath.class1 ]: false },
+				class2: { [ baseTheme.classes.class2 ]: false, [ testTheme2.testPath.class2 ]: true }
 			});
 		}
 	},
@@ -89,8 +100,8 @@ registerSuite({
 		},
 		'should return override class as well as baseclass'() {
 			assert.deepEqual(themeableInstance.theme, {
-				class1: { [ testTheme.class1 ]: true },
-				class2: { [ baseTheme.class2 ]: true, [ overrideClasses.class2 ]: true }
+				class1: { [ testTheme.testPath.class1 ]: true },
+				class2: { [ baseTheme.classes.class2 ]: true, [ overrideClasses.class2 ]: true }
 			});
 		},
 		'should regenerate class names on overrides change'() {
@@ -103,8 +114,8 @@ registerSuite({
 				changedPropertyKeys: [ 'overrideClasses' ]
 			});
 			assert.deepEqual(themeableInstance.theme, {
-				class1: { [ testTheme.class1 ]: true },
-				class2: { [ baseTheme.class2 ]: true, [ overrideClasses.class2 ]: false, [ overrideClasses2.class2 ]: true }
+				class1: { [ testTheme.testPath.class1 ]: true },
+				class2: { [ baseTheme.classes.class2 ]: true, [ overrideClasses.class2 ]: false, [ overrideClasses2.class2 ]: true }
 			});
 		},
 		'should regenerate class names on theme and overrides change'() {
@@ -117,10 +128,10 @@ registerSuite({
 				changedPropertyKeys: [ 'theme', 'overrideClasses' ]
 			});
 			assert.deepEqual(themeableInstance.theme, {
-				class1: { [ baseTheme.class1 ]: true, [ testTheme.class1 ]: false },
+				class1: { [ baseTheme.classes.class1 ]: true, [ testTheme.testPath.class1 ]: false },
 				class2: {
-					[ testTheme2.class2 ]: true,
-					[ baseTheme.class2 ]: false,
+					[ testTheme2.testPath.class2 ]: true,
+					[ baseTheme.classes.class2 ]: false,
 					[ overrideClasses.class2 ]: false,
 					[ overrideClasses2.class2 ]: true
 				}
@@ -130,12 +141,12 @@ registerSuite({
 	'should only negate each class once'() {
 		themeableInstance = themeableFactory();
 
-		const theme1 = { class1: 'firstChange' };
-		const theme2 = { class1: 'secondChange' };
+		const theme1 = { testPath: { class1: 'firstChange' }};
+		const theme2 = { testPath: { class1: 'secondChange' }};
 		let themeClasses = themeableInstance.theme;
 
 		assert.deepEqual(themeableInstance.theme.class1, {
-			[ baseTheme.class1 ]: true
+			[ baseTheme.classes.class1 ]: true
 		}, 'should have base theme set to true');
 
 		themeableInstance.emit({
@@ -146,8 +157,8 @@ registerSuite({
 		themeClasses = themeableInstance.theme;
 
 		assert.deepEqual(themeableInstance.theme.class1, {
-			[ baseTheme.class1 ]: false,
-			[ theme1.class1 ]: true
+			[ baseTheme.classes.class1 ]: false,
+			[ theme1.testPath.class1 ]: true
 		}, 'should have base theme set to false and theme1 class1 set to true');
 
 		themeableInstance.emit({
@@ -158,8 +169,8 @@ registerSuite({
 		themeClasses = themeableInstance.theme;
 
 		assert.deepEqual(themeableInstance.theme.class1, {
-			[ theme1.class1 ]: false,
-			[ theme2.class1 ]: true
+			[ theme1.testPath.class1 ]: false,
+			[ theme2.testPath.class1 ]: true
 		}, 'should have theme1 class1 set to false and theme2 class1 set to true');
 	},
 	'properties changing outside of the scope of theme should not change theme'() {
@@ -179,7 +190,7 @@ registerSuite({
 	},
 	integration: {
 		'should work as mixin to createWidgetBase'() {
-			type ThemeableWidget = Widget<WidgetProperties> & Themeable<typeof baseTheme>;
+			type ThemeableWidget = Widget<WidgetProperties> & Themeable<typeof baseThemeClasses>;
 
 			const createThemeableWidget = createWidgetBase.mixin(themeable).mixin({
 				mixin: {
@@ -197,12 +208,15 @@ registerSuite({
 			});
 
 			const result = <VNode> themeableWidget.__render__();
-			assert.deepEqual(result.children![0].properties!.classes, { [ testTheme.class1 ]: true });
+			assert.deepEqual(result.children![0].properties!.classes, { [ testTheme.testPath.class1 ]: true });
 
 			themeableWidget.setProperties({ theme: testTheme3 });
 
 			const result2 = <VNode> themeableWidget.__render__();
-			assert.deepEqual(result2.children![0].properties!.classes, { [ testTheme.class1 ]: false, [ testTheme3.class1 ]: true });
+			assert.deepEqual(result2.children![0].properties!.classes, {
+				[ testTheme.testPath.class1 ]: false,
+				[ testTheme3.testPath.class1 ]: true
+			});
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- uses `baseTheme.path` to restrict theme classes to those that are applicable to the widget.
- means that widget classes no longer need to be scoped via a widget name suffix.

**Depends upon:**

- [ ] cli-build PR: https://github.com/dojo/cli-build/pull/57
- [ ] grunt-dojo2 PR: https://github.com/dojo/grunt-dojo2/pull/92

Resolves #297
