### PR TITLE
Set locales on `lang` attribute.

### DIFF
--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -9,8 +9,7 @@ import { isHNode } from './../d';
 export interface I18nProperties extends WidgetProperties {
 	/**
 	 * The locale for the widget. Is not specified, then the root locale (as determined by `@dojo/i18n`) is assumed.
-	 * If specified, the widget's node will have a `data-locale` property set to the locale, in order to facilitate
-	 * styling localized components if the use case arises.
+	 * If specified, the widget's node will have a `lang` property set to the locale.
 	 */
 	locale?: string;
 
@@ -27,8 +26,8 @@ export interface I18nProperties extends WidgetProperties {
  * An internal helper interface for defining locale and text direction attributes on widget nodes.
  */
 interface I18nVNodeProperties extends VNodeProperties {
-	'data-locale': string | null;
 	dir: string | null;
+	lang: string | null;
 }
 
 export type LocalizedMessages<T extends Messages> = T & {
@@ -100,15 +99,15 @@ export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(b
 			if (isHNode(result)) {
 				const { locale, rtl } = this.properties;
 				const vNodeProperties: I18nVNodeProperties = {
-					'data-locale': null,
-					dir: null
+					dir: null,
+					lang: null
 				};
 
 				if (typeof rtl === 'boolean') {
 					vNodeProperties['dir'] = rtl ? 'rtl' : 'ltr';
 				}
 				if (locale) {
-					vNodeProperties['data-locale'] = locale;
+					vNodeProperties['lang'] = locale;
 				}
 
 				assign(result.properties, vNodeProperties);

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -111,15 +111,15 @@ registerSuite({
 
 		const result = <VNode> localized.__render__();
 		assert.isOk(result);
-		assert.isNull(result.properties!['data-locale']);
+		assert.isNull(result.properties!['lang']);
 	},
-	'`properties.locale` updates the widget node\'s `data-locale` property': {
+	'`properties.locale` updates the widget node\'s `lang` property': {
 		'when non-empty'() {
 			localized = new Localized({locale: 'ar-JO'});
 
 			const result = <VNode> localized.__render__();
 			assert.isOk(result);
-			assert.strictEqual(result.properties!['data-locale'], 'ar-JO');
+			assert.strictEqual(result.properties!['lang'], 'ar-JO');
 		},
 
 		'when empty'() {
@@ -127,7 +127,7 @@ registerSuite({
 
 			const result = localized.__render__();
 			assert.isOk(result);
-			assert.isNull(result.properties!['data-locale']);
+			assert.isNull(result.properties!['lang']);
 		}
 	},
 


### PR DESCRIPTION
Update the `I18n` mixin to add locales to an HTML element's `lang` attribute instead of to the custom `data-locale` attribute.

**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #353
