### PR TITLE
remove 'id' from widget base

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -138,10 +138,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this.setProperties(properties);
 	}
 
-	public get id(): string | undefined {
-		return this._properties.id;
-	}
-
 	public get properties(): Readonly<P> {
 		return this._properties;
 	}

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -62,11 +62,6 @@ export type SubmitEventHandler = EventHandler;
 export interface WidgetProperties {
 
 	/**
-	 * id for a widget
-	 */
-	id?: string;
-
-	/**
 	 * The key for a widget. Used to differentiate uniquely identify child widgets for
 	 * rendering and instance management
 	 */
@@ -190,11 +185,6 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	 * Widget properties
 	 */
 	readonly properties: P;
-
-	/**
-	 * Widget id
-	 */
-	readonly id: string | undefined;
 
 	/**
 	 * Returns the widget's children

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -749,26 +749,6 @@ registerSuite({
 			assert.isTrue(widgetTwoInstantiated);
 		}
 	},
-	'id': {
-		'in properties'() {
-			const widgetBase = new WidgetBase({
-					id: 'foo'
-			});
-
-			assert.strictEqual(widgetBase.id, 'foo');
-		},
-		'not in properties'() {
-			const widgetBase = new WidgetBase({});
-
-			assert.isUndefined(widgetBase.id);
-		},
-		'is read only'() {
-			const widgetBase = new WidgetBase({});
-			assert.throws(() => {
-				(<any> widgetBase).id = 'foo'; /* .id is readonly, so TypeScript will prevent mutation */
-			});
-		}
-	},
 	'invalidate emits invalidated event'() {
 		const widgetBase = new WidgetBase({});
 		let count = 0;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes `id` from widget base

Resolves #337 
