### PR TITLE
Adding helpful types for event handlers, issue #240

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -239,3 +239,45 @@ export interface WidgetFactory<W extends WidgetMixin<P>, P extends WidgetPropert
 export interface TypedTargetEvent<T extends EventTarget> extends Event {
 	target: T;
 }
+
+/*
+ These are the event handlers exposed by Maquette.
+ */
+
+export type EventHandlerResult = boolean | void;
+
+export interface EventHandler {
+	(event?: Event): EventHandlerResult;
+}
+
+export interface FocusEventHandler {
+	(event?: FocusEvent): EventHandlerResult;
+}
+
+export interface KeyboardEventHandler {
+	(event?: KeyboardEvent): EventHandlerResult;
+}
+
+export interface MouseEventHandler {
+	(event?: MouseEvent): EventHandlerResult;
+}
+
+export type BlurEventHandler = FocusEventHandler;
+export type ChangeEventHandler = EventHandler;
+export type ClickEventHandler = MouseEventHandler;
+export type DoubleClicEventHandler = MouseEventHandler;
+export type InputEventHandler = EventHandler;
+export type KeyDownEventHandler = KeyboardEventHandler;
+export type KeyPressEventHandler = KeyboardEventHandler;
+export type KeyUpEventHandler = KeyboardEventHandler;
+export type LoadEventHandler = EventHandler;
+export type MouseDownEventHandler = MouseEventHandler;
+export type MouseEnterEventHandler = MouseEventHandler;
+export type MouseLeaveEventHandler = MouseEventHandler;
+export type MouseMoveEventHandler = MouseEventHandler;
+export type MouseOutEventHandler = MouseEventHandler;
+export type MouseOverEventHandler = MouseEventHandler;
+export type MouseUpEventHandler = MouseEventHandler;
+export type MouseWheelEventHandler = (event?: MouseWheelEvent | WheelEvent) => EventHandlerResult;
+export type ScrollEventHandler = (event?: UIEvent) => EventHandlerResult;
+export type SubmitEventHandler = EventHandler;

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -265,7 +265,7 @@ export interface MouseEventHandler {
 export type BlurEventHandler = FocusEventHandler;
 export type ChangeEventHandler = EventHandler;
 export type ClickEventHandler = MouseEventHandler;
-export type DoubleClicEventHandler = MouseEventHandler;
+export type DoubleClickEventHandler = MouseEventHandler;
 export type InputEventHandler = EventHandler;
 export type KeyDownEventHandler = KeyboardEventHandler;
 export type KeyPressEventHandler = KeyboardEventHandler;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding types so you don't have to re-type event handler signatures all the time.

Old,

```ts
interface MyWidget {
    onClick(event?: MouseEvent): void;
}
```

New,

```ts
interface MyWidget {
    onClick: ClickEventHandler;
}
```

Resolves #240 
