### PR TITLE
Remove type from FormLabel

### DIFF
--- a/src/mixins/FormLabel.ts
+++ b/src/mixins/FormLabel.ts
@@ -32,11 +32,6 @@ export interface FormLabelMixinProperties {
 	value?: string;
 
 	/**
-	 * The type of the form field (equates to the `type` attribute in the DOM)
-	 */
-	type?: string;
-
-	/**
 	 * Prevents the user from interacting with the form field
 	 */
 	disabled?: boolean;
@@ -109,14 +104,12 @@ const labelDefaults = {
 /**
  * Allowed attributes for a11y
  */
-const allowedFormFieldAttributes = ['checked', 'describedBy', 'disabled', 'invalid', 'maxLength', 'minLength', 'multiple', 'name', 'placeholder', 'readOnly', 'required', 'type', 'value'];
+const allowedFormFieldAttributes = ['checked', 'describedBy', 'disabled', 'invalid', 'maxLength', 'minLength', 'multiple', 'name', 'placeholder', 'readOnly', 'required', 'value'];
 
 export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T {
 	return class extends base {
 
 		properties: FormLabelMixinProperties;
-
-		type: string;
 
 		renderDecoratorFormLabel(result: DNode): DNode {
 			const labelNodeAttributes: any = {};
@@ -158,12 +151,8 @@ export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties
 		}
 
 		private getFormFieldA11yAttributes() {
-			const { properties, type } = this;
+			const { properties } = this;
 			const attributeKeys = Object.keys(properties);
-
-			if (type) {
-				attributeKeys.push('type');
-			}
 
 			const nodeAttributes: any = {};
 
@@ -171,9 +160,6 @@ export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties
 
 				if (attributeKeys.indexOf(key) === -1) {
 					continue;
-				}
-				else if (key === 'type') {
-					nodeAttributes.type = type;
 				}
 				else if (key === 'readOnly' && properties.readOnly) {
 					nodeAttributes.readonly = 'readonly';

--- a/tests/unit/mixins/FormLabel.ts
+++ b/tests/unit/mixins/FormLabel.ts
@@ -92,14 +92,6 @@ registerSuite({
 			assert.isTrue(vnode.properties!.classes!['qux'], 'Classes should be set on the label node');
 		}
 	},
-	'type'() {
-		const formField: any = new FormLabelWidget({});
-		formField.type = 'foo';
-
-		const vnode = <VNode> formField.__render__();
-
-		assert.strictEqual(vnode.properties!['type'], 'foo');
-	},
 	'label': {
 		'string label'() {
 			const formField: any = new FormLabelWidget({


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
With the use of `render()` it no longer makes sense to have `type` on the instance, so I removed type entirely from FormLabel. The only widget that would use `properties.type` is `TextInput`, so it makes more sense to handle on a widget-by-widget basis.
