### PR TITLE
Moving properties into initialization

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -240,9 +240,9 @@ export function initializeElement(element: CustomElement) {
 	});
 
 	const widgetInstance: Projector = element.getWidgetFactory().mixin(createProjectorMixin)({
-		root: element
+		root: element,
+		properties: initialProperties
 	});
-	widgetInstance.setProperties(initialProperties);
 	widgetInstance.setChildren(children);
 	element.setWidgetInstance(widgetInstance);
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moving properties into widget construction of custom element, instead of afterwards.
