### PR TITLE
Widget Base decorator support including `diffProperty` and `afterRender`

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -27,14 +27,30 @@ interface WidgetCacheWrapper {
 }
 
 /**
- * Regular expression to find specific property diff functions
+ * Diff property configuration
  */
-const propertyFunctionNameRegex = /^diffProperty(.*)/;
+interface DiffPropertyConfig {
+	propertyName: string;
+	diffFunction: Function;
+}
 
 /**
- * Regular expression to find render decorator functions
+ * Decorator that can be used to register a function to run as an aspect to `render`
  */
-const decoratorFunctionNameRegex = /^renderDecorator.*/;
+export function afterRender(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+	target.addDecorator('afterRender', target[propertyKey]);
+}
+
+/**
+ * Decorator that can be used to register a function as specific property diff
+ *
+ * @param propertyName the name of the property that the diff function is for
+ */
+export function diffProperty(propertyName: string) {
+	return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+		target.addDecorator('diffProperty', { propertyName, diffFunction: target[propertyKey] });
+	};
+}
 
 /**
  * Main widget base for all widgets to extend
@@ -97,6 +113,11 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	private bindFunctionPropertyMap: WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>;
 
 	/**
+	 * A generic bag for decorators
+	 */
+	private _decorators: Map<string, any[]>;
+
+	/**
 	 * Internal factory registry
 	 */
 	protected registry: FactoryRegistry | undefined;
@@ -116,20 +137,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this.renderDecorators = new Set<string>();
 		this.bindFunctionPropertyMap = new WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>();
 
-		const self: { [index: string]: any } = this;
-		for (let property in this) {
-			let match = property.match(propertyFunctionNameRegex);
-			if (match && (typeof self[match[0]] === 'function')) {
-				this.diffPropertyFunctionMap.set(match[0], `${match[1].slice(0, 1).toLowerCase()}${match[1].slice(1)}`);
-				continue;
-			}
-			match = property.match(decoratorFunctionNameRegex);
-			if (match && (typeof self[match[0]] === 'function')) {
-				this.renderDecorators.add(match[0]);
-				continue;
-			}
-		};
-
 		this.own(this.on('properties:changed', (evt: PropertiesChangeEvent<WidgetBase<WidgetProperties>, WidgetProperties>) => {
 			this.invalidate();
 		}));
@@ -145,22 +152,23 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 
 		this.bindFunctionProperties(properties);
 
-		this.diffPropertyFunctionMap.forEach((property: string, diffFunctionName: string) => {
-			const previousProperty = this.previousProperties[property];
-			const newProperty = (<any> properties)[property];
-			const self: { [index: string]: any } = this;
-			const result: PropertyChangeRecord = self[diffFunctionName](previousProperty, newProperty);
+		const registeredDiffPropertyConfigs: DiffPropertyConfig[] = this.getDecorator('diffProperty') || [];
+
+		registeredDiffPropertyConfigs.forEach(({ propertyName, diffFunction }) => {
+			const previousProperty = this.previousProperties[propertyName];
+			const newProperty = (<any> properties)[propertyName];
+			const result: PropertyChangeRecord = diffFunction(previousProperty, newProperty);
 
 			if (!result) {
 				return;
 			}
 
 			if (result.changed) {
-				diffPropertyChangedKeys.push(property);
+				diffPropertyChangedKeys.push(propertyName);
 			}
-			delete (<any> properties)[property];
-			delete this.previousProperties[property];
-			diffPropertyResults[property] = result.value;
+			delete (<any> properties)[propertyName];
+			delete this.previousProperties[propertyName];
+			diffPropertyResults[propertyName] = result.value;
 		});
 
 		const diffPropertiesResult = this.diffProperties(this.previousProperties, properties);
@@ -209,9 +217,9 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	public __render__(): VNode | string | null {
 		if (this.dirty || !this.cachedVNode) {
 			let dNode = this.render();
-			this.renderDecorators.forEach((decoratorFunctionName: string) => {
-				const self: { [index: string]: any } = this;
-				dNode = self[decoratorFunctionName](dNode);
+			const afterRenders = this.getDecorator('afterRender') || [];
+			afterRenders.forEach((afterRenderFunction: Function) => {
+				dNode = afterRenderFunction.call(this, dNode);
 			});
 			const widget = this.dNodeToVNode(dNode);
 			this.manageDetachedChildren();
@@ -253,6 +261,35 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 				properties[propertyKey] = boundFunc;
 			}
 		});
+	}
+
+	/**
+	 * Function to add decorators to WidgetBase
+	 *
+	 * @param decoratorKey The key of the decorator
+	 * @param value The value of the decorator
+	 */
+	protected addDecorator(decoratorKey: string, value: any): void {
+		value = Array.isArray(value) ? value : [ value ];
+		if (!this._decorators) {
+			this._decorators = new Map<string, any[]>();
+		}
+
+		const currentValue = this._decorators.get(decoratorKey) || [];
+		this._decorators.set(decoratorKey, [ ...currentValue, ...value ]);
+	}
+
+	/**
+	 * Function to retrieve decorator values
+	 *
+	 * @param decoratorKey The key of the decorator
+	 * @returns An array of decorator values or undefined
+	 */
+	protected getDecorator(decoratorKey: string): any[] | undefined {
+		if (this._decorators) {
+			return this._decorators.get(decoratorKey);
+		}
+		return undefined;
 	}
 
 	/**

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -42,9 +42,9 @@ export function afterRender(target: any, propertyKey: string, descriptor: Proper
 }
 
 /**
- * Decorator that can be used to register a function as specific property diff
+ * Decorator that can be used to register a function as a specific property diff
  *
- * @param propertyName the name of the property that the diff function is for
+ * @param propertyName The name of the property of which the diff function is applied
  */
 export function diffProperty(propertyName: string) {
 	return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
@@ -113,7 +113,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	private bindFunctionPropertyMap: WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>;
 
 	/**
-	 * A generic bag for decorators
+	 * A generic property bag for decorators
 	 */
 	private _decorators: Map<string, any[]>;
 

--- a/src/mixins/FormLabel.ts
+++ b/src/mixins/FormLabel.ts
@@ -5,7 +5,7 @@ import {
 	Constructor,
 	WidgetProperties
 } from '../interfaces';
-import { WidgetBase } from './../WidgetBase';
+import { WidgetBase, afterRender } from './../WidgetBase';
 
 /**
  * Label settings for form label text content, position (before or after), and visibility
@@ -107,11 +107,12 @@ const labelDefaults = {
 const allowedFormFieldAttributes = ['checked', 'describedBy', 'disabled', 'invalid', 'maxLength', 'minLength', 'multiple', 'name', 'placeholder', 'readOnly', 'required', 'value'];
 
 export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T {
-	return class extends base {
+	class FormLabel extends base {
 
 		properties: FormLabelMixinProperties;
 
-		renderDecoratorFormLabel(result: DNode): DNode {
+		@afterRender
+		renderDecorator(result: DNode): DNode {
 			const labelNodeAttributes: any = {};
 			if (isHNode(result)) {
 				assign(result.properties, this.getFormFieldA11yAttributes());
@@ -182,6 +183,8 @@ export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties
 			return nodeAttributes;
 		}
 	};
+
+	return FormLabel;
 }
 
 export default FormLabelMixin;

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -3,7 +3,7 @@ import { assign } from '@dojo/core/lang';
 import i18n, { Bundle, formatMessage, getCachedMessages, Messages, observeLocale } from '@dojo/i18n/i18n';
 import { VNodeProperties } from '@dojo/interfaces/vdom';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';
-import { WidgetBase } from './../WidgetBase';
+import { WidgetBase, afterRender } from './../WidgetBase';
 import { isHNode } from './../d';
 
 export interface I18nProperties extends WidgetProperties {
@@ -65,7 +65,7 @@ export interface I18nMixin {
 }
 
 export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<I18nMixin> {
-	return class extends base {
+	class I18n extends base {
 		properties: I18nProperties;
 
 		constructor(...args: any[]) {
@@ -95,7 +95,8 @@ export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(b
 			}), messages) as LocalizedMessages<T>;
 		}
 
-		renderDecoratorI18n(result: DNode): DNode {
+		@afterRender
+		renderDecorator(result: DNode): DNode {
 			if (isHNode(result)) {
 				const { locale, rtl } = this.properties;
 				const vNodeProperties: I18nVNodeProperties = {
@@ -140,6 +141,8 @@ export function I18nMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(b
 			});
 		}
 	};
+
+	return I18n;
 }
 
 export default I18nMixin;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -70,7 +70,7 @@ export interface ThemeableMixin {
  */
 export function theme (theme: {}) {
 	return function(constructor: Function) {
-		constructor.prototype.baseClasses = theme;
+		constructor.prototype.addDecorator('baseClasses', theme);
 	};
 }
 
@@ -247,6 +247,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 		 */
 		private recalculateThemeClasses() {
 			const { properties: { theme = {} } } = this;
+			this.baseClasses = (this.getDecorator('baseClasses') || [])[0];
 			const themeKey = this.baseClasses[THEME_KEY];
 			this.baseClassesReverseLookup = createBaseClassesLookup(this.baseClasses);
 			this.theme = theme[themeKey] || {};
@@ -259,8 +260,6 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 		/**
 		 * Function fired when properties are changed on the widget.
 		 *
-		 * @param theme The theme property
-		 * @param overrideClasses The overrideClasses property
 		 * @param changedPropertyKeys Array of properties that have changed
 		 */
 		private onPropertiesChanged(changedPropertyKeys: string[]) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add built in widget base support for decorators and support base functionality in non decorator environments. Add `@afterRender` and `@diffProperty` core decorator used like 

```ts
class MyWidget extends WidgetBase{
    
    @diffProperty('foo')
    diffFoo(previousProperty: any, newProperty: any) {
        // do diff here
        return {
            changed: true,
            value: 'myFoo'
        }
    }

    @afterRender
    addThingsToRenderResult(result: DNode) {
        // do things here
        return result;
    }
}
```

With the equivalent functionality in a non decorator environment using `addDecorator` in the constructor.

```ts
class MyWidget extends WidgetBase{
    
    constructor() {
        super();
        this.addDecorator('diffProperty', { propertyName: 'foo', diffFunction: this.diffFoo });
        this.addDecorator('afterRender', this.addThingsToRenderResult);
    }

    diffFoo(previousProperty: any, newProperty: any) {
        // do diff here
        return {
            changed: true,
            value: 'myFoo'
        }
    }

    addThingsToRenderResult(result: DNode) {
        // do things here
        return result;
    }
}
```

Resolves #330 & #352 
