### PR TITLE
Decorator that adds listeners for `properties:changed` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,14 +249,36 @@ If a property has a custom diff function then that property is excluded from tho
 ##### The 'properties:changed' event
 
 When `diffProperties` has completed, the results are used to update the properties on the widget instance.
-If any properties were changed, then the `properties:changed` event is emitted.
+If any properties were changed, then the `properties:changed` event is emitted. 
 
-*Attaching*
+Attaching a listener to the event is exposed via a decorator `@onPropertiesChanged`.
+
+*using the `onPropertiesChanged ` decorator*
 
 ```ts
-this.on('properties:changed', (evt: PropertiesChangedEvent<MyWidget, MyProperties>) {
-	// do something
-});
+class MyWidget extends WidgetBase<WidgetProperties> {
+
+	@onPropertiesChanged
+	myPropChangedListener(evt: PropertiesChangeEvent<this, WidgetProperties>) {
+		// do something
+	}
+}
+```
+
+*registering the `onPropertiesChanged ` function in the constructor*
+
+```ts
+class MyWidget extends WidgetBase<WidgetProperties> {
+
+	constructor() {
+		super();
+		this.addDecorator('onPropertiesChanged', this.myPropChangedListener)
+	}
+
+	myPropChangedListener(evt: PropertiesChangeEvent<this, WidgetProperties>) {
+		// do something
+	}
+}
 ```
 
 *Example event payload*

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -53,6 +53,13 @@ export function diffProperty(propertyName: string) {
 }
 
 /**
+ * Decorator used to register listeners to the `properties:changed` event.
+ */
+export function onPropertiesChanged(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+	target.addDecorator('onPropertiesChanged', target[propertyKey]);
+}
+
+/**
  * Main widget base for all widgets to extend
  */
 export class WidgetBase<P extends WidgetProperties> extends Evented implements WidgetBaseInterface<P> {
@@ -139,6 +146,11 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 
 		this.own(this.on('properties:changed', (evt: PropertiesChangeEvent<WidgetBase<WidgetProperties>, WidgetProperties>) => {
 			this.invalidate();
+
+			const propertiesChangedListeners = this.getDecorator('onPropertiesChanged') || [];
+			propertiesChangedListeners.forEach((propertiesChangedFunction, index) => {
+				propertiesChangedFunction.call(this, evt);
+			});
 		}));
 	}
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -148,7 +148,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			this.invalidate();
 
 			const propertiesChangedListeners = this.getDecorator('onPropertiesChanged') || [];
-			propertiesChangedListeners.forEach((propertiesChangedFunction, index) => {
+			propertiesChangedListeners.forEach((propertiesChangedFunction) => {
 				propertiesChangedFunction.call(this, evt);
 			});
 		}));

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -1,6 +1,6 @@
 import { includes } from '@dojo/shim/array';
 import FactoryRegistry from '../FactoryRegistry';
-import { WidgetBase } from './../WidgetBase';
+import { WidgetBase, onPropertiesChanged } from './../WidgetBase';
 import {
 	PropertyChangeRecord,
 	PropertiesChangeEvent,
@@ -12,30 +12,23 @@ export interface RegistryMixinProperties extends WidgetProperties {
 	registry: FactoryRegistry;
 }
 
-export function RegistryMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T {
-	return class extends base {
-		properties: RegistryMixinProperties;
-
-		constructor(...args: any[]) {
-			super(...args);
-			this.own(this.on('properties:changed', (evt: PropertiesChangeEvent<this, RegistryMixinProperties>) => {
-				if (includes(evt.changedPropertyKeys, 'registry')) {
-					this.registry = evt.properties.registry;
-				}
-			}));
-			const { properties: { registry } } = this;
-			if (registry) {
-				this.registry = registry;
-			}
-		}
-
+export function RegistryMixin<T extends Constructor<WidgetBase<RegistryMixinProperties>>>(base: T): T {
+	class Registry extends base {
 		public diffPropertyRegistry(previousValue: FactoryRegistry, value: FactoryRegistry): PropertyChangeRecord {
 			return {
 				changed: previousValue !== value,
 				value: value
 			};
 		}
+
+		@onPropertiesChanged
+		protected onPropertiesChanged(evt: PropertiesChangeEvent<this, RegistryMixinProperties>) {
+			if (includes(evt.changedPropertyKeys, 'registry')) {
+				this.registry = evt.properties.registry;
+			}
+		}
 	};
+	return Registry;
 }
 
 export default RegistryMixin;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -1,8 +1,8 @@
 import Map from '@dojo/shim/Map';
 import { includes } from '@dojo/shim/array';
 import { assign } from '@dojo/core/lang';
-import { Constructor, PropertiesChangeEvent, WidgetProperties } from './../interfaces';
-import { WidgetBase } from './../WidgetBase';
+import { Constructor, WidgetProperties, PropertiesChangeEvent } from './../interfaces';
+import { WidgetBase, onPropertiesChanged } from './../WidgetBase';
 
 /**
  * A representation of the css class names to be applied and
@@ -124,7 +124,7 @@ function createBaseClassesLookup(classes: BaseClasses): ClassNames {
  * Function that returns a class decorated with with Themeable functionality
  */
 export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeableProperties>>>(base: T): T & Constructor<ThemeableMixin> {
-	return class extends base {
+	class Themeable extends base {
 
 		/**
 		 * The Themeable baseClasses
@@ -155,16 +155,6 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 		 * Loaded theme
 		 */
 		private theme: ClassNames = {};
-
-		/**
-		 * @constructor
-		 */
-		constructor(...args: any[]) {
-			super(...args);
-			this.own(this.on('properties:changed', (evt: PropertiesChangeEvent<this, ThemeableProperties>) => {
-				this.onPropertiesChanged(evt.changedPropertyKeys);
-			}));
-		}
 
 		/**
 		 * Function used to add themeable classes to a widget. Returns a chained function 'fixed'
@@ -262,7 +252,8 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 		 *
 		 * @param changedPropertyKeys Array of properties that have changed
 		 */
-		private onPropertiesChanged(changedPropertyKeys: string[]) {
+		@onPropertiesChanged
+		protected onPropertiesChanged({ changedPropertyKeys }: PropertiesChangeEvent<this, ThemeableProperties>) {
 			const themeChanged = includes(changedPropertyKeys, 'theme');
 			const overrideClassesChanged = includes(changedPropertyKeys, 'overrideClasses');
 
@@ -271,6 +262,8 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 			}
 		}
 	};
+
+	return Themeable;
 }
 
 export default ThemeableMixin;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for a decorator to mark functions as listeners of the `properties:changed` event. Functions with `@onPropertiesChanged` the decorator will be called when the widgets `properties:changed` event is fired.

**Note:** In future we may expose a more generic decorator that could be used for all events, something like `@on('properties:changed')` from the core `Evented` class.

```ts
class MyWidget extends WidgetBase{

    @onPropertiesChanged
    myPropertiesChangedListener(evt: PropertiesChangeEvent<this, MyWidgetProperties>) {
        // do things here on property change
    }
}
```

Resolves #365 
