### PR TITLE
Lazily register widget classes

### DIFF
--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -30,8 +30,8 @@ export type ClassNameFlagsMap = {
  * Properties required for the themeable mixin
  */
 export interface ThemeableProperties extends WidgetProperties {
-	theme?: { [index: string]: ClassNames };
-	overrideClasses?: ClassNames;
+	theme?: any;
+	overrideClasses?: any;
 }
 
 /**

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -243,7 +243,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 		}
 
 		/**
-		 * Recaculate registered classes for current theme.
+		 * Recalculate registered classes for current theme.
 		 */
 		private recalculateThemeClasses() {
 			const { properties: { theme = {} } } = this;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -1,3 +1,4 @@
+import Map from '@dojo/shim/Map';
 import { includes } from '@dojo/shim/array';
 import { assign } from '@dojo/core/lang';
 import { Constructor, PropertiesChangeEvent, WidgetProperties } from './../interfaces';

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -19,14 +19,6 @@ export type ClassNames = {
 }
 
 /**
- * The object returned by getClasses required by maquette for
- * adding / removing classes. They are flagged to true / false.
- */
-export type ClassNameFlagsMap = {
-	[key: string]: ClassNameFlags;
-}
-
-/**
  * Properties required for the themeable mixin
  */
 export interface ThemeableProperties extends WidgetProperties {

--- a/tests/support/styles/overrideClasses1.css.ts
+++ b/tests/support/styles/overrideClasses1.css.ts
@@ -1,0 +1,1 @@
+export const class1 = 'override1Class1';

--- a/tests/support/styles/overrideClasses2.css.ts
+++ b/tests/support/styles/overrideClasses2.css.ts
@@ -1,0 +1,1 @@
+export const class1 = 'override2Class1';

--- a/tests/support/styles/testWidget.css.ts
+++ b/tests/support/styles/testWidget.css.ts
@@ -1,0 +1,2 @@
+export const class1 = 'baseClass1';
+export const class2 = 'baseClass2';

--- a/tests/support/styles/testWidgetTheme1.css.ts
+++ b/tests/support/styles/testWidgetTheme1.css.ts
@@ -1,0 +1,1 @@
+export const class1 = 'theme1Class1';

--- a/tests/support/styles/testWidgetTheme2.css.ts
+++ b/tests/support/styles/testWidgetTheme2.css.ts
@@ -1,0 +1,1 @@
+export const class1 = 'theme2Class1';

--- a/tests/support/styles/testWidgetTheme3.css.ts
+++ b/tests/support/styles/testWidgetTheme3.css.ts
@@ -1,0 +1,1 @@
+export const class1 = 'testTheme3Class1 testTheme3AdjoinedClass1';

--- a/tests/support/styles/theme1.css.ts
+++ b/tests/support/styles/theme1.css.ts
@@ -1,0 +1,7 @@
+import * as testWidgetTheme from './testWidgetTheme1.css';
+
+const theme1 = {
+	'testPath': testWidgetTheme
+};
+
+export default theme1;

--- a/tests/support/styles/theme2.css.ts
+++ b/tests/support/styles/theme2.css.ts
@@ -1,0 +1,7 @@
+import * as testWidgetTheme from './testWidgetTheme2.css';
+
+const theme2 = {
+	'testPath': testWidgetTheme
+};
+
+export default theme2;

--- a/tests/support/styles/theme3.css.ts
+++ b/tests/support/styles/theme3.css.ts
@@ -1,0 +1,7 @@
+import * as testWidgetTheme from './testWidgetTheme3.css';
+
+const theme3 = {
+	'testPath': testWidgetTheme
+};
+
+export default theme3;

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -6,37 +6,14 @@ import { WidgetBase } from '../../../src/WidgetBase';
 import { v } from '../../../src/d';
 import { stub, SinonStub } from 'sinon';
 
-const baseClasses = {
-	[' _key']: 'testPath',
-	class1: 'baseClass1',
-	class2: 'baseClass2'
-};
+import * as baseClasses from './../../support/styles/testWidget.css';
+import * as overrideClasses1 from './../../support/styles/overrideClasses1.css';
+import * as overrideClasses2 from './../../support/styles/overrideClasses2.css';
+import testTheme1 from './../../support/styles/theme1.css';
+import testTheme2 from './../../support/styles/theme2.css';
+import testTheme3 from './../../support/styles/theme3.css';
 
-const testTheme1 = {
-	testPath: {
-		class1: 'theme1Class1'
-	}
-};
-
-const testTheme2 = {
-	testPath: {
-		class1: 'theme2Class1'
-	}
-};
-
-const testTheme3 = {
-	testPath: {
-		class1: 'testTheme3Class1 testTheme3AdjoinedClass1'
-	}
-};
-
-const overrideClasses1 = {
-	class1: 'override1Class1'
-};
-
-const overrideClasses2 = {
-	class1: 'override2Class1'
-};
+(<any> baseClasses)[' _key'] = 'testPath';
 
 @theme(baseClasses)
 class Test extends ThemeableMixin(WidgetBase)<ThemeableProperties> { }

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -69,8 +69,7 @@ registerSuite({
 			const { class1 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false
+				[ baseClasses.class1 ]: true
 			});
 
 			assert.isFalse(consoleStub.called);
@@ -82,12 +81,11 @@ registerSuite({
 			const flaggedClasses = themeableInstance.classes(class1, newClassName).get();
 
 			assert.deepEqual(flaggedClasses, {
-				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false
+				[ baseClasses.class1 ]: true
 			});
 
 			assert.isTrue(consoleStub.calledOnce);
-			assert.isTrue(consoleStub.firstCall.args[0].indexOf(newClassName) > -1);
+			assert.strictEqual(consoleStub.firstCall.args[0], `Class name: ${newClassName} is not from baseClasses, use chained 'fixed' method instead`);
 		},
 		'should split adjoined classes into multiple classes'() {
 			themeableInstance = new Test();
@@ -132,8 +130,6 @@ registerSuite({
 			const fixedClassName = 'fixedClassName';
 			const flaggedClasses = themeableInstance.classes().fixed(fixedClassName).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClasses.class1 ]: false,
-				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 		},
@@ -144,7 +140,6 @@ registerSuite({
 			const flaggedClasses = themeableInstance.classes(class1).fixed(fixedClassName).get();
 			assert.deepEqual(flaggedClasses, {
 				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 		},
@@ -153,8 +148,6 @@ registerSuite({
 			const fixedClassName = 'fixedClassName';
 			const flaggedClasses = themeableInstance.classes().fixed(fixedClassName, null).get();
 			assert.deepEqual(flaggedClasses, {
-				[ baseClasses.class1 ]: false,
-				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 		},
@@ -165,14 +158,12 @@ registerSuite({
 			const flaggedClassesFirstCall = themeableInstance.classes(class1).fixed(fixedClassName).get();
 			assert.deepEqual(flaggedClassesFirstCall, {
 				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			}, `${fixedClassName} should be true on first call`);
 
 			const flaggedClassesSecondCall = themeableInstance.classes(class1).get();
 			assert.deepEqual(flaggedClassesSecondCall, {
 				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: false
 			}, `${fixedClassName} should be false on second call`);
 		},
@@ -183,27 +174,26 @@ registerSuite({
 			const flaggedClasses = themeableInstance.classes(class1).fixed(adjoinedClassName).get();
 			assert.deepEqual(flaggedClasses, {
 				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false,
 				'adjoinedClassName1': true,
 				'adjoinedClassName2': true
 			});
 		},
 		'should remove adjoined fixed classes when they are no longer provided'() {
 			themeableInstance = new Test();
-			const { class1 } = baseClasses;
+			const { class1, class2 } = baseClasses;
 			const adjoinedClassName = 'adjoinedClassName1 adjoinedClassName2';
-			const flaggedClassesFirstCall = themeableInstance.classes(class1).fixed(adjoinedClassName).get();
+			const flaggedClassesFirstCall = themeableInstance.classes(class1, class2).fixed(adjoinedClassName).get();
 			assert.deepEqual(flaggedClassesFirstCall, {
 				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false,
+				[ baseClasses.class2 ]: true,
 				'adjoinedClassName1': true,
 				'adjoinedClassName2': true
 			}, 'adjoined classed should both be true on first call');
 
-			const flaggedClassesSecondCall = themeableInstance.classes(class1).get();
+			const flaggedClassesSecondCall = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClassesSecondCall, {
 				[ baseClasses.class1 ]: true,
-				[ baseClasses.class2 ]: false,
+				[ baseClasses.class2 ]: true,
 				'adjoinedClassName1': false,
 				'adjoinedClassName2': false
 			}, `adjoiend class names should be false on second call`);
@@ -221,12 +211,12 @@ registerSuite({
 			});
 		},
 		'should negate old theme class when a new theme is set'() {
+			const { class1, class2 } = baseClasses;
 			themeableInstance = new Test();
 			themeableInstance.setProperties({ theme: testTheme1 });
-			themeableInstance.classes().get();
+			themeableInstance.classes(class1).get();
 			themeableInstance.setProperties({ theme: testTheme2 });
 
-			const { class1, class2 } = baseClasses;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ testTheme1.testPath.class1 ]: false,
@@ -304,7 +294,6 @@ registerSuite({
 			const result = <VNode> themeableWidget.__render__();
 			assert.deepEqual(result.children![0].properties!.classes, {
 				[ testTheme1.testPath.class1 ]: true,
-				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 
@@ -314,7 +303,6 @@ registerSuite({
 			assert.deepEqual(result2.children![0].properties!.classes, {
 				[ testTheme1.testPath.class1 ]: false,
 				[ testTheme2.testPath.class1 ]: true,
-				[ baseClasses.class2 ]: false,
 				[ fixedClassName ]: true
 			});
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Convert themeable to lazily register classes as they are used instead of registering all the possible classes upfront and every time theme/overrideClasses changes.

Resolves #360
