### PR TITLE
Changed BaseClassses shape and key to _key

### DIFF
--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -74,7 +74,7 @@ export interface ThemeableMixin extends Evented {
  * Themeable
  */
 export interface Themeable extends ThemeableMixin {
-	baseClasses: BaseClasses;
+	baseClasses: {};
 	properties: ThemeableProperties;
 }
 
@@ -83,7 +83,7 @@ export interface Themeable extends ThemeableMixin {
  */
 export interface ThemeableFactory extends ComposeFactory<ThemeableMixin, ThemeableOptions> {}
 
-export type BaseClasses = { [key: string]: string; };
+type BaseClasses = { [key: string]: string; };
 
 /**
  * Map containing lookups for available css module class names.

--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -83,7 +83,7 @@ export interface Themeable extends ThemeableMixin {
  */
 export interface ThemeableFactory extends ComposeFactory<ThemeableMixin, ThemeableOptions> {}
 
-type BaseClasses = { [key: string]: string; };
+export type BaseClasses = { [key: string]: string; };
 
 /**
  * Map containing lookups for available css module class names.

--- a/src/mixins/themeable.ts
+++ b/src/mixins/themeable.ts
@@ -79,20 +79,11 @@ export interface Themeable extends ThemeableMixin {
 }
 
 /**
- * BaseClasses to be passed as this.baseClasses. The path string is used to
- * perform a lookup against any theme that has been set.
- */
-export interface BaseClasses {
-	classes: ClassNames;
-	key: string;
-}
-
-/**
  * Compose Themeable Factory interface
  */
 export interface ThemeableFactory extends ComposeFactory<ThemeableMixin, ThemeableOptions> {}
 
-type StringIndexedObject = { [key: string]: string; };
+type BaseClasses = { [key: string]: string; };
 
 /**
  * Map containing lookups for available css module class names.
@@ -113,6 +104,8 @@ const baseClassesReverseLookupMap = new WeakMap<Themeable, ClassNames>();
  */
 const allClassNamesMap = new WeakMap<Themeable, ClassNameFlags>();
 
+const THEME_KEY = ' _key';
+
 function appendToAllClassNames(instance: Themeable, classNames: string[]) {
 	const negativeClassFlags = createClassNameObject(classNames, false);
 	const currentNegativeClassFlags = allClassNamesMap.get(instance);
@@ -126,11 +119,16 @@ function createClassNameObject(classNames: string[], applied: boolean) {
 	}, {});
 }
 
-function generateThemeClasses(instance: Themeable, { classes: baseClassesClasses, key }: BaseClasses, theme: any = {}, overrideClasses: any = {}) {
+function generateThemeClasses(instance: Themeable, baseClasses: BaseClasses, theme: any = {}, overrideClasses: any = {}) {
 	let allClasses: string[] = [];
-	const sourceThemeClasses = theme.hasOwnProperty(key) ? assign({}, baseClassesClasses, theme[key]) : baseClassesClasses;
+	const themeKey = baseClasses[THEME_KEY];
+	const sourceThemeClasses = themeKey && theme.hasOwnProperty(themeKey) ? assign({}, baseClasses, theme[themeKey]) : baseClasses;
 
-	const themeClasses = Object.keys(baseClassesClasses).reduce((newAppliedClassNames, className: string) => {
+	const themeClasses = Object.keys(baseClasses).reduce((newAppliedClassNames, className: string) => {
+		if (className === THEME_KEY) {
+			return newAppliedClassNames;
+		}
+
 		let cssClassNames = sourceThemeClasses[className].split(' ');
 
 		if (overrideClasses.hasOwnProperty(className)) {
@@ -159,7 +157,7 @@ function onPropertiesChanged(instance: Themeable, { theme, overrideClasses }: Th
 	}
 }
 
-function createBaseClassesLookup({ classes }: BaseClasses): ClassNames {
+function createBaseClassesLookup(classes: BaseClasses): ClassNames {
 	return Object.keys(classes).reduce((currentClassNames, key: string) => {
 		currentClassNames[classes[key]] = key;
 		return currentClassNames;

--- a/tests/unit/mixins/themeable.ts
+++ b/tests/unit/mixins/themeable.ts
@@ -2,20 +2,16 @@ import compose from '@dojo/compose/compose';
 import { VNode } from '@dojo/interfaces/vdom';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import themeable, { Themeable, BaseClasses } from '../../../src/mixins/themeable';
+import themeable, { Themeable } from '../../../src/mixins/themeable';
 import createWidgetBase from '../../../src/createWidgetBase';
 import { v } from '../../../src/d';
 import { Widget, WidgetProperties, DNode } from '../../../src/interfaces';
 import { stub, SinonStub } from 'sinon';
 
-const baseClassesClasses = {
+const baseClasses = {
+	[' _key']: 'testPath',
 	class1: 'baseClass1',
 	class2: 'baseClass2'
-};
-
-const baseClasses: BaseClasses = {
-	key: 'testPath',
-	classes: baseClassesClasses
 };
 
 const testTheme1 = {
@@ -67,35 +63,35 @@ registerSuite({
 		},
 		'should return baseClasses flagged classes via the classes function'() {
 			themeableInstance = themeableFactory();
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: true
 			});
 
 			assert.isFalse(consoleStub.called);
 		},
 		'should return negated classes for those that are not passed'() {
 			themeableInstance = themeableFactory();
-			const { class1 } = baseClassesClasses;
+			const { class1 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false
 			});
 
 			assert.isFalse(consoleStub.called);
 		},
 		'should ignore any new classes that do not exist in the baseClasses and show console error'() {
 			themeableInstance = themeableFactory();
-			const { class1 } = baseClassesClasses;
+			const { class1 } = baseClasses;
 			const newClassName = 'newClassName';
 			const flaggedClasses = themeableInstance.classes(class1, newClassName).get();
 
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false
 			});
 
 			assert.isTrue(consoleStub.calledOnce);
@@ -106,12 +102,12 @@ registerSuite({
 				properties: { theme: testTheme3 }
 			});
 
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				testTheme3Class1: true,
 				testTheme3AdjoinedClass1: true,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class2 ]: true
 			});
 		},
 		'should remove adjoined classes when they are no longer provided'() {
@@ -127,13 +123,13 @@ registerSuite({
 				changedPropertyKeys: [ 'theme' ]
 			});
 
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ testTheme1.testPath.class1 ]: true,
 				testTheme3Class1: false,
 				testTheme3AdjoinedClass1: false,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class2 ]: true
 			});
 		}
 	},
@@ -143,68 +139,68 @@ registerSuite({
 			const fixedClassName = 'fixedClassName';
 			const flaggedClasses = themeableInstance.classes().fixed(fixedClassName).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: false,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class1 ]: false,
+				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 		},
 		'should pass through new classes'() {
 			themeableInstance = themeableFactory();
-			const { class1 } = baseClassesClasses;
+			const { class1 } = baseClasses;
 			const fixedClassName = 'fixedClassName';
 			const flaggedClasses = themeableInstance.classes(class1).fixed(fixedClassName).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 		},
 		'should negate any new classes that are not requested on second call'() {
 			themeableInstance = themeableFactory();
-			const { class1 } = baseClassesClasses;
+			const { class1 } = baseClasses;
 			const fixedClassName = 'fixedClassName';
 			const flaggedClassesFirstCall = themeableInstance.classes(class1).fixed(fixedClassName).get();
 			assert.deepEqual(flaggedClassesFirstCall, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			}, `${fixedClassName} should be true on first call`);
 
 			const flaggedClassesSecondCall = themeableInstance.classes(class1).get();
 			assert.deepEqual(flaggedClassesSecondCall, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: false
 			}, `${fixedClassName} should be false on second call`);
 		},
 		'should split adjoined fixed classes into multiple classes'() {
 			themeableInstance = themeableFactory();
-			const { class1 } = baseClassesClasses;
+			const { class1 } = baseClasses;
 			const adjoinedClassName = 'adjoinedClassName1 adjoinedClassName2';
 			const flaggedClasses = themeableInstance.classes(class1).fixed(adjoinedClassName).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false,
 				'adjoinedClassName1': true,
 				'adjoinedClassName2': true
 			});
 		},
 		'should remove adjoined fixed classes when they are no longer provided'() {
 			themeableInstance = themeableFactory();
-			const { class1 } = baseClassesClasses;
+			const { class1 } = baseClasses;
 			const adjoinedClassName = 'adjoinedClassName1 adjoinedClassName2';
 			const flaggedClassesFirstCall = themeableInstance.classes(class1).fixed(adjoinedClassName).get();
 			assert.deepEqual(flaggedClassesFirstCall, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false,
 				'adjoinedClassName1': true,
 				'adjoinedClassName2': true
 			}, 'adjoined classed should both be true on first call');
 
 			const flaggedClassesSecondCall = themeableInstance.classes(class1).get();
 			assert.deepEqual(flaggedClassesSecondCall, {
-				[ baseClassesClasses.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: false,
 				'adjoinedClassName1': false,
 				'adjoinedClassName2': false
 			}, `adjoiend class names should be false on second call`);
@@ -215,11 +211,11 @@ registerSuite({
 			themeableInstance = themeableFactory({
 				properties: { theme: testTheme1 }
 			});
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ testTheme1.testPath.class1 ]: true,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class2 ]: true
 			});
 		},
 		'should negate old theme class when a new theme is set'() {
@@ -234,12 +230,12 @@ registerSuite({
 				changedPropertyKeys: [ 'theme' ]
 			});
 
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ testTheme1.testPath.class1 ]: false,
 				[ testTheme2.testPath.class1 ]: true,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class2 ]: true
 			});
 		},
 		'will not regenerate theme classes if theme changed property is not set'() {
@@ -254,11 +250,11 @@ registerSuite({
 				changedPropertyKeys: [ 'id' ]
 			});
 
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ testTheme1.testPath.class1 ]: true,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class2 ]: true
 			}, 'theme2 classes should not be present');
 		}
 	},
@@ -267,12 +263,12 @@ registerSuite({
 			themeableInstance = themeableFactory({
 				properties: { overrideClasses: overrideClasses1 }
 			});
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: true,
+				[ baseClasses.class1 ]: true,
 				[ overrideClasses1.class1 ]: true,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class2 ]: true
 			});
 		},
 		'should set override classes to false when they are changed'() {
@@ -287,13 +283,13 @@ registerSuite({
 				changedPropertyKeys: [ 'overrideClasses' ]
 			});
 
-			const { class1, class2 } = baseClassesClasses;
+			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClassesClasses.class1 ]: true,
+				[ baseClasses.class1 ]: true,
 				[ overrideClasses1.class1 ]: false,
 				[ overrideClasses2.class1 ]: true,
-				[ baseClassesClasses.class2 ]: true
+				[ baseClasses.class2 ]: true
 			});
 		}
 	},
@@ -306,7 +302,7 @@ registerSuite({
 				mixin: {
 					baseClasses,
 					getChildrenNodes(this: ThemeableWidget ): DNode[] {
-						const { class1 } = baseClassesClasses;
+						const { class1 } = baseClasses;
 						return [
 							v('div', { classes: this.classes(class1).fixed(fixedClassName).get() })
 						];
@@ -321,7 +317,7 @@ registerSuite({
 			const result = <VNode> themeableWidget.__render__();
 			assert.deepEqual(result.children![0].properties!.classes, {
 				[ testTheme1.testPath.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 
@@ -331,7 +327,7 @@ registerSuite({
 			assert.deepEqual(result2.children![0].properties!.classes, {
 				[ testTheme1.testPath.class1 ]: false,
 				[ testTheme2.testPath.class1 ]: true,
-				[ baseClassesClasses.class2 ]: false,
+				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 		}


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

BaseClasses is now a flat object again such that we can use the `typed-css-modules` cli and don't have to use `baseTheme.classes.className` and instead can use `baseTheme.className`.
