### PR TITLE
Decouple initial set properties from the widget base constructor

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -103,9 +103,8 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 
 	/**
 	 * @constructor
-	 * @param options widget options for construction
 	 */
-	constructor(properties: P) {
+	constructor() {
 		super({});
 
 		this._children = [];
@@ -134,15 +133,13 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this.own(this.on('properties:changed', (evt: PropertiesChangeEvent<WidgetBase<WidgetProperties>, WidgetProperties>) => {
 			this.invalidate();
 		}));
-
-		this.setProperties(properties);
 	}
 
 	public get properties(): Readonly<P> {
 		return this._properties;
 	}
 
-	public setProperties(properties: P & { [index: string]: any }): void {
+	public setProperties(properties: P): void {
 		const diffPropertyResults: { [index: string]: PropertyChangeRecord } = {};
 		const diffPropertyChangedKeys: string[] = [];
 
@@ -150,7 +147,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 
 		this.diffPropertyFunctionMap.forEach((property: string, diffFunctionName: string) => {
 			const previousProperty = this.previousProperties[property];
-			const newProperty = properties[property];
+			const newProperty = (<any> properties)[property];
 			const self: { [index: string]: any } = this;
 			const result: PropertyChangeRecord = self[diffFunctionName](previousProperty, newProperty);
 
@@ -161,7 +158,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			if (result.changed) {
 				diffPropertyChangedKeys.push(property);
 			}
-			delete properties[property];
+			delete (<any> properties)[property];
 			delete this.previousProperties[property];
 			diffPropertyResults[property] = result.value;
 		});
@@ -331,7 +328,8 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 				cachedChild.used = true;
 			}
 			else {
-				child = new factory(properties);
+				child = new factory();
+				child.setProperties(properties);
 				child.own(child.on('invalidated', () => {
 					this.invalidate();
 				}));

--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -241,7 +241,8 @@ export function initializeElement(element: CustomElement) {
 
 	const projector = ProjectorMixin(element.getWidgetFactory());
 
-	const widgetInstance = new projector(initialProperties);
+	const widgetInstance = new projector();
+	widgetInstance.setProperties(initialProperties);
 	widgetInstance.setChildren(children);
 	element.setWidgetInstance(widgetInstance);
 

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -285,7 +285,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties
 		}
 
 		/**
-		 * Initialize the reverse loop up map and the generatedThemeClasses.
+		 * Initialize the reverse look up map and the generatedThemeClasses.
 		 */
 		private initializeClasses(): void {
 			if (!this.initialized) {

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -284,7 +284,10 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties
 			}
 		}
 
-		private initializeClasses() {
+		/**
+		 * Initialize the reverse loop up map and the generatedThemeClasses.
+		 */
+		private initializeClasses(): void {
 			if (!this.initialized) {
 				const { theme, overrideClasses } = this.properties;
 				this.baseClassesReverseLookup = createBaseClassesLookup(this.baseClasses);

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -159,9 +159,9 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties
 		private generatedClassNames: ClassNameFlagsMap;
 
 		/**
-		 * Indicates if the base classes have been initialised.
+		 * Indicates if the base classes have been initialized.
 		 */
-		private initialised: boolean;
+		private initialized: boolean;
 
 		/**
 		 * @constructor
@@ -171,7 +171,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties
 			this.own(this.on('properties:changed', (evt: PropertiesChangeEvent<this, ThemeableProperties>) => {
 				this.onPropertiesChanged(evt.properties, evt.changedPropertyKeys);
 			}));
-			this.initialised = false;
+			this.initialized = false;
 		}
 
 		/**
@@ -186,7 +186,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties
 		 *
 		 */
 		public classes(...classNames: (string | null)[]): ClassesFunctionChain {
-			this.initiliaseClasses();
+			this.initializeClasses();
 
 			const appliedClasses = classNames
 				.filter((className) => className !== null)
@@ -278,18 +278,18 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<WidgetProperties
 			const overrideClassesChanged = includes(changedPropertyKeys, 'overrideClasses');
 
 			if (themeChanged || overrideClassesChanged) {
-				this.initialised ?
+				this.initialized ?
 					this.generateThemeClasses(this.baseClasses, theme, overrideClasses) :
-					this.initiliaseClasses();
+					this.initializeClasses();
 			}
 		}
 
-		private initiliaseClasses() {
-			if (!this.initialised) {
+		private initializeClasses() {
+			if (!this.initialized) {
 				const { theme, overrideClasses } = this.properties;
 				this.baseClassesReverseLookup = createBaseClassesLookup(this.baseClasses);
 				this.generateThemeClasses(this.baseClasses, theme , overrideClasses);
-				this.initialised = true;
+				this.initialized = true;
 			}
 		}
 	};

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -11,7 +11,7 @@ import FactoryRegistry from './../../src/FactoryRegistry';
 registerSuite({
 	name: 'WidgetBase',
 	api() {
-		const widgetBase = new WidgetBase({});
+		const widgetBase = new WidgetBase();
 		assert(widgetBase);
 		assert.isFunction(widgetBase.render);
 		assert.isFunction(widgetBase.invalidate);
@@ -19,7 +19,7 @@ registerSuite({
 	children() {
 		let childrenEventEmitted = false;
 		const expectedChild = v('div');
-		const widget = new WidgetBase({});
+		const widget = new WidgetBase();
 		widget.on('widget:children', () => {
 			childrenEventEmitted = true;
 		});
@@ -31,31 +31,31 @@ registerSuite({
 		assert.isTrue(childrenEventEmitted);
 	},
 	'Applies div as default tag'() {
-			const widget = new WidgetBase({});
+			const widget = new WidgetBase();
 			const renderedWidget = <VNode> (<any> widget).__render__();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'div');
 	},
 	diffProperties: {
 		'no updated properties'() {
 			const properties = { id: 'id', foo: 'bar' };
-			const widgetBase = new WidgetBase({});
+			const widgetBase = new WidgetBase();
 			const result = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(result.changedKeys, 0);
 		},
 		'updated properties'() {
-			const widgetBase = new WidgetBase({});
+			const widgetBase = new WidgetBase();
 			const properties = { id: 'id', foo: 'baz' };
 			const result = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(result.changedKeys, 1);
 		},
 		'new properties'() {
-			const widgetBase = new WidgetBase({});
+			const widgetBase = new WidgetBase();
 			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
 			const result = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(result.changedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
-			const widgetBase = new WidgetBase({});
+			const widgetBase = new WidgetBase();
 			const properties = { id: 'id', foo: '', bar: null, baz: 0, qux: false };
 			const result = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(result.changedKeys, 4);
@@ -77,7 +77,8 @@ registerSuite({
 				}
 			}
 
-			new TestWidget({ foo: 'bar' });
+			const testWidget = new TestWidget();
+			testWidget.setProperties({ foo: 'bar' });
 
 			assert.equal(callCount, 1);
 		},
@@ -98,7 +99,8 @@ registerSuite({
 				}
 			}
 
-			const widget = new TestWidget({ foo: 'bar', baz: 'qux' });
+			const widget = new TestWidget();
+			widget.setProperties({ foo: 'bar', baz: 'qux' });
 
 			widget.on('properties:changed', (event: any) => {
 				assert.include(event.changedPropertyKeys, 'foo');
@@ -114,7 +116,8 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({ foo: 'bar' });
+			const widget: any = new TestWidget();
+			widget.setProperties({ foo: 'bar' });
 
 			widget.on('properties:changed', (event: any) => {
 				assert.include(event.changedPropertyKeys, 'foo');
@@ -132,8 +135,8 @@ registerSuite({
 
 			class TestWidget extends WidgetBase<any> {
 				count: number;
-				constructor(options: any) {
-					super(options);
+				constructor() {
+					super();
 					this.count = 0;
 				}
 
@@ -146,7 +149,7 @@ registerSuite({
 				}
 			}
 
-			const testWidget: any = new TestWidget({});
+			const testWidget: any = new TestWidget();
 			testWidget.__render__();
 			assert.strictEqual(testWidget.count, 1);
 			testWidget.invalidate();
@@ -171,7 +174,7 @@ registerSuite({
 			class TestWidget extends WidgetBase<any> {
 				count: number;
 				constructor() {
-					super({});
+					super();
 					this.count = 0;
 				}
 
@@ -218,7 +221,7 @@ registerSuite({
 				}
 
 				constructor() {
-					super({});
+					super();
 					this.count = 0;
 				}
 
@@ -265,7 +268,7 @@ registerSuite({
 				}
 
 				constructor() {
-					super({});
+					super();
 					this.count = 0;
 				}
 
@@ -297,7 +300,7 @@ registerSuite({
 				}
 
 				constructor() {
-					super({});
+					super();
 					this.count = 0;
 				}
 
@@ -328,7 +331,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const result = <VNode> widget.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children && result.children[0].vnodeSelector, 'header');
@@ -358,7 +361,7 @@ registerSuite({
 
 			let invalidateCount = 0;
 
-			const myWidget: any = new TestWidget({});
+			const myWidget: any = new TestWidget();
 			myWidget.on('invalidated', () => {
 				invalidateCount++;
 			});
@@ -404,7 +407,7 @@ registerSuite({
 				}
 			}
 
-			const myWidget: any = new TestWidget({});
+			const myWidget: any = new TestWidget();
 
 			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 0);
@@ -429,7 +432,7 @@ registerSuite({
 				}
 			}
 
-			const myWidget: any = new TestWidget({});
+			const myWidget: any = new TestWidget();
 			const consoleStub = stub(console, 'warn');
 			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 0);
@@ -449,7 +452,7 @@ registerSuite({
 
 			class TestWidget extends WidgetBase<any> {
 				constructor() {
-					super({});
+					super();
 					this.registry = registry;
 				}
 
@@ -477,7 +480,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const result = <VNode> widget.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children![0].vnodeSelector, 'header');
@@ -490,7 +493,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const result = <VNode> widget.__render__();
 			assert.isUndefined(result.children);
 			assert.equal(result.text, 'I am a text node');
@@ -506,7 +509,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const result = <VNode> widget.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.properties!.bind, widget);
@@ -525,7 +528,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const result = <VNode> widget.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.properties!.bind, widget);
@@ -539,7 +542,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const result = <VNode> widget.__render__();
 			assert.isUndefined(result.text);
 			assert.lengthOf(result.children, 2);
@@ -552,7 +555,7 @@ registerSuite({
 
 			class TestChildWidget extends WidgetBase<any> {
 				constructor() {
-					super({});
+					super();
 					countWidgetCreated++;
 				}
 
@@ -576,7 +579,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const firstRenderResult = <VNode> widget.__render__();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 0);
@@ -626,7 +629,7 @@ registerSuite({
 				}
 			}
 
-			const widget: any = new TestWidget({});
+			const widget: any = new TestWidget();
 			const consoleStub = stub(console, 'warn');
 			widget.__render__();
 			assert.isTrue(consoleStub.calledOnce);
@@ -644,7 +647,8 @@ registerSuite({
 				]
 			};
 
-			const myWidget = new WidgetBase<any>(properties);
+			const myWidget = new WidgetBase<any>();
+			myWidget.setProperties(properties);
 			assert.deepEqual((<any> myWidget.properties).items, [ 'a', 'b' ]);
 			properties.items.push('c');
 			myWidget.setProperties(properties);
@@ -660,7 +664,8 @@ registerSuite({
 				]
 			};
 
-			const myWidget: any = new WidgetBase(properties);
+			const myWidget: any = new WidgetBase();
+			myWidget.setProperties(properties);
 			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.properties).items, [ 'a', 'b' ]);
 			myWidget.setProperties(<any> { items: [ 'a', 'b', 'c'] });
@@ -668,7 +673,8 @@ registerSuite({
 			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c' ]);
 		},
 		'__render__() and invalidate()'() {
-			const widgetBase: any = new WidgetBase({ id: 'foo', label: 'foo' });
+			const widgetBase: any = new WidgetBase();
+			widgetBase.setProperties({ id: 'foo', label: 'foo' });
 			const result1 = <VNode> widgetBase.__render__();
 			const result2 = <VNode> widgetBase.__render__();
 			widgetBase.invalidate();
@@ -687,7 +693,7 @@ registerSuite({
 
 			class TestChildWidget extends WidgetBase<any> {
 				constructor() {
-					super({});
+					super();
 					childWidgetInstantiatedCount++;
 				}
 			}
@@ -710,7 +716,7 @@ registerSuite({
 				}
 			}
 
-			const testWidget: any = new TestWidget({});
+			const testWidget: any = new TestWidget();
 			testWidget.__render__();
 
 			assert.equal(childWidgetInstantiatedCount, 5);
@@ -722,13 +728,13 @@ registerSuite({
 
 			class WidgetOne extends WidgetBase<any> {
 				constructor() {
-					super({});
+					super();
 					widgetOneInstantiated = true;
 				}
 			}
 			class WidgetTwo extends WidgetBase<any> {
 				constructor() {
-					super({});
+					super();
 					widgetTwoInstantiated = true;
 				}
 			}
@@ -740,7 +746,7 @@ registerSuite({
 				}
 			}
 
-			const myWidget: any = new TestWidget({});
+			const myWidget: any = new TestWidget();
 			myWidget.__render__();
 			assert.isTrue(widgetOneInstantiated);
 			renderWidgetOne = false;
@@ -750,7 +756,7 @@ registerSuite({
 		}
 	},
 	'invalidate emits invalidated event'() {
-		const widgetBase = new WidgetBase({});
+		const widgetBase = new WidgetBase();
 		let count = 0;
 		widgetBase.on('invalidated', function() {
 			console.log('invalid');
@@ -767,7 +773,7 @@ registerSuite({
 
 		class TestChildWidget extends WidgetBase<any> {
 			constructor() {
-				super({});
+				super();
 				childInvalidate = () => {
 					childInvalidateCalled = true;
 					this.invalidate();
@@ -787,7 +793,7 @@ registerSuite({
 			}
 		}
 
-		const widget = new Widget({});
+		const widget = new Widget();
 
 		(<any> widget).__render__();
 		childInvalidate();

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -110,7 +110,7 @@ registerSuite({
 	},
 	decorator: {
 		'modifies only nodes that match predicate'() {
-			const testWidget = new TestWidget({});
+			const testWidget = new TestWidget();
 			const predicate = (node: DNode): boolean => {
 				return isWNode(node);
 			};
@@ -135,7 +135,7 @@ registerSuite({
 			}
 		},
 		'modifies no node when predicate not matched'() {
-			const testWidget = new TestWidget({});
+			const testWidget = new TestWidget();
 			const predicate = (node: DNode): boolean => {
 				return false;
 			};
@@ -160,7 +160,7 @@ registerSuite({
 			}
 		},
 		'applies modifier to all nodes when no predicate supplied'() {
-			const testWidget = new TestWidget({});
+			const testWidget = new TestWidget();
 			const modifier = (node: DNode): void => {
 				if (isWNode(node)) {
 					(<any> node.properties)['decorated'] = true;
@@ -184,7 +184,7 @@ registerSuite({
 			}
 		},
 		'cannot replace or modify actual node'() {
-			const testWidget = new TestWidget({});
+			const testWidget = new TestWidget();
 			const magicNode = v('magic');
 			const modifier = (node: DNode): void => {
 				if (node === null) {

--- a/tests/unit/mixins/FormLabel.ts
+++ b/tests/unit/mixins/FormLabel.ts
@@ -10,18 +10,18 @@ class FormLabelWidget extends FormLabelMixin(WidgetBase)<FormLabelMixinPropertie
 registerSuite({
 	name: 'mixins/createFormLabelMixin',
 	construction() {
-		const formLabelMixin: any = new FormLabelWidget({});
+		const formLabelMixin: any = new FormLabelWidget();
 
 		assert.isDefined(formLabelMixin);
 	},
 	getFormFieldNodeAttributes: {
 		'for HNode'() {
-			const formField: any = new FormLabelWidget(<any> {
+			const formField = new FormLabelWidget();
+			formField.setProperties(<any> {
 				value: 'foo',
 				maxLength: 100,
 				randomProp: 'qux'
 			});
-
 			let vnode = <VNode> formField.__render__();
 
 			assert.strictEqual(vnode.vnodeSelector, 'div');
@@ -59,7 +59,8 @@ registerSuite({
 				}
 			};
 
-			const formField: any = new ExtendedFormField(<any> {
+			const formField: any = new ExtendedFormField();
+			formField.setProperties(<any> {
 				value: 'foo',
 				maxLength: 100,
 				randomProp: 'qux'
@@ -78,7 +79,8 @@ registerSuite({
 				}
 			};
 
-			const formField: any = new ExtendedFormField({
+			const formField: any = new ExtendedFormField();
+			formField.setProperties({
 				label: 'foo',
 				value: 'bar',
 				maxLength: 100,
@@ -94,7 +96,8 @@ registerSuite({
 	},
 	'label': {
 		'string label'() {
-			const formField: any = new FormLabelWidget({
+			const formField: any = new FormLabelWidget();
+			formField.setProperties({
 				label: 'bar'
 			});
 			const vnode = <VNode> formField.__render__();
@@ -104,7 +107,8 @@ registerSuite({
 			assert.strictEqual(vnode.children![1].properties!.innerHTML, 'bar');
 		},
 		'label options'() {
-			const formField: any = new FormLabelWidget({
+			const formField: any = new FormLabelWidget();
+			formField.setProperties({
 				label: {
 					content: 'bar',
 					position: 'before',
@@ -129,14 +133,14 @@ registerSuite({
 			assert.lengthOf(vnode.children, 1);
 		},
 		'no label'() {
-			const formField: any = new FormLabelWidget({});
+			const formField: any = new FormLabelWidget();
 			const vnode = <VNode> formField.__render__();
 
 			assert.strictEqual(vnode.vnodeSelector, 'div');
 			assert.lengthOf(vnode.children, 0);
 		},
 		'changing label'() {
-			const formField: any = new FormLabelWidget({});
+			const formField: any = new FormLabelWidget();
 			let vnode = <VNode> formField.__render__();
 
 			assert.strictEqual(vnode.vnodeSelector, 'div');

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -27,7 +27,7 @@ registerSuite({
 	},
 
 	api() {
-		const localized = new Localized({});
+		const localized = new Localized();
 		assert(localized);
 		assert.isFunction(localized.localizeBundle);
 	},
@@ -35,7 +35,7 @@ registerSuite({
 	'.localizeBundle()': {
 		'Returns default messages when locale bundle not loaded'() {
 			return switchLocale('fr').then(() => {
-				localized = new Localized({});
+				localized = new Localized();
 				const messages = localized.localizeBundle(bundle);
 
 				assert.strictEqual(messages.hello, 'Hello');
@@ -44,7 +44,8 @@ registerSuite({
 		},
 
 		'Uses `properties.locale` when available'() {
-			localized = new Localized({ locale: 'fr' });
+			localized = new Localized();
+			localized.setProperties({ locale: 'fr' });
 			return i18n(bundle, 'fr').then(() => {
 				const messages = localized.localizeBundle(bundle);
 				assert.strictEqual(messages.hello, 'Bonjour');
@@ -54,7 +55,7 @@ registerSuite({
 
 		'Uses default locale when no locale is set'() {
 			return switchLocale('fr').then(() => {
-				localized = new Localized({});
+				localized = new Localized();
 				return i18n(bundle, 'fr').then(() => {
 					const messages = localized.localizeBundle(bundle);
 					assert.strictEqual(messages.hello, 'Bonjour');
@@ -64,7 +65,7 @@ registerSuite({
 		},
 
 		'Returns an object with a `format` method'() {
-			localized = new Localized({});
+			localized = new Localized();
 			let messages = localized.localizeBundle(bundle);
 
 			assert.isFunction(messages.format);
@@ -81,7 +82,7 @@ registerSuite({
 
 	'root locale switching': {
 		'Updates when no `locale` property is set'() {
-			localized = new Localized({});
+			localized = new Localized();
 			sinon.spy(localized, 'invalidate');
 
 			return switchLocale('fr').then(() => {
@@ -90,9 +91,8 @@ registerSuite({
 		},
 
 		'Does not update when `locale` property is set'() {
-			localized = new Localized({
-					locale: 'en'
-			});
+			localized = new Localized();
+			localized.setProperties({ locale: 'en' });
 			sinon.spy(localized, 'invalidate');
 
 			return switchLocale('fr').then(() => {
@@ -107,7 +107,8 @@ registerSuite({
 			}
 		}
 
-		localized = new LocalizedExtended({locale: 'ar-JO'});
+		localized = new LocalizedExtended();
+		localized.setProperties({locale: 'ar-JO'});
 
 		const result = <VNode> localized.__render__();
 		assert.isOk(result);
@@ -115,7 +116,8 @@ registerSuite({
 	},
 	'`properties.locale` updates the widget node\'s `lang` property': {
 		'when non-empty'() {
-			localized = new Localized({locale: 'ar-JO'});
+			localized = new Localized();
+			localized.setProperties({locale: 'ar-JO'});
 
 			const result = <VNode> localized.__render__();
 			assert.isOk(result);
@@ -123,7 +125,7 @@ registerSuite({
 		},
 
 		'when empty'() {
-			localized = new Localized({});
+			localized = new Localized();
 
 			const result = localized.__render__();
 			assert.isOk(result);
@@ -133,7 +135,8 @@ registerSuite({
 
 	'`properties.rtl`': {
 		'The `dir` attribute is "rtl" when true'() {
-			localized = new Localized({ rtl: true });
+			localized = new Localized();
+			localized.setProperties({ rtl: true });
 
 			const result = localized.__render__();
 			assert.isOk(result);
@@ -141,7 +144,8 @@ registerSuite({
 		},
 
 		'The `dir` attribute is "ltr" when false'() {
-			localized = new Localized({ rtl: false });
+			localized = new Localized();
+			localized.setProperties({ rtl: false });
 
 			const result = localized.__render__();
 			assert.isOk(result);
@@ -149,7 +153,7 @@ registerSuite({
 		},
 
 		'The `dir` attribute is not set when not a boolean.'() {
-			localized = new Localized({});
+			localized = new Localized();
 
 			const result = localized.__render__();
 			assert.isOk(result);

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -59,7 +59,7 @@ registerSuite({
 			render() {
 				return null;
 			}
-		}({});
+		}();
 
 		try {
 			projector.__render__();
@@ -75,7 +75,7 @@ registerSuite({
 			render() {
 				return '';
 			}
-		}({});
+		}();
 
 		try {
 			projector.__render__();
@@ -97,7 +97,7 @@ registerSuite({
 				results.properties = undefined;
 				return results;
 			}
-		}({});
+		}();
 
 		const vnode  = <any> projector.__render__();
 		assert.isUndefined(vnode.properties);
@@ -105,7 +105,7 @@ registerSuite({
 	'attach to projector': {
 		'append'() {
 			const childNodeLength = document.body.childNodes.length;
-			const projector = new TestWidget({});
+			const projector = new TestWidget();
 
 			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
@@ -122,7 +122,7 @@ registerSuite({
 				render() {
 					return v('body', this.children);
 				}
-			}({});
+			}();
 
 			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
@@ -135,7 +135,7 @@ registerSuite({
 		},
 		'merge'() {
 			const childNodeLength = document.body.childNodes.length;
-			const projector = new TestWidget({});
+			const projector = new TestWidget();
 
 			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
@@ -150,7 +150,7 @@ registerSuite({
 	'attach event'() {
 		const root = document.createElement('div');
 		document.body.appendChild(root);
-		const projector = new TestWidget({});
+		const projector = new TestWidget();
 
 		projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
@@ -167,14 +167,14 @@ registerSuite({
 		});
 	},
 	'get root'() {
-		const projector = new TestWidget({});
+		const projector = new TestWidget();
 		const root = document.createElement('div');
 		assert.equal(projector.root, document.body);
 		projector.root = root;
 		assert.equal(projector.root, root);
 	},
 	'get projector state'() {
-		const projector = new TestWidget({});
+		const projector = new TestWidget();
 
 		assert.equal(projector.projectorState, ProjectorState.Detached);
 		return projector.append().then(() => {
@@ -185,7 +185,7 @@ registerSuite({
 
 	},
 	'destroy'() {
-		const projector: any = new TestWidget({});
+		const projector: any = new TestWidget();
 		const maquetteProjectorStopSpy = spy(projector.projector, 'stop');
 		const maquetteProjectorDetachSpy = spy(projector.projector, 'detach');
 
@@ -203,7 +203,7 @@ registerSuite({
 
 	},
 	'invalidate on setting children'() {
-		const projector = new TestWidget({});
+		const projector = new TestWidget();
 		let called = false;
 
 		projector.on('invalidated', () => {
@@ -215,7 +215,7 @@ registerSuite({
 		assert.isTrue(called);
 	},
 	'invalidate before attached'() {
-		const projector: any = new TestWidget({});
+		const projector: any = new TestWidget();
 		const maquetteProjectorSpy = spy(projector.projector, 'scheduleRender');
 		let called = false;
 
@@ -229,7 +229,7 @@ registerSuite({
 		assert.isFalse(called);
 	},
 	'invalidate after attached'() {
-		const projector: any = new TestWidget({});
+		const projector: any = new TestWidget();
 		const maquetteProjectorSpy = spy(projector.projector, 'scheduleRender');
 		let called = false;
 
@@ -245,12 +245,12 @@ registerSuite({
 	},
 	'reattach'() {
 		const root = document.createElement('div');
-		const projector = new TestWidget({});
+		const projector = new TestWidget();
 		const promise = projector.append(root);
 		assert.strictEqual(promise, projector.append(), 'same promise should be returned');
 	},
 	'setRoot throws when already attached'() {
-		const projector = new TestWidget({});
+		const projector = new TestWidget();
 		const div = document.createElement('div');
 		projector.root = div;
 		return projector.append().then((handle) => {
@@ -274,7 +274,7 @@ registerSuite({
 			}
 		}
 
-		const projector = new TestProjector({});
+		const projector = new TestProjector();
 
 		await projector.append();
 
@@ -323,7 +323,7 @@ registerSuite({
 			}
 		}
 
-		const projector = new TestProjector({});
+		const projector = new TestProjector();
 
 		await projector.append();
 
@@ -381,7 +381,7 @@ registerSuite({
 			}
 		}
 
-		const projector = new TestProjector({});
+		const projector = new TestProjector();
 
 		await projector.append();
 
@@ -431,7 +431,7 @@ registerSuite({
 					afterCreate
 				});
 			}
-		})({});
+		})();
 
 		// we check if the attached event fires because we need to know if
 		// the projector's afterCreate method is called, and that is where

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -13,17 +13,20 @@ registerSuite({
 	property: {
 		'passed registry is available via getter'() {
 			const registry = new FactoryRegistry();
-			const instance: any = new TestWithRegistry({ registry });
+			const instance: any = new TestWithRegistry();
+			instance.setProperties({ registry });
 			assert.equal(instance.registry, registry);
 		},
 		'no passed registry, nothing available via getter'() {
-			const instance: any = new TestWithRegistry(<any> {});
+			const instance: any = new TestWithRegistry();
+			instance.setProperties(<any> {});
 			assert.equal(instance.registry, undefined);
 		},
 		'passed registry updated on property change'() {
 			const registry = new FactoryRegistry();
 			const newRegistry = new FactoryRegistry();
-			const instance: any = new TestWithRegistry({ registry });
+			const instance: any = new TestWithRegistry();
+			instance.setProperties({ registry });
 			assert.equal(instance.registry, registry);
 			instance.emit({
 				type: 'properties:changed',
@@ -35,7 +38,8 @@ registerSuite({
 		},
 		'different property passed on property change should not affect registy'() {
 			const registry = new FactoryRegistry();
-			const instance: any = new TestWithRegistry({ registry });
+			const instance: any = new TestWithRegistry();
+			instance.setProperties({ registry });
 			assert.equal(instance.registry, registry);
 			instance.emit({
 				type: 'properties:changed',
@@ -69,7 +73,8 @@ registerSuite({
 			const registry = new FactoryRegistry();
 			registry.define('test', Header);
 
-			const instance: any = new IntegrationTest({ registry });
+			const instance: any = new IntegrationTest();
+			instance.setProperties({ registry });
 
 			let result = <VNode> instance.__render__();
 			assert.lengthOf(result.children, 1);

--- a/tests/unit/mixins/Stateful.ts
+++ b/tests/unit/mixins/Stateful.ts
@@ -8,11 +8,11 @@ class Test extends StatefulMixin(WidgetBase)<any> { }
 registerSuite({
 	name: 'mixins/StatefulMixin',
 	creation() {
-		const stateful = new Test({});
+		const stateful = new Test();
 		assert.deepEqual(stateful.state, {}, 'stateful should have empty state');
 	},
 	'get and set state'() {
-		const stateful = new Test({});
+		const stateful = new Test();
 		const state = {
 			foo: 'bar'
 		};
@@ -21,7 +21,7 @@ registerSuite({
 		assert.deepEqual(stateful.state, state);
 	},
 	'partially update state'() {
-		const stateful = new Test({});
+		const stateful = new Test();
 		const state = {
 			foo: 'bar'
 		};
@@ -35,7 +35,7 @@ registerSuite({
 		assert.deepEqual(stateful.state, { foo: 'bar', baz: 'qux' });
 	},
 	'emits `state:changed` event on state update'() {
-		const stateful = new Test({});
+		const stateful = new Test();
 		const state = {
 			foo: 'bar'
 		};
@@ -57,7 +57,7 @@ registerSuite({
 				super.invalidate();
 				invalidateCalled = true;
 			}
-		}({});
+		}();
 		stateful.setState({});
 		assert.isTrue(invalidateCalled);
 	}

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -54,7 +54,7 @@ registerSuite({
 			consoleStub.restore();
 		},
 		'should return baseClasses flagged classes via the classes function'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -65,7 +65,7 @@ registerSuite({
 			assert.isFalse(consoleStub.called);
 		},
 		'should return negated classes for those that are not passed'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1).get();
 			assert.deepEqual(flaggedClasses, {
@@ -76,7 +76,7 @@ registerSuite({
 			assert.isFalse(consoleStub.called);
 		},
 		'should ignore any new classes that do not exist in the baseClasses and show console error'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1 } = baseClasses;
 			const newClassName = 'newClassName';
 			const flaggedClasses = themeableInstance.classes(class1, newClassName).get();
@@ -90,8 +90,8 @@ registerSuite({
 			assert.isTrue(consoleStub.firstCall.args[0].indexOf(newClassName) > -1);
 		},
 		'should split adjoined classes into multiple classes'() {
-			themeableInstance = new Test({ theme: testTheme3 });
-
+			themeableInstance = new Test();
+			themeableInstance.setProperties({ theme: testTheme3 });
 			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -101,8 +101,8 @@ registerSuite({
 			});
 		},
 		'should remove adjoined classes when they are no longer provided'() {
-			themeableInstance = new Test({ theme: testTheme3 });
-
+			themeableInstance = new Test();
+			themeableInstance.setProperties({ theme: testTheme3 });
 			themeableInstance.emit({
 				type: 'properties:changed',
 				properties: {
@@ -121,7 +121,7 @@ registerSuite({
 			});
 		},
 		'should filter out null params passed to classes function'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2, null).get();
 			assert.deepEqual(flaggedClasses, {
@@ -134,7 +134,7 @@ registerSuite({
 	},
 	'classes.fixed chained function': {
 		'should work without any classes passed to first function'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const fixedClassName = 'fixedClassName';
 			const flaggedClasses = themeableInstance.classes().fixed(fixedClassName).get();
 			assert.deepEqual(flaggedClasses, {
@@ -144,7 +144,7 @@ registerSuite({
 			});
 		},
 		'should pass through new classes'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1 } = baseClasses;
 			const fixedClassName = 'fixedClassName';
 			const flaggedClasses = themeableInstance.classes(class1).fixed(fixedClassName).get();
@@ -155,7 +155,7 @@ registerSuite({
 			});
 		},
 		'should filter out null params passed to fixed function'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const fixedClassName = 'fixedClassName';
 			const flaggedClasses = themeableInstance.classes().fixed(fixedClassName, null).get();
 			assert.deepEqual(flaggedClasses, {
@@ -165,7 +165,7 @@ registerSuite({
 			});
 		},
 		'should negate any new classes that are not requested on second call'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1 } = baseClasses;
 			const fixedClassName = 'fixedClassName';
 			const flaggedClassesFirstCall = themeableInstance.classes(class1).fixed(fixedClassName).get();
@@ -183,7 +183,7 @@ registerSuite({
 			}, `${fixedClassName} should be false on second call`);
 		},
 		'should split adjoined fixed classes into multiple classes'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1 } = baseClasses;
 			const adjoinedClassName = 'adjoinedClassName1 adjoinedClassName2';
 			const flaggedClasses = themeableInstance.classes(class1).fixed(adjoinedClassName).get();
@@ -195,7 +195,7 @@ registerSuite({
 			});
 		},
 		'should remove adjoined fixed classes when they are no longer provided'() {
-			themeableInstance = new Test({});
+			themeableInstance = new Test();
 			const { class1 } = baseClasses;
 			const adjoinedClassName = 'adjoinedClassName1 adjoinedClassName2';
 			const flaggedClassesFirstCall = themeableInstance.classes(class1).fixed(adjoinedClassName).get();
@@ -217,7 +217,8 @@ registerSuite({
 	},
 	'setting a theme': {
 		'should override basetheme classes with theme classes'() {
-			themeableInstance = new Test({ theme: testTheme1 });
+			themeableInstance = new Test();
+			themeableInstance.setProperties({ theme: testTheme1 });
 			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -226,7 +227,8 @@ registerSuite({
 			});
 		},
 		'should negate old theme class when a new theme is set'() {
-			themeableInstance = new Test({ theme: testTheme1 });
+			themeableInstance = new Test();
+			themeableInstance.setProperties({ theme: testTheme1 });
 			themeableInstance.emit({
 				type: 'properties:changed',
 				properties: {
@@ -244,7 +246,8 @@ registerSuite({
 			});
 		},
 		'will not regenerate theme classes if theme changed property is not set'() {
-			themeableInstance = new Test({ theme: testTheme1 });
+			themeableInstance = new Test();
+			themeableInstance.setProperties({ theme: testTheme1 });
 			themeableInstance.emit({
 				type: 'properties:changed',
 				properties: {
@@ -263,7 +266,8 @@ registerSuite({
 	},
 	'setting override classes': {
 		'should supplement basetheme classes with override classes'() {
-			themeableInstance = new Test({ overrideClasses: overrideClasses1 });
+			themeableInstance = new Test();
+			themeableInstance.setProperties({ overrideClasses: overrideClasses1 });
 			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -273,7 +277,8 @@ registerSuite({
 			});
 		},
 		'should set override classes to false when they are changed'() {
-			themeableInstance = new Test({ overrideClasses: overrideClasses1 });
+			themeableInstance = new Test();
+			themeableInstance.setProperties({ overrideClasses: overrideClasses1 });
 			themeableInstance.emit({
 				type: 'properties:changed',
 				properties: {
@@ -296,10 +301,10 @@ registerSuite({
 		'should work as mixin to createWidgetBase'() {
 			const fixedClassName = 'fixedClassName';
 
+			@theme(baseClasses)
 			class IntegrationTest extends Test {
-				constructor(options: any) {
-					options.baseClasses = baseClasses;
-					super(options);
+				constructor() {
+					super();
 				}
 
 				render() {
@@ -310,7 +315,8 @@ registerSuite({
 				}
 			}
 
-			const themeableWidget: any = new IntegrationTest({ theme: testTheme1 });
+			const themeableWidget: any = new IntegrationTest();
+			themeableWidget.setProperties({ theme: testTheme1 });
 
 			const result = <VNode> themeableWidget.__render__();
 			assert.deepEqual(result.children![0].properties!.classes, {

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -101,18 +101,12 @@ registerSuite({
 			});
 		},
 		'should remove adjoined classes when they are no longer provided'() {
+			const { class1, class2 } = baseClasses;
 			themeableInstance = new Test();
 			themeableInstance.setProperties({ theme: testTheme3 });
-			themeableInstance.emit({
-				type: 'properties:changed',
-				properties: {
-					theme: testTheme1
-				},
-				changedPropertyKeys: [ 'theme' ]
-			});
-
-			const { class1, class2 } = baseClasses;
-			const flaggedClasses = themeableInstance.classes(class1, class2).get();
+			let flaggedClasses = themeableInstance.classes(class1, class2).get();
+			themeableInstance.setProperties({ theme: testTheme1 });
+			flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ testTheme1.testPath.class1 ]: true,
 				testTheme3Class1: false,
@@ -229,13 +223,8 @@ registerSuite({
 		'should negate old theme class when a new theme is set'() {
 			themeableInstance = new Test();
 			themeableInstance.setProperties({ theme: testTheme1 });
-			themeableInstance.emit({
-				type: 'properties:changed',
-				properties: {
-					theme: testTheme2
-				},
-				changedPropertyKeys: [ 'theme' ]
-			});
+			themeableInstance.classes().get();
+			themeableInstance.setProperties({ theme: testTheme2 });
 
 			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
@@ -277,17 +266,11 @@ registerSuite({
 			});
 		},
 		'should set override classes to false when they are changed'() {
+			const { class1, class2 } = baseClasses;
 			themeableInstance = new Test();
 			themeableInstance.setProperties({ overrideClasses: overrideClasses1 });
-			themeableInstance.emit({
-				type: 'properties:changed',
-				properties: {
-					overrideClasses: overrideClasses2
-				},
-				changedPropertyKeys: [ 'overrideClasses' ]
-			});
-
-			const { class1, class2 } = baseClasses;
+			themeableInstance.classes(class1, class2).get();
+			themeableInstance.setProperties({ overrideClasses: overrideClasses2 });
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ baseClasses.class1 ]: true,

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -39,7 +39,8 @@ registerSuite({
 			}
 		};
 
-		let domWrapper: any = new DomWrapper({ domNode: <any> mock });
+		let domWrapper: any = new DomWrapper();
+		domWrapper.setProperties({ domNode: <any> mock });
 
 		domWrapper.dirty = false;
 		domWrapper.cachedVNode = {
@@ -61,7 +62,8 @@ registerSuite({
 			}
 		};
 
-		let domWrapper: any = new DomWrapper({ domNode: <any> 'test' });
+		let domWrapper: any = new DomWrapper();
+		domWrapper.setProperties({ domNode: <any> 'test' });
 
 		domWrapper.dirty = false;
 		domWrapper.cachedVNode = {
@@ -72,7 +74,8 @@ registerSuite({
 	},
 
 	'Nothing bad happens if there if node is a string'() {
-		let domWrapper: any = new DomWrapper({ domNode: <any> 'test' });
+		let domWrapper: any = new DomWrapper();
+		domWrapper.setProperties({ domNode: <any> 'test' });
 
 		domWrapper.dirty = false;
 		domWrapper.cachedVNode = {
@@ -83,7 +86,8 @@ registerSuite({
 	},
 
 	'updates with no renders don\'t do anything'() {
-		let domWrapper: any = new DomWrapper({ domNode: <any> undefined });
+		let domWrapper: any = new DomWrapper();
+		domWrapper.setProperties({ domNode: <any> undefined });
 		domWrapper.dirty = false;
 		domWrapper.cachedVNode = {
 			domNode: null
@@ -101,7 +105,8 @@ registerSuite({
 			}
 		};
 
-		let domWrapper: any = new DomWrapper({ domNode: <any> undefined });
+		let domWrapper: any = new DomWrapper();
+		domWrapper.setProperties({ domNode: <any> undefined });
 		domWrapper.dirty = false;
 		domWrapper.cachedVNode = {
 			domNode: parentNode
@@ -111,7 +116,8 @@ registerSuite({
 	},
 
 	'render aspect is ok if we dont return an hnode'() {
-		let domWrapper: any = new DomWrapper({ domNode: <any> undefined });
+		let domWrapper: any = new DomWrapper();
+		domWrapper.setProperties({ domNode: <any> undefined });
 		domWrapper.dirty = false;
 		domWrapper.cachedVNode = {
 			domNode: 'test'


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

As described by the issue, with the initial setProperties occurring in WidgetBase constructor it means that the first event is missed by sub classes and inadvertently promotes a pattern of putting logic in the constructor. This can be a problem for non decorator alternatives to decorators provided functionality, such as `@theme` as there is no reasonable way to ensure that `this.baseClasses` is available in in the mixins constructor.

This will become a core principle of Dojo 2 widgets, that only variable initialisation and listening to events (`.on`) should happen in the constructor.

Resolves #356 
