### PR TITLE
Update check for Widget class type

### DIFF
--- a/src/FactoryRegistry.ts
+++ b/src/FactoryRegistry.ts
@@ -1,6 +1,7 @@
 import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
-import { WidgetBase, WidgetConstructor } from './WidgetBase';
+import Symbol from '@dojo/shim/Symbol';
+import { WidgetConstructor } from './interfaces';
 
 /**
  * A function the returns a Promise<WidgetConstructor>
@@ -11,6 +12,11 @@ export type WidgetFactoryFunction = () => Promise<WidgetConstructor>
  * Factory Registry Item - Either WidgetConsructor, Promise for a WidgetConstructor or WidgetFactoryFunction
  */
 export type FactoryRegistryItem = WidgetConstructor | Promise<WidgetConstructor> | WidgetFactoryFunction
+
+/**
+ * Widget base symbol type
+ */
+export const WIDGET_BASE_TYPE = Symbol('Widget Base');
 
 /**
  * Factory Registry Interface
@@ -49,7 +55,7 @@ export interface FactoryRegistryInterface {
  * @returns true/false indicating is the item is a WidgetConstructor
  */
 export function isWidgetBaseConstructor(item: any): item is WidgetConstructor {
-	return WidgetBase.isPrototypeOf(item) || item === WidgetBase;
+	return Boolean(item && item._type === WIDGET_BASE_TYPE);
 }
 
 /**

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -138,28 +138,14 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this.setProperties(properties);
 	}
 
-	/**
-	 * return the widget's id from properties
-	 */
 	public get id(): string | undefined {
 		return this._properties.id;
 	}
 
-	/**
-	 * Return readonly widget properties
-	 */
 	public get properties(): Readonly<P> {
 		return this._properties;
 	}
 
-	/**
-	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
-	 * previous properties. Runs though any registered specific property diff functions collecting the results and then
-	 * runs the remainder through the catch all diff function. The aggregate of the two sets of the results is then
-	 * set as the widgets properties
-	 *
-	 * @param properties The new widget properties
-	 */
 	public setProperties(properties: P & { [index: string]: any }): void {
 		const diffPropertyResults: { [index: string]: PropertyChangeRecord } = {};
 		const diffPropertyChangedKeys: string[] = [];
@@ -200,16 +186,10 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this.previousProperties = this.properties;
 	}
 
-	/**
-	 * Returns the widgets children
-	 */
 	public get children(): DNode[] {
 		return this._children;
 	}
 
-	/**
-	 * Sets the widgets children
-	 */
 	public setChildren(children: DNode[]): void {
 		this._children = children;
 		this.emit({
@@ -218,13 +198,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		});
 	}
 
-	/**
-	 * The default diff function for properties, also responsible for cloning the properties.
-	 *
-	 * @param previousProperties The widgets previous properties
-	 * @param newProperties The widgets new properties
-	 * @returns A properties change record for the the diff
-	 */
 	public diffProperties(previousProperties: P & { [index: string]: any }, newProperties: P & { [index: string]: any }): PropertiesChangeRecord<P> {
 		const changedKeys = Object.keys(newProperties).reduce((changedPropertyKeys: string[], propertyKey: string): string[] => {
 			if (previousProperties[propertyKey] !== newProperties[propertyKey]) {
@@ -236,18 +209,10 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		return { changedKeys, properties: assign({}, newProperties) };
 	}
 
-	/**
-	 * Default render, returns a `div` with widgets children
-	 *
-	 * @returns the DNode for the widget
-	 */
 	public render(): DNode {
 		return v('div', {}, this.children);
 	}
 
-	/**
-	 * Main internal function for dealing with widget rendering
-	 */
 	public __render__(): VNode | string | null {
 		if (this.dirty || !this.cachedVNode) {
 			let dNode = this.render();
@@ -266,9 +231,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		return this.cachedVNode;
 	}
 
-	/**
-	 * invalidate the widget
-	 */
 	public invalidate(): void {
 		this.dirty = true;
 		this.emit({

--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -1,5 +1,5 @@
 import { w } from './d';
-import { WidgetProperties, WidgetConstructor, WidgetBase, DNode } from './WidgetBase';
+import { WidgetBaseInterface, WidgetProperties, WidgetConstructor, DNode } from './interfaces';
 import { ProjectorMixin } from './mixins/Projector';
 import { DomWrapper } from './util/DomWrapper';
 import { assign } from '@dojo/core/lang';
@@ -116,8 +116,8 @@ export interface CustomElementDescriptor {
 export interface CustomElement extends HTMLElement {
 	getWidgetFactory(): WidgetConstructor;
 	getDescriptor(): CustomElementDescriptor;
-	getWidgetInstance(): WidgetBase<any>;
-	setWidgetInstance(instance: WidgetBase<any>): void;
+	getWidgetInstance(): WidgetBaseInterface<any>;
+	setWidgetInstance(instance: WidgetBaseInterface<any>): void;
 }
 
 function getWidgetPropertyFromAttribute(attributeName: string, attributeValue: string | null, descriptor: CustomElementAttributeDescriptor): [ string, any ] {

--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -1,10 +1,11 @@
-import { w } from './d';
-import { WidgetBaseInterface, WidgetProperties, WidgetConstructor, DNode } from './interfaces';
-import { ProjectorMixin } from './mixins/Projector';
-import { DomWrapper } from './util/DomWrapper';
 import { assign } from '@dojo/core/lang';
 import { from as arrayFrom } from '@dojo/shim/array';
 import global from '@dojo/core/global';
+import { WidgetBaseInterface, WidgetProperties, Constructor, DNode } from './interfaces';
+import { WidgetBase } from './WidgetBase';
+import { w } from './d';
+import { ProjectorMixin } from './mixins/Projector';
+import { DomWrapper } from './util/DomWrapper';
 
 /**
  * @type CustomElementAttributeDescriptor
@@ -80,7 +81,7 @@ export interface CustomElementDescriptor {
 	/**
 	 * Widget factory that will create the widget
 	 */
-	widgetFactory: WidgetConstructor;
+	widgetFactory: Constructor<WidgetBase<WidgetProperties>>;
 
 	/**
 	 * List of attributes on the custom element to map to widget properties
@@ -114,7 +115,7 @@ export interface CustomElementDescriptor {
  * @property                                setWidgetInstance   Set the widget instance for this element
  */
 export interface CustomElement extends HTMLElement {
-	getWidgetFactory(): WidgetConstructor;
+	getWidgetFactory(): Constructor<WidgetBase<WidgetProperties>>;
 	getDescriptor(): CustomElementDescriptor;
 	getWidgetInstance(): WidgetBaseInterface<any>;
 	setWidgetInstance(instance: WidgetBaseInterface<any>): void;

--- a/src/d.ts
+++ b/src/d.ts
@@ -7,8 +7,8 @@ import {
 	HNode,
 	WNode,
 	WidgetProperties,
-	WidgetBase
-} from './WidgetBase';
+	WidgetBaseConstructor
+} from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
 /**
@@ -34,11 +34,6 @@ export function isWNode(child: DNode): child is WNode {
 export function isHNode(child: DNode): child is HNode {
 	return Boolean(child && (typeof child !== 'string') && child.type === HNODE);
 }
-
-/**
- * Widget Base Constructor type with a generic for Widget Properties
- */
-export type WidgetBaseConstructor<P extends WidgetProperties> = new (properties: P) => WidgetBase<P>
 
 /**
  * Generic decorate function for DNodes. The nodes are modified in place based on the provided predicate

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,3 +1,7 @@
+import { VNode, VNodeProperties } from '@dojo/interfaces/vdom';
+import { EventTypedObject } from '@dojo/interfaces/core';
+import { Evented } from './bases/Evented';
+
 /**
  * Generic constructor type
  */
@@ -51,3 +55,190 @@ export type MouseUpEventHandler = MouseEventHandler;
 export type MouseWheelEventHandler = (event?: MouseWheelEvent | WheelEvent) => EventHandlerResult;
 export type ScrollEventHandler = (event?: UIEvent) => EventHandlerResult;
 export type SubmitEventHandler = EventHandler;
+
+/**
+ * Base widget properties
+ */
+export interface WidgetProperties {
+
+	/**
+	 * id for a widget
+	 */
+	id?: string;
+
+	/**
+	 * The key for a widget. Used to differentiate uniquely identify child widgets for
+	 * rendering and instance management
+	 */
+	key?: string;
+
+	/**
+	 * The scope to bind all function properties
+	 */
+	bind?: any;
+}
+
+/**
+ * Wrapper for v
+ */
+export interface HNode {
+	/**
+	 * Array of processed VNode children.
+	 */
+	vNodes?: (string | VNode | null)[];
+	/**
+	 * Specified children
+	 */
+	children: (DNode | string)[];
+
+	/**
+	 * render function that wraps returns VNode
+	 */
+	render<T>(options?: { bind?: T }): VNode;
+
+	/**
+	 * The properties used to create the VNode
+	 */
+	properties: VNodeProperties;
+
+	/**
+	 * The type of node
+	 */
+	type: symbol;
+}
+
+/**
+ * Wrapper for `w`
+ */
+export interface WNode {
+	/**
+	 * Factory to create a widget
+	 */
+	factory: WidgetConstructor | string;
+
+	/**
+	 * Options used to create factory a widget
+	 */
+	properties: WidgetProperties;
+
+	/**
+	 * DNode children
+	 */
+	children: DNode[];
+
+	/**
+	 * The type of node
+	 */
+	type: symbol;
+}
+
+/**
+ * union type for all possible return types from render
+ */
+export type DNode = HNode | WNode | string | null;
+
+/**
+ * the event emitted on properties:changed
+ */
+export interface PropertiesChangeEvent<T, P extends WidgetProperties> extends EventTypedObject<'properties:changed'> {
+	/**
+	 * the full set of properties
+	 */
+	properties: P;
+	/**
+	 * the changed properties between setProperty calls
+	 */
+	changedPropertyKeys: string[];
+	/**
+	 * the target (this)
+	 */
+	target: T;
+}
+
+/**
+ * Propeerty Change record for specific property diff functions
+ */
+export interface PropertyChangeRecord {
+	changed: boolean;
+	value: any;
+}
+
+/**
+ * Properties changed record, return for diffProperties
+ */
+export interface PropertiesChangeRecord<P extends WidgetProperties> {
+	changedKeys: string[];
+	properties: P;
+}
+
+/**
+ *
+ */
+export type WidgetBaseConstructor<P extends WidgetProperties> = Constructor<WidgetBaseInterface<P>>;
+
+/**
+ * WidgetBase constructor type
+ */
+export type WidgetConstructor = WidgetBaseConstructor<WidgetProperties>;
+
+/**
+ * The interface for WidgetBase
+ */
+export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented {
+
+	/**
+	 * Widget properties
+	 */
+	readonly properties: P;
+
+	/**
+	 * Widget id
+	 */
+	readonly id: string | undefined;
+
+	/**
+	 * Returns the widgets children
+	 */
+	readonly children: DNode[];
+
+	/**
+	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
+	 * previous properties. Runs though any registered specific property diff functions collecting the results and then
+	 * runs the remainder through the catch all diff function. The aggregate of the two sets of the results is then
+	 * set as the widgets properties
+	 *
+	 * @param properties The new widget properties
+	 */
+	setProperties(properties: P & { [index: string]: any }): void;
+
+	/**
+	 * Sets the widgets children
+	 */
+	setChildren(children: DNode[]): void;
+
+	/**
+	 * The default diff function for properties, also responsible for cloning the properties.
+	 *
+	 * @param previousProperties The widgets previous properties
+	 * @param newProperties The widgets new properties
+	 * @returns A properties change record for the the diff
+	 */
+	diffProperties(previousProperties: P & { [index: string]: any }, newProperties: P & { [index: string]: any }): PropertiesChangeRecord<P>;
+
+	/**
+	 * Default render, returns a `div` with widgets children
+	 *
+	 * @returns the DNode for the widget
+	 */
+	render(): DNode;
+
+	/**
+	 * Main internal function for dealing with widget rendering
+	 */
+	__render__(): VNode | string | null;
+
+	/**
+	 * invalidate the widget
+	 */
+	invalidate(): void;
+}

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -156,7 +156,7 @@ export interface PropertiesChangeEvent<T, P extends WidgetProperties> extends Ev
 }
 
 /**
- * Propeerty Change record for specific property diff functions
+ * Property Change record for specific property diff functions
  */
 export interface PropertyChangeRecord {
 	changed: boolean;
@@ -197,7 +197,7 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	readonly id: string | undefined;
 
 	/**
-	 * Returns the widgets children
+	 * Returns the widget's children
 	 */
 	readonly children: DNode[];
 
@@ -205,28 +205,28 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
 	 * previous properties. Runs though any registered specific property diff functions collecting the results and then
 	 * runs the remainder through the catch all diff function. The aggregate of the two sets of the results is then
-	 * set as the widgets properties
+	 * set as the widget's properties
 	 *
 	 * @param properties The new widget properties
 	 */
 	setProperties(properties: P & { [index: string]: any }): void;
 
 	/**
-	 * Sets the widgets children
+	 * Sets the widget's children
 	 */
 	setChildren(children: DNode[]): void;
 
 	/**
 	 * The default diff function for properties, also responsible for cloning the properties.
 	 *
-	 * @param previousProperties The widgets previous properties
-	 * @param newProperties The widgets new properties
+	 * @param previousProperties The widget's previous properties
+	 * @param newProperties The widget's new properties
 	 * @returns A properties change record for the the diff
 	 */
 	diffProperties(previousProperties: P & { [index: string]: any }, newProperties: P & { [index: string]: any }): PropertiesChangeRecord<P>;
 
 	/**
-	 * Default render, returns a `div` with widgets children
+	 * Default render, returns a `div` with widget's children
 	 *
 	 * @returns the DNode for the widget
 	 */

--- a/src/mixins/FormLabel.ts
+++ b/src/mixins/FormLabel.ts
@@ -3,7 +3,7 @@ import { v, isHNode } from '../d';
 import {
 	DNode,
 	WidgetConstructor
-} from '../WidgetBase';
+} from '../interfaces';
 
 /**
  * Label settings for form label text content, position (before or after), and visibility

--- a/src/mixins/FormLabel.ts
+++ b/src/mixins/FormLabel.ts
@@ -2,8 +2,10 @@ import { assign } from '@dojo/core/lang';
 import { v, isHNode } from '../d';
 import {
 	DNode,
-	WidgetConstructor
+	Constructor,
+	WidgetProperties
 } from '../interfaces';
+import { WidgetBase } from './../WidgetBase';
 
 /**
  * Label settings for form label text content, position (before or after), and visibility
@@ -109,7 +111,7 @@ const labelDefaults = {
  */
 const allowedFormFieldAttributes = ['checked', 'describedBy', 'disabled', 'invalid', 'maxLength', 'minLength', 'multiple', 'name', 'placeholder', 'readOnly', 'required', 'type', 'value'];
 
-export function FormLabelMixin<T extends WidgetConstructor>(base: T): T {
+export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T {
 	return class extends base {
 
 		properties: FormLabelMixinProperties;

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -2,8 +2,8 @@
 import { assign } from '@dojo/core/lang';
 import i18n, { Bundle, formatMessage, getCachedMessages, Messages, observeLocale } from '@dojo/i18n/i18n';
 import { VNodeProperties } from '@dojo/interfaces/vdom';
-import { DNode, WidgetConstructor, WidgetProperties } from './../interfaces';
-import { Constructor } from './../interfaces';
+import { Constructor, DNode, WidgetProperties } from './../interfaces';
+import { WidgetBase } from './../WidgetBase';
 import { isHNode } from './../d';
 
 export interface I18nProperties extends WidgetProperties {
@@ -65,7 +65,7 @@ export interface I18n {
 	localizeBundle<T extends Messages>(bundle: Bundle<T>): LocalizedMessages<T>;
 }
 
-export function I18nMixin<T extends WidgetConstructor>(base: T): T & Constructor<I18n> {
+export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<I18n> {
 	return class extends base {
 		properties: I18nProperties;
 

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -2,7 +2,7 @@
 import { assign } from '@dojo/core/lang';
 import i18n, { Bundle, formatMessage, getCachedMessages, Messages, observeLocale } from '@dojo/i18n/i18n';
 import { VNodeProperties } from '@dojo/interfaces/vdom';
-import { DNode, WidgetConstructor, WidgetProperties } from './../WidgetBase';
+import { DNode, WidgetConstructor, WidgetProperties } from './../interfaces';
 import { Constructor } from './../interfaces';
 import { isHNode } from './../d';
 

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -1,8 +1,8 @@
 import Promise from '@dojo/shim/Promise';
 import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
 import { EventTargettedObject, Handle } from '@dojo/interfaces/core';
-import { WidgetConstructor, WidgetProperties } from './../interfaces';
-import { Constructor } from './../interfaces';
+import { Constructor, WidgetProperties } from './../interfaces';
+import { WidgetBase } from './../WidgetBase';
 import cssTransitions from '../animations/cssTransitions';
 
 /**
@@ -64,7 +64,7 @@ export interface Projector {
 	readonly projectorState: ProjectorState;
 }
 
-export function ProjectorMixin<T extends WidgetConstructor>(base: T): T & Constructor<Projector> {
+export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<Projector> {
 	return class extends base {
 
 		public properties: ProjectorProperties;

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -1,7 +1,7 @@
 import Promise from '@dojo/shim/Promise';
 import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
 import { EventTargettedObject, Handle } from '@dojo/interfaces/core';
-import { WidgetConstructor, WidgetProperties } from './../WidgetBase';
+import { WidgetConstructor, WidgetProperties } from './../interfaces';
 import { Constructor } from './../interfaces';
 import cssTransitions from '../animations/cssTransitions';
 

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -5,7 +5,7 @@ import {
 	PropertiesChangeEvent,
 	WidgetConstructor,
 	WidgetProperties
-} from '../WidgetBase';
+} from '../interfaces';
 
 export interface RegistryMixinProperties extends WidgetProperties {
 	registry: FactoryRegistry;
@@ -14,6 +14,8 @@ export interface RegistryMixinProperties extends WidgetProperties {
 export function RegistryMixin<T extends WidgetConstructor>(base: T): T {
 	return class extends base {
 		properties: RegistryMixinProperties;
+
+		protected registry: FactoryRegistry;
 
 		constructor(...args: any[]) {
 			super(...args);

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -1,9 +1,10 @@
 import { includes } from '@dojo/shim/array';
 import FactoryRegistry from '../FactoryRegistry';
+import { WidgetBase } from './../WidgetBase';
 import {
 	PropertyChangeRecord,
 	PropertiesChangeEvent,
-	WidgetConstructor,
+	Constructor,
 	WidgetProperties
 } from '../interfaces';
 
@@ -11,11 +12,9 @@ export interface RegistryMixinProperties extends WidgetProperties {
 	registry: FactoryRegistry;
 }
 
-export function RegistryMixin<T extends WidgetConstructor>(base: T): T {
+export function RegistryMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T {
 	return class extends base {
 		properties: RegistryMixinProperties;
-
-		protected registry: FactoryRegistry;
 
 		constructor(...args: any[]) {
 			super(...args);

--- a/src/mixins/Stateful.ts
+++ b/src/mixins/Stateful.ts
@@ -1,6 +1,6 @@
 import { deepAssign } from '@dojo/core/lang';
-import { WidgetConstructor } from './../interfaces';
-import { Constructor } from './../interfaces';
+import { Constructor, WidgetProperties } from './../interfaces';
+import { WidgetBase } from './../WidgetBase';
 
 /**
  * State
@@ -33,7 +33,7 @@ export interface Statful {
  */
 const stateChangedEventType = 'state:changed';
 
-export function StatefulMixin<T extends WidgetConstructor>(base: T): T & Constructor<Statful> {
+export function StatefulMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<Statful> {
 	return class extends base {
 
 		private _state: State;

--- a/src/mixins/Stateful.ts
+++ b/src/mixins/Stateful.ts
@@ -1,5 +1,5 @@
 import { deepAssign } from '@dojo/core/lang';
-import { WidgetConstructor } from './../WidgetBase';
+import { WidgetConstructor } from './../interfaces';
 import { Constructor } from './../interfaces';
 
 /**

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -1,7 +1,7 @@
 import { includes } from '@dojo/shim/array';
 import { assign } from '@dojo/core/lang';
-import { PropertiesChangeEvent, WidgetConstructor, WidgetProperties } from './../interfaces';
-import { Constructor } from './../interfaces';
+import { Constructor, PropertiesChangeEvent, WidgetProperties } from './../interfaces';
+import { WidgetBase } from './../WidgetBase';
 
 /**
  * A representation of the css class names to be applied and
@@ -84,7 +84,7 @@ export function theme (theme: {}) {
 /**
  * Function for returns a class decoratied with with Themeable functionality
  */
-export function ThemeableMixin<T extends WidgetConstructor>(base: T): Constructor<ThemeablMixin> & T {
+export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): Constructor<ThemeablMixin> & T {
 	return class extends base {
 
 		/**

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -1,6 +1,6 @@
 import { includes } from '@dojo/shim/array';
 import { assign } from '@dojo/core/lang';
-import { PropertiesChangeEvent, WidgetConstructor, WidgetProperties } from './../WidgetBase';
+import { PropertiesChangeEvent, WidgetConstructor, WidgetProperties } from './../interfaces';
 import { Constructor } from './../interfaces';
 
 /**

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -1,5 +1,5 @@
 import { initializeElement, CustomElementDescriptor, handleAttributeChanged } from './customElements';
-import { WidgetConstructor, WidgetBase } from './WidgetBase';
+import { WidgetConstructor, WidgetBaseInterface } from './interfaces';
 
 declare namespace customElements {
 	function define(name: string, constructor: any): void;
@@ -21,7 +21,7 @@ export interface CustomElementDescriptorFactory {
  */
 export function registerCustomElement(descriptorFactory: CustomElementDescriptorFactory) {
 	const descriptor = descriptorFactory();
-	let widgetInstance: WidgetBase<any>;
+	let widgetInstance: WidgetBaseInterface<any>;
 
 	customElements.define(descriptor.tagName, class extends HTMLElement {
 		constructor() {
@@ -34,11 +34,11 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 			handleAttributeChanged(this, name, newValue, oldValue);
 		}
 
-		getWidgetInstance(): WidgetBase<any> {
+		getWidgetInstance(): WidgetBaseInterface<any> {
 			return widgetInstance;
 		}
 
-		setWidgetInstance(widget: WidgetBase<any>): void {
+		setWidgetInstance(widget: WidgetBaseInterface<any>): void {
 			widgetInstance = widget;
 		}
 

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -1,5 +1,6 @@
 import { initializeElement, CustomElementDescriptor, handleAttributeChanged } from './customElements';
-import { WidgetConstructor, WidgetBaseInterface } from './interfaces';
+import { Constructor, WidgetProperties } from './interfaces';
+import { WidgetBase } from './WidgetBase';
 
 declare namespace customElements {
 	function define(name: string, constructor: any): void;
@@ -21,7 +22,7 @@ export interface CustomElementDescriptorFactory {
  */
 export function registerCustomElement(descriptorFactory: CustomElementDescriptorFactory) {
 	const descriptor = descriptorFactory();
-	let widgetInstance: WidgetBaseInterface<any>;
+	let widgetInstance: WidgetBase<any>;
 
 	customElements.define(descriptor.tagName, class extends HTMLElement {
 		constructor() {
@@ -34,15 +35,15 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 			handleAttributeChanged(this, name, newValue, oldValue);
 		}
 
-		getWidgetInstance(): WidgetBaseInterface<any> {
+		getWidgetInstance(): WidgetBase<any> {
 			return widgetInstance;
 		}
 
-		setWidgetInstance(widget: WidgetBaseInterface<any>): void {
+		setWidgetInstance(widget: WidgetBase<any>): void {
 			widgetInstance = widget;
 		}
 
-		getWidgetFactory(): WidgetConstructor {
+		getWidgetFactory(): Constructor<WidgetBase<WidgetProperties>> {
 			return this.getDescriptor().widgetFactory;
 		}
 

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -1,4 +1,5 @@
-import { DNode, WidgetBase, WidgetProperties } from './../WidgetBase';
+import { WidgetBase } from './../WidgetBase';
+import { DNode, WidgetProperties } from './../interfaces';
 import { isHNode } from '../d';
 import { assign } from '@dojo/core/lang';
 import { VNode } from '@dojo/interfaces/vdom';

--- a/tests/functional/support/registerCustomElement.ts
+++ b/tests/functional/support/registerCustomElement.ts
@@ -1,4 +1,5 @@
-import { WidgetBase, WidgetProperties } from '../../../src/WidgetBase';
+import { WidgetBase } from '../../../src/WidgetBase';
+import { WidgetProperties } from '../../../src/interfaces';
 import { v } from '../../../src/d';
 import registerCustomElement from '../../../src/registerCustomElement';
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1,7 +1,8 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Promise from '@dojo/shim/Promise';
-import { WidgetBase, DNode } from '../../src/WidgetBase';
+import { DNode } from '../../src/interfaces';
+import { WidgetBase } from '../../src/WidgetBase';
 import { VNode } from '@dojo/interfaces/vdom';
 import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -1,7 +1,8 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { assign } from '@dojo/core/lang';
-import { WidgetBase, DNode, HNode } from '../../src/WidgetBase';
+import { DNode, HNode } from '../../src/interfaces';
+import { WidgetBase } from '../../src/WidgetBase';
 import { v, w, decorate, registry, WNODE, HNODE, isWNode, isHNode } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
 

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -1,7 +1,8 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { isHNode } from '../../../src/d';
-import { WidgetBase, HNode } from './../../../src/WidgetBase';
+import { HNode } from './../../../src/interfaces';
+import { WidgetBase } from './../../../src/WidgetBase';
 import { DomWrapper } from '../../../src/util/DomWrapper';
 
 function callCreate(widget: WidgetBase<any>, includeUpdate = false) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Change the check for a Widget class type in order to avoid the cyclical dependency between `FactoryRegistry` and `WidgetBase` - will also require extracting interfaces out into the common interfaces.d.ts file.

Resolves #344 
