### PR TITLE
Widget Base decorator support including `diffProperty` and `afterRender`

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -27,7 +27,7 @@ interface WidgetCacheWrapper {
 }
 
 /**
- * decorator that can be used to register functions to run after a widgets render
+ * Decorator that can be used to register a function to run as an aspect to `render`
  */
 export function afterRender(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
 	const afterRenderArray = target.getDecoratorAttr('afterRender') || [];
@@ -38,7 +38,9 @@ export function afterRender(target: any, propertyKey: string, descriptor: Proper
 }
 
 /**
- * decorator that can be used to register functions to for specific property diffs
+ * Decorator that can be used to register a function as specific property diff
+ *
+ * @param propertyName the name of the property that the diff function is for
  */
 export function diffProperty(propertyName: string) {
 	return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
@@ -111,7 +113,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	private bindFunctionPropertyMap: WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>;
 
 	/**
-	 * A generic bag for decorator attributes to be added to.
+	 * A generic bag for decorator attributes.
 	 */
 	private _decoratorAttributes: any;
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -97,6 +97,11 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	private bindFunctionPropertyMap: WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>;
 
 	/**
+	 * A generic bag for decorator attributes to be added to.
+	 */
+	private _decoratorAttributes: any;
+
+	/**
 	 * Internal factory registry
 	 */
 	protected registry: FactoryRegistry | undefined;
@@ -237,6 +242,26 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			type: 'invalidated',
 			target: this
 		});
+	}
+
+	/**
+	 * setter used by decorators to add an attribute to the bag
+	 */
+	protected setDecoratorAttr(name: string, value: any): void {
+		if (!this._decoratorAttributes) {
+			this._decoratorAttributes = {};
+		}
+		this._decoratorAttributes[name] = value;
+	}
+
+	/**
+	 * getter used by decorators to get an attribute from the bag
+	 */
+	protected getDecoratorAttr(name: string): any {
+		if (!this._decoratorAttributes) {
+			return null;
+		}
+		return this._decoratorAttributes[name];
 	}
 
 	/**

--- a/src/mixins/FormLabel.ts
+++ b/src/mixins/FormLabel.ts
@@ -5,7 +5,7 @@ import {
 	Constructor,
 	WidgetProperties
 } from '../interfaces';
-import { WidgetBase } from './../WidgetBase';
+import { WidgetBase, afterRender } from './../WidgetBase';
 
 /**
  * Label settings for form label text content, position (before or after), and visibility
@@ -112,13 +112,14 @@ const labelDefaults = {
 const allowedFormFieldAttributes = ['checked', 'describedBy', 'disabled', 'invalid', 'maxLength', 'minLength', 'multiple', 'name', 'placeholder', 'readOnly', 'required', 'type', 'value'];
 
 export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T {
-	return class extends base {
+	class FormLabel extends base {
 
 		properties: FormLabelMixinProperties;
 
 		type: string;
 
-		renderDecoratorFormLabel(result: DNode): DNode {
+		@afterRender
+		renderDecorator(result: DNode): DNode {
 			const labelNodeAttributes: any = {};
 			if (isHNode(result)) {
 				assign(result.properties, this.getFormFieldA11yAttributes());
@@ -196,6 +197,8 @@ export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties
 			return nodeAttributes;
 		}
 	};
+
+	return FormLabel;
 }
 
 export default FormLabelMixin;

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -3,7 +3,7 @@ import { assign } from '@dojo/core/lang';
 import i18n, { Bundle, formatMessage, getCachedMessages, Messages, observeLocale } from '@dojo/i18n/i18n';
 import { VNodeProperties } from '@dojo/interfaces/vdom';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';
-import { WidgetBase } from './../WidgetBase';
+import { WidgetBase, afterRender } from './../WidgetBase';
 import { isHNode } from './../d';
 
 export interface I18nProperties extends WidgetProperties {
@@ -66,7 +66,7 @@ export interface I18n {
 }
 
 export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<I18n> {
-	return class extends base {
+	class I18n extends base {
 		properties: I18nProperties;
 
 		constructor(...args: any[]) {
@@ -96,7 +96,8 @@ export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(b
 			}), messages) as LocalizedMessages<T>;
 		}
 
-		renderDecoratorI18n(result: DNode): DNode {
+		@afterRender
+		renderDecorator(result: DNode): DNode {
 			if (isHNode(result)) {
 				const { locale, rtl } = this.properties;
 				const vNodeProperties: I18nVNodeProperties = {
@@ -144,6 +145,8 @@ export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(b
 			});
 		}
 	};
+
+	return I18n;
 }
 
 export default I18nMixin;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -77,7 +77,7 @@ export interface ThemeableMixinInterface {
  */
 export function theme (theme: {}) {
 	return function(constructor: Function) {
-		constructor.prototype.baseClasses = theme;
+		constructor.prototype.setDecoratorAttr('baseClasses', theme);
 	};
 }
 
@@ -117,6 +117,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties
 		 */
 		constructor(...args: any[]) {
 			super(...args);
+			this.baseClasses = this.getDecoratorAttr('baseClasses') || {};
 			this.own(this.on('properties:changed', (evt: PropertiesChangeEvent<this, ThemeableProperties>) => {
 				this.onPropertiesChanged(evt.properties, evt.changedPropertyKeys);
 			}));

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -343,13 +343,14 @@ registerSuite({
 		class ExtendedTestWidget extends TestWidget {
 			@afterRender
 			thirdAfterRender(result: DNode): DNode {
-				assert.strictEqual(afterRenderCount++, 3);
+				assert.strictEqual(afterRenderCount, 3);
 				return result;
 			}
 		}
 
 		const widget = new ExtendedTestWidget({});
-		widget.render();
+		widget.__render__();
+		assert.strictEqual(afterRenderCount, 3);
 	},
 	render: {
 		'render with non widget children'() {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Promise from '@dojo/shim/Promise';
 import { DNode } from '../../src/interfaces';
-import { WidgetBase } from '../../src/WidgetBase';
+import { WidgetBase, diffProperty, afterRender } from '../../src/WidgetBase';
 import { VNode } from '@dojo/interfaces/vdom';
 import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';
@@ -67,6 +67,8 @@ registerSuite({
 			let callCount = 0;
 
 			class TestWidget extends WidgetBase<any> {
+
+				@diffProperty('foo')
 				diffPropertyFoo(this: any, previousProperty: any, newProperty: any): any {
 					callCount++;
 					assert.equal(newProperty, 'bar');
@@ -83,6 +85,8 @@ registerSuite({
 		},
 		'result from diff property override diff and assign'() {
 			class TestWidget extends WidgetBase<any> {
+
+				@diffProperty('foo')
 				diffPropertyFoo(this: any, previousProperty: any, newProperty: any): any {
 					return {
 						changed: true,
@@ -90,6 +94,7 @@ registerSuite({
 					};
 				}
 
+				@diffProperty('baz')
 				diffPropertyBaz(this: any, previousProperty: any, newProperty: any): any {
 					return {
 						changed: false,
@@ -109,6 +114,8 @@ registerSuite({
 		},
 		'uses base diff when an individual property diff returns null'() {
 			class TestWidget extends WidgetBase<any> {
+
+				@diffProperty('foo')
 				diffPropertyFoo(this: any, previousProperty: any, newProperty: any): any {
 					return null;
 				}
@@ -317,6 +324,32 @@ registerSuite({
 				assert.strictEqual(testWidget.count, 0);
 			}
 		}
+	},
+	afterRender() {
+		let afterRenderCount = 1;
+		class TestWidget extends WidgetBase<any> {
+			@afterRender
+			firstAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount++, 1);
+				return result;
+			}
+			@afterRender
+			secondAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount++, 2);
+				return result;
+			}
+		}
+
+		class ExtendedTestWidget extends TestWidget {
+			@afterRender
+			thirdAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount++, 3);
+				return result;
+			}
+		}
+
+		const widget = new ExtendedTestWidget({});
+		widget.render();
 	},
 	render: {
 		'render with non widget children'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Provide an API for setting and getting decorator property values and expose two decorator functions `afterRender` and `diffProperty`.

They both replace existing functionality that collected functions in the constructor based on a regular expression.

*afterRender*: function that accepts and returns a `DNode` - run using the result of `render`
*diffProperty*: function that specifies a function to use for a specific property diff.

Resolves #330 
Resolves #331
