### PR TITLE
Remove dependency on Maquette's Projector.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/i18n": "2.0.0-alpha.5",
     "@dojo/shim": "2.0.0-beta.9",
-    "maquette": ">=2.3.7 <=2.4.1"
+    "maquette": "2.4.3"
   },
   "devDependencies": {
     "@dojo/interfaces": "2.0.0-alpha.11",
@@ -66,7 +66,6 @@
     "@dojo/core": "2.0.0-alpha.22",
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/i18n": "2.0.0-alpha.5",
-    "@dojo/shim": "2.0.0-beta.9",
-    "maquette": ">=2.3.7 <=2.4.1"
+    "@dojo/shim": "2.0.0-beta.9"
   }
 }

--- a/tests/support/loadJsdom.ts
+++ b/tests/support/loadJsdom.ts
@@ -19,10 +19,14 @@ global.document = doc;
 /* Assign a global window as well */
 global.window = doc.defaultView;
 
-/* Polyfill requestAnimationFrame */
+/* Polyfill requestAnimationFrame - this can never be called an *actual* polyfill */
 global.requestAnimationFrame = (cb: (...args: any[]) => {}) => {
 	setImmediate(cb);
+	// return something at least!
+	return true;
 };
+
+global.cancelAnimationFrame = () => {};
 
 export default doc;
 

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -4,8 +4,9 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { spy } from 'sinon';
 import { v } from '../../../src/d';
-import { ProjectorMixin, ProjectorState } from '../../../src/mixins/Projector';
+import { ProjectorMixin, ProjectorAttachState } from '../../../src/mixins/Projector';
 import { WidgetBase } from '../../../src/WidgetBase';
+import global from '@dojo/core/global';
 
 class TestWidget extends ProjectorMixin(WidgetBase)<any> {}
 
@@ -51,8 +52,21 @@ async function waitFor(callback: () => boolean, message: string = 'timed out wai
 	});
 }
 
+let rafSpy: any;
+let cancelRafSpy: any;
+
 registerSuite({
 	name: 'mixins/projectorMixin',
+
+	beforeEach() {
+		rafSpy = spy(global, 'requestAnimationFrame');
+		cancelRafSpy = spy(global, 'cancelAnimationFrame');
+	},
+
+	afterEach() {
+		rafSpy.restore();
+		cancelRafSpy.restore();
+	},
 
 	'render throws an error for null result'() {
 		const projector = new class extends TestWidget {
@@ -173,32 +187,57 @@ registerSuite({
 		projector.root = root;
 		assert.equal(projector.root, root);
 	},
+	'pause'() {
+		const projector = new TestWidget();
+		let called = false;
+		projector.on('render:scheduled', () => {
+			called = true;
+		});
+		return projector.append().then(() => {
+			projector.pause();
+			projector.scheduleRender();
+			assert.isFalse(called);
+		});
+	},
+	'pause cancels animation frame if scheduled'() {
+		const projector = new TestWidget();
+
+		return projector.append().then(() => {
+			projector.scheduleRender();
+			projector.pause();
+			assert.isTrue(cancelRafSpy.called);
+		});
+	},
+	'resume'() {
+		const projector = new TestWidget();
+		spy(projector, 'scheduleRender');
+		assert.isFalse((<any> projector.scheduleRender).called);
+		projector.resume();
+		assert.isTrue((<any> projector.scheduleRender).called);
+	},
 	'get projector state'() {
 		const projector = new TestWidget();
 
-		assert.equal(projector.projectorState, ProjectorState.Detached);
+		assert.equal(projector.projectorState, ProjectorAttachState.Detached);
 		return projector.append().then(() => {
-			assert.equal(projector.projectorState, ProjectorState.Attached);
+			assert.equal(projector.projectorState, ProjectorAttachState.Attached);
 			projector.destroy();
-			assert.equal(projector.projectorState, ProjectorState.Detached);
+			assert.equal(projector.projectorState, ProjectorAttachState.Detached);
 		});
 
 	},
 	'destroy'() {
 		const projector: any = new TestWidget();
-		const maquetteProjectorStopSpy = spy(projector.projector, 'stop');
-		const maquetteProjectorDetachSpy = spy(projector.projector, 'detach');
+		const maquetteProjectorStopSpy = spy(projector, 'pause');
 
 		return projector.append().then(() => {
 			projector.destroy();
 
 			assert.isTrue(maquetteProjectorStopSpy.calledOnce);
-			assert.isTrue(maquetteProjectorDetachSpy.calledOnce);
 
 			projector.destroy();
 
 			assert.isTrue(maquetteProjectorStopSpy.calledOnce);
-			assert.isTrue(maquetteProjectorDetachSpy.calledOnce);
 		});
 
 	},
@@ -216,7 +255,6 @@ registerSuite({
 	},
 	'invalidate before attached'() {
 		const projector: any = new TestWidget();
-		const maquetteProjectorSpy = spy(projector.projector, 'scheduleRender');
 		let called = false;
 
 		projector.on('render:scheduled', () => {
@@ -225,12 +263,10 @@ registerSuite({
 
 		projector.invalidate();
 
-		assert.isFalse(maquetteProjectorSpy.called);
 		assert.isFalse(called);
 	},
 	'invalidate after attached'() {
 		const projector: any = new TestWidget();
-		const maquetteProjectorSpy = spy(projector.projector, 'scheduleRender');
 		let called = false;
 
 		projector.on('render:scheduled', () => {
@@ -239,7 +275,6 @@ registerSuite({
 
 		return projector.append().then(() => {
 			projector.invalidate();
-			assert.isTrue(maquetteProjectorSpy.called);
 			assert.isTrue(called);
 		});
 	},
@@ -257,6 +292,28 @@ registerSuite({
 			assert.throws(() => {
 				projector.root = document.body;
 			}, Error, 'already attached');
+		});
+	},
+	'can attach an event'() {
+		let domNode: any;
+		let domEvent: any;
+		const onclick = (evt: any) => {
+			domEvent = evt;
+		};
+		const afterCreate = (node: Node) => {
+			domNode = node;
+		};
+		const Projector = class extends TestWidget {
+			render() {
+				return v('div', { onclick, afterCreate });
+			}
+		};
+
+		const projector = new Projector();
+		return projector.append().then(() => {
+			const mouseEvent = new global.window.MouseEvent('click', { view: window, bubbles: true });
+			domNode.dispatchEvent(mouseEvent);
+			assert.equal(mouseEvent, domEvent);
 		});
 	},
 	async '-active gets appended to enter/exit animations by default'(this: any) {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -311,9 +311,8 @@ registerSuite({
 
 		const projector = new Projector();
 		return projector.append().then(() => {
-			const mouseEvent = new global.window.MouseEvent('click', { view: window, bubbles: true });
-			domNode.dispatchEvent(mouseEvent);
-			assert.equal(mouseEvent, domEvent);
+			domNode.click();
+			assert.instanceOf(domEvent, global.window.MouseEvent);
 		});
 	},
 	async '-active gets appended to enter/exit animations by default'(this: any) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
This removes our reliance on the Maquette projector, so we can now have more control over things such as event handling.

* Events now are listeners rather than handlers, this should mean no longer needing an `afterCreate` in widgets for things such as `transitionend`. As well as working with polyfills such as PEPjs.

* At the moment, maquette gives me no way to actually tear down event listeners on removal of a domnode - these should be garbage collected but we will have to see. 

* Event listeners are added on a per node basis, nothing clever. This may be problematic with a large number of listeners. I have code here: https://github.com/matt-gadd/widget-core/blob/projector-replace/src/mixins/Projector.ts#L150-L173. Which switches to delegating all the events to the root node of the projector, so there is only ever 1 listener per event for everything. There are issues with this approach for events that don't bubble such as `onfocus` and `onblur` though. In the future we might want to switch to a synthetic event system similar to Reacts.

* We should consider making all of our events `passive` by default, given the way things are going. Being able to configure this would be useful also.

* We no longer schedule a render when an event is triggered which is what Maquette does by default. This is simply because it doesn't make sense to do this with our invalidation system.

* In the future we might want to consider inverting this, making the eventHandlerInterceptor a no-op and passing an addEventHandler function in the `projectorOptions`, which nodes receive in the `afterCreate` and `afterUpdate`. This would be nicer as the registration would happen from the widget itself.
