### PR TITLE
Allowing afterCreate to be called on the projector, issue #323

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -1,8 +1,9 @@
+import { EventTargettedObject, Handle } from '@dojo/interfaces/core';
 import Promise from '@dojo/shim/Promise';
 import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
 import { EventTargettedObject, Handle } from '@dojo/interfaces/core';
+import { WidgetProperties } from './../WidgetBase';
 import { Constructor, WidgetProperties } from './../interfaces';
-import { WidgetBase } from './../WidgetBase';
 import cssTransitions from '../animations/cssTransitions';
 
 /**
@@ -73,7 +74,8 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 		private _root: Element;
 		private attachPromise: Promise<Handle>;
 		private attachHandle: Handle;
-		private afterCreate: () => void;
+		private afterCreate: (...args: any[]) => void;
+		private originalAfterCreate?: () => void;
 
 		constructor(...args: any[]) {
 			super(...args);
@@ -134,6 +136,10 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 			}
 			const { afterCreate } = this;
 			if (result.properties) {
+				if (result.properties.afterCreate) {
+					this.originalAfterCreate = <any> result.properties.afterCreate;
+				}
+
 				result.properties.afterCreate = afterCreate;
 			}
 
@@ -174,7 +180,12 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 			});
 
 			this.attachPromise = new Promise((resolve, reject) => {
-				this.afterCreate = () => {
+				this.afterCreate = (...args: any[]) => {
+					if (this.originalAfterCreate) {
+						const [ , , , properties ] = args;
+						this.originalAfterCreate.apply(properties.bind || properties, args);
+					}
+
 					this.emit({
 						type: 'projector:attached',
 						target: this

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -1,8 +1,7 @@
 import { EventTargettedObject, Handle } from '@dojo/interfaces/core';
 import Promise from '@dojo/shim/Promise';
 import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
-import { EventTargettedObject, Handle } from '@dojo/interfaces/core';
-import { WidgetProperties } from './../WidgetBase';
+import { WidgetBase } from './../WidgetBase';
 import { Constructor, WidgetProperties } from './../interfaces';
 import cssTransitions from '../animations/cssTransitions';
 

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -404,5 +404,46 @@ registerSuite({
 		await waitFor(() => {
 			return document.getElementById('test-element') === null;
 		}, 'Element never got removed');
+	},
+	'afterCreate can be overriden'() {
+		let afterCreateCalled = false;
+
+		function afterCreate(this: any, element: any, projectorOptions: any, vNodeSelector: any, properties: any, children: any) {
+			afterCreateCalled = true;
+
+			assert.isNotNull(element);
+			assert.isNotNull(projectorOptions);
+			assert.isNotNull(vNodeSelector);
+			assert.isNotNull(properties);
+			assert.isNotNull(children);
+			assert.strictEqual(this, projector);
+		}
+
+		const root = document.createElement('div');
+		document.body.appendChild(root);
+
+		const projector = new (class extends TestWidget {
+			root = root;
+
+			render() {
+				return v('span', {
+					innerHTML: 'hello world',
+					afterCreate
+				});
+			}
+		})({});
+
+		// we check if the attached event fires because we need to know if
+		// the projector's afterCreate method is called, and that is where
+		// this event is dispatched
+		let eventFired = false;
+		projector.on('projector:attached', () => {
+			eventFired = true;
+		});
+
+		return projector.append().then(() => {
+			assert.isTrue(afterCreateCalled);
+			assert.isTrue(eventFired);
+		});
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This will allow you to override `afterCreate` on the projector and have both your method, and the projector's method, called.  This is sort of brute-forced in there, as I couldn't think of a clever way to use aspects for something like this, since the method itself is dynamic.

Resolves #323 
