### PR TITLE
Warn for unknown widget registry item

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -453,7 +453,8 @@ export class WidgetBase<P extends WidgetProperties> extends Evented {
 					return null;
 				}
 				else if (item === null) {
-					throw new Error();
+					console.warn(`Unable to render unknown widget factory ${factory}`);
+					return null;
 				}
 				factory = item;
 			}

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -332,7 +332,7 @@ registerSuite({
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children && result.children[0].vnodeSelector, 'header');
 		},
-		'async factorys only initialise once'() {
+		'async factories only initialise once'() {
 			let resolveFunction: any;
 			const loadFunction = () => {
 				return new Promise((resolve) => {
@@ -417,6 +417,24 @@ registerSuite({
 					resolve();
 				});
 			});
+		},
+		'warn for unknown factory registry'() {
+			const factory = 'unknown-entry';
+			class TestWidget extends WidgetBase<any> {
+				render() {
+					return v('div', [
+						w(factory, {})
+					]);
+				}
+			}
+
+			const myWidget: any = new TestWidget({});
+			const consoleStub = stub(console, 'warn');
+			let result = <VNode> myWidget.__render__();
+			assert.lengthOf(result.children, 0);
+			assert.isTrue(consoleStub.calledOnce);
+			assert.isTrue(consoleStub.calledWith(`Unable to render unknown widget factory ${factory}`));
+			consoleStub.restore();
 		},
 		'render using scoped factory registry'() {
 			class TestHeaderWidget extends WidgetBase<any> {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Warn for an unknown registry item over throwing an error.

Resolves #332 
