### PR TITLE
Fix up mixin interfaces

### DIFF
--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -50,7 +50,7 @@ export type LocalizedMessages<T extends Messages> = T & {
 /**
  * interface for I18n functionality
  */
-export interface I18n {
+export interface I18nMixin {
 	/**
 	 * Return the cached messages for the specified bundle for the current locale, assuming they have already
 	 * benn loaded. If the locale-specific messages have not been loaded, they are fetched and the widget state
@@ -65,7 +65,7 @@ export interface I18n {
 	localizeBundle<T extends Messages>(bundle: Bundle<T>): LocalizedMessages<T>;
 }
 
-export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<I18n> {
+export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<I18nMixin> {
 	return class extends base {
 		properties: I18nProperties;
 

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -36,7 +36,7 @@ export interface AttachOptions {
 	root?: Element;
 }
 
-export interface Projector {
+export interface ProjectorMixin {
 
 	/**
 	 * Append the projector to the root.
@@ -64,7 +64,7 @@ export interface Projector {
 	readonly projectorState: ProjectorState;
 }
 
-export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<Projector> {
+export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<ProjectorMixin> {
 	return class extends base {
 
 		public projectorState: ProjectorState;
@@ -210,4 +210,4 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 	};
 }
 
-export default Projector;
+export default ProjectorMixin;

--- a/src/mixins/Stateful.ts
+++ b/src/mixins/Stateful.ts
@@ -12,7 +12,7 @@ export interface State {
 /**
  * Stateful interface
  */
-export interface Statful {
+export interface StatfulMixin {
 
 	/**
 	 * state property
@@ -33,7 +33,7 @@ export interface Statful {
  */
 const stateChangedEventType = 'state:changed';
 
-export function StatefulMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<Statful> {
+export function StatefulMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<StatfulMixin> {
 	return class extends base {
 
 		private _state: State;

--- a/src/mixins/Stateful.ts
+++ b/src/mixins/Stateful.ts
@@ -12,7 +12,7 @@ export interface State {
 /**
  * Stateful interface
  */
-export interface StatfulMixin {
+export interface StatefulMixin {
 
 	/**
 	 * state property
@@ -33,7 +33,7 @@ export interface StatfulMixin {
  */
 const stateChangedEventType = 'state:changed';
 
-export function StatefulMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<StatfulMixin> {
+export function StatefulMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<StatefulMixin> {
 	return class extends base {
 
 		private _state: State;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -60,7 +60,7 @@ const THEME_KEY = ' _key';
 /**
  * Interface for the ThemeableMixin
  */
-export interface ThemeableMixinInterface {
+export interface ThemeableMixin {
 
 	/**
 	 * Processes all the possible classes for the instance with setting the passed class names to
@@ -130,7 +130,7 @@ function createBaseClassesLookup(classes: BaseClasses): ClassNames {
 /**
  * Function for returns a class decoratied with with Themeable functionality
  */
-export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): Constructor<ThemeableMixinInterface> & T {
+export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<ThemeableMixin> {
 	return class extends base {
 
 		/**


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Interfaces can be the same name as the function for mixins provided they are both exported from the same module. Also the Base class needs to be specified first for the return intersection type.
