### PR TITLE
Remove classes from base widget properties

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -231,7 +231,6 @@ export interface WidgetProperties {
 	[index: string]: any;
 	id?: string;
 	key?: string;
-	classes?: string[];
 	bind?: any;
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Classes are not dealt with in widget base anymore, therefore shouldn't be on the base widget properties.
