### PR TITLE
Move to VirtualDomProperties

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -100,12 +100,17 @@ export function v(tag: string, propertiesOrChildren: VirtualDomProperties = {}, 
 			children,
 			properties,
 			render<T>(this: { vNodes: VNode[], properties: VirtualDomProperties }, options: { bind?: T } = { }) {
-				let { classes } = this.properties;
-				if (typeof classes === 'function') {
-					classes = classes();
+				let properties = this.properties;
+
+				if (this.properties) {
+					let { classes } = this.properties;
+					if (typeof classes === 'function') {
+						classes = classes();
+						properties = assign(this.properties, { classes });
+					}
 				}
 
-				return h(tag, assign(options, this.properties, classes ? { classes } : {}), this.vNodes);
+				return h(tag, assign(options, properties), this.vNodes);
 			},
 			type: HNODE
 		};

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,11 +1,12 @@
 import { assign } from '@dojo/core/lang';
-import { VNode, VNodeProperties } from '@dojo/interfaces/vdom';
+import { VNode } from '@dojo/interfaces/vdom';
 import Symbol from '@dojo/shim/Symbol';
 import { h } from 'maquette';
 import {
 	DNode,
 	HNode,
 	WNode,
+	VirtualDomProperties,
 	WidgetProperties,
 	WidgetBaseConstructor
 } from './interfaces';
@@ -84,10 +85,10 @@ export function w<P extends WidgetProperties>(factory: WidgetBaseConstructor<P> 
 /**
  * Wrapper function for calls to create hyperscript, lazily executes the hyperscript creation
  */
-export function v(tag: string, properties: VNodeProperties, children?: DNode[]): HNode;
+export function v(tag: string, properties: VirtualDomProperties, children?: DNode[]): HNode;
 export function v(tag: string, children: DNode[]): HNode;
 export function v(tag: string): HNode;
-export function v(tag: string, propertiesOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
+export function v(tag: string, propertiesOrChildren: VirtualDomProperties = {}, children: DNode[] = []): HNode {
 		let properties = propertiesOrChildren;
 
 		if (Array.isArray(propertiesOrChildren)) {
@@ -98,8 +99,13 @@ export function v(tag: string, propertiesOrChildren: VNodeProperties = {}, child
 		return {
 			children,
 			properties,
-			render<T>(this: { vNodes: VNode[], properties: VNodeProperties }, options: { bind?: T } = { }) {
-				return h(tag, assign(options, this.properties), this.vNodes);
+			render<T>(this: { vNodes: VNode[], properties: VirtualDomProperties }, options: { bind?: T } = { }) {
+				let { classes } = this.properties;
+				if (typeof classes === 'function') {
+					classes = classes();
+				}
+
+				return h(tag, assign(options, this.properties, classes ? { classes } : {}), this.vNodes);
 			},
 			type: HNODE
 		};

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -56,7 +56,7 @@ export type MouseWheelEventHandler = (event?: MouseWheelEvent | WheelEvent) => E
 export type ScrollEventHandler = (event?: UIEvent) => EventHandlerResult;
 export type SubmitEventHandler = EventHandler;
 
-type ClassesFunction = () => {
+export type ClassesFunction = () => {
 	[index: string]: boolean | null | undefined;
 }
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -74,7 +74,7 @@ export interface VirtualDomProperties {
 	 * The animation to perform when this node is removed while its parent remains.
 	 * When this value is a string, you must pass a `projectionOptions.transitions` object when creating the projector using [[createProjector]].
 	 * {@link http://maquettejs.org/docs/animations.html|More about animations}.
-	 * @param element - Element that ought to be removed from to the DOM.
+	 * @param element - Element that ought to be removed from the DOM.
 	 * @param removeElement - Function that removes the element from the DOM.
 	 * This argument is provided purely for convenience.
 	 * You may use this function to remove the element when the animation is done.
@@ -91,10 +91,10 @@ export interface VirtualDomProperties {
 	 */
 	updateAnimation?: (element: Element, properties?: VNodeProperties, previousProperties?: VNodeProperties) => void;
 	/**
-	 * Callback that is executed after this node is added to the DOM. Childnodes and properties have
+	 * Callback that is executed after this node is added to the DOM. Child nodes and properties have
 	 * already been applied.
 	 * @param element - The element that was added to the DOM.
-	 * @param projectionOptions - The projection options that were used see [[createProjector]].
+	 * @param projectionOptions - The projection options that were used, see [[createProjector]].
 	 * @param vnodeSelector - The selector passed to the [[h]] function.
 	 * @param properties - The properties passed to the [[h]] function.
 	 * @param children - The children that were created.
@@ -102,10 +102,10 @@ export interface VirtualDomProperties {
 	afterCreate?(element: Element, projectionOptions: ProjectionOptions, vnodeSelector: string, properties: VNodeProperties,
 	children: VNode[]): void;
 	/**
-	 * Callback that is executed every time this node may have been updated. Childnodes and properties
+	 * Callback that is executed every time this node may have been updated. Child nodes and properties
 	 * have already been updated.
 	 * @param element - The element that may have been updated in the DOM.
-	 * @param projectionOptions - The projection options that were used see [[createProjector]].
+	 * @param projectionOptions - The projection options that were used, see [[createProjector]].
 	 * @param vnodeSelector - The selector passed to the [[h]] function.
 	 * @param properties - The properties passed to the [[h]] function.
 	 * @param children - The children for this node.
@@ -188,7 +188,7 @@ export interface VirtualDomProperties {
 	readonly alt?: string;
 	readonly srcset?: string;
 	/**
-	 * Puts a non-interactive piece of html inside the DOM node.
+	 * Puts a non-interactive string of html inside the DOM node.
 	 *
 	 * Note: if you use innerHTML, maquette cannot protect you from XSS vulnerabilities and you must make sure that the innerHTML value is safe.
 	 */

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -127,9 +127,8 @@ export interface VirtualDomProperties {
 	readonly key?: Object;
 	/**
 	 * An object literal like `{important:true}` which allows css classes, like `important` to be added and removed
-	 * dynamically.
+	 * dynamically. Can also take a function, that must return an object literal.
 	 */
-	/*readonly classes?: { [index: string]: boolean | null | undefined };*/
 	readonly classes?: {
 		[index: string]: boolean | null | undefined;
 	} | ClassesFunction;

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,4 +1,4 @@
-import { VNode, VNodeProperties } from '@dojo/interfaces/vdom';
+import { VNode, VNodeProperties, ProjectionOptions } from '@dojo/interfaces/vdom';
 import { EventTypedObject } from '@dojo/interfaces/core';
 import { Evented } from './bases/Evented';
 
@@ -56,6 +56,151 @@ export type MouseWheelEventHandler = (event?: MouseWheelEvent | WheelEvent) => E
 export type ScrollEventHandler = (event?: UIEvent) => EventHandlerResult;
 export type SubmitEventHandler = EventHandler;
 
+type ClassesFunction = () => {
+	[index: string]: boolean | null | undefined;
+}
+
+export interface VirtualDomProperties {
+	/**
+	 * The animation to perform when this node is added to an already existing parent.
+	 * When this value is a string, you must pass a `projectionOptions.transitions` object when creating the
+	 * projector using [[createProjector]].
+	 * {@link http://maquettejs.org/docs/animations.html|More about animations}.
+	 * @param element - Element that was just added to the DOM.
+	 * @param properties - The properties object that was supplied to the [[h]] method
+	 */
+	enterAnimation?: ((element: Element, properties?: VNodeProperties) => void) | string;
+	/**
+	 * The animation to perform when this node is removed while its parent remains.
+	 * When this value is a string, you must pass a `projectionOptions.transitions` object when creating the projector using [[createProjector]].
+	 * {@link http://maquettejs.org/docs/animations.html|More about animations}.
+	 * @param element - Element that ought to be removed from to the DOM.
+	 * @param removeElement - Function that removes the element from the DOM.
+	 * This argument is provided purely for convenience.
+	 * You may use this function to remove the element when the animation is done.
+	 * @param properties - The properties object that was supplied to the [[h]] method that rendered this [[VNode]] the previous time.
+	 */
+	exitAnimation?: ((element: Element, removeElement: () => void, properties?: VNodeProperties) => void) | string;
+	/**
+	 * The animation to perform when the properties of this node change.
+	 * This also includes attributes, styles, css classes. This callback is also invoked when node contains only text and that text changes.
+	 * {@link http://maquettejs.org/docs/animations.html|More about animations}.
+	 * @param element - Element that was modified in the DOM.
+	 * @param properties - The last properties object that was supplied to the [[h]] method
+	 * @param previousProperties - The previous properties object that was supplied to the [[h]] method
+	 */
+	updateAnimation?: (element: Element, properties?: VNodeProperties, previousProperties?: VNodeProperties) => void;
+	/**
+	 * Callback that is executed after this node is added to the DOM. Childnodes and properties have
+	 * already been applied.
+	 * @param element - The element that was added to the DOM.
+	 * @param projectionOptions - The projection options that were used see [[createProjector]].
+	 * @param vnodeSelector - The selector passed to the [[h]] function.
+	 * @param properties - The properties passed to the [[h]] function.
+	 * @param children - The children that were created.
+	 */
+	afterCreate?(element: Element, projectionOptions: ProjectionOptions, vnodeSelector: string, properties: VNodeProperties,
+	children: VNode[]): void;
+	/**
+	 * Callback that is executed every time this node may have been updated. Childnodes and properties
+	 * have already been updated.
+	 * @param element - The element that may have been updated in the DOM.
+	 * @param projectionOptions - The projection options that were used see [[createProjector]].
+	 * @param vnodeSelector - The selector passed to the [[h]] function.
+	 * @param properties - The properties passed to the [[h]] function.
+	 * @param children - The children for this node.
+	 */
+	afterUpdate?(element: Element, projectionOptions: ProjectionOptions, vnodeSelector: string, properties: VNodeProperties,
+	children: VNode[]): void;
+	/**
+	 * When specified, the event handlers will be invoked with 'this' pointing to the value.
+	 * This is useful when using the prototype/class based implementation of Components.
+	 *
+	 * When no [[key]] is present, this object is also used to uniquely identify a DOM node.
+	 */
+	readonly bind?: Object;
+	/**
+	 * Used to uniquely identify a DOM node among siblings.
+	 * A key is required when there are more children with the same selector and these children are added or removed dynamically.
+	 * NOTE: this does not have to be a string or number, a [[Component]] Object for instance is also possible.
+	 */
+	readonly key?: Object;
+	/**
+	 * An object literal like `{important:true}` which allows css classes, like `important` to be added and removed
+	 * dynamically.
+	 */
+	/*readonly classes?: { [index: string]: boolean | null | undefined };*/
+	readonly classes?: {
+		[index: string]: boolean | null | undefined;
+	} | ClassesFunction;
+	/**
+	 * An object literal like `{height:'100px'}` which allows styles to be changed dynamically. All values must be strings.
+	 */
+	readonly styles?: { [index: string]: string | null | undefined };
+
+	// From Element
+	ontouchcancel?(ev?: TouchEvent): boolean | void;
+	ontouchend?(ev?: TouchEvent): boolean | void;
+	ontouchmove?(ev?: TouchEvent): boolean | void;
+	ontouchstart?(ev?: TouchEvent): boolean | void;
+	// From HTMLFormElement
+	readonly action?: string;
+	readonly encoding?: string;
+	readonly enctype?: string;
+	readonly method?: string;
+	readonly name?: string;
+	readonly target?: string;
+	// From HTMLElement
+	onblur?(ev?: FocusEvent): boolean | void;
+	onchange?(ev?: Event): boolean | void;
+	onclick?(ev?: MouseEvent): boolean | void;
+	ondblclick?(ev?: MouseEvent): boolean | void;
+	onfocus?(ev?: FocusEvent): boolean | void;
+	oninput?(ev?: Event): boolean | void;
+	onkeydown?(ev?: KeyboardEvent): boolean | void;
+	onkeypress?(ev?: KeyboardEvent): boolean | void;
+	onkeyup?(ev?: KeyboardEvent): boolean | void;
+	onload?(ev?: Event): boolean | void;
+	onmousedown?(ev?: MouseEvent): boolean | void;
+	onmouseenter?(ev?: MouseEvent): boolean | void;
+	onmouseleave?(ev?: MouseEvent): boolean | void;
+	onmousemove?(ev?: MouseEvent): boolean | void;
+	onmouseout?(ev?: MouseEvent): boolean | void;
+	onmouseover?(ev?: MouseEvent): boolean | void;
+	onmouseup?(ev?: MouseEvent): boolean | void;
+	onmousewheel?(ev?: WheelEvent | MouseWheelEvent): boolean | void;
+	onscroll?(ev?: UIEvent): boolean | void;
+	onsubmit?(ev?: Event): boolean | void;
+	readonly spellcheck?: boolean;
+	readonly tabIndex?: number;
+	readonly disabled?: boolean;
+	readonly title?: string;
+	readonly accessKey?: string;
+	readonly id?: string;
+	// From HTMLInputElement
+	readonly type?: string;
+	readonly autocomplete?: string;
+	readonly checked?: boolean;
+	readonly placeholder?: string;
+	readonly readOnly?: boolean;
+	readonly src?: string;
+	readonly value?: string;
+	// From HTMLImageElement
+	readonly alt?: string;
+	readonly srcset?: string;
+	/**
+	 * Puts a non-interactive piece of html inside the DOM node.
+	 *
+	 * Note: if you use innerHTML, maquette cannot protect you from XSS vulnerabilities and you must make sure that the innerHTML value is safe.
+	 */
+	readonly innerHTML?: string;
+
+	/**
+	 * Everything that is not explicitly listed (properties and attributes that are either uncommon or custom).
+	 */
+	readonly [index: string]: any;
+}
+
 /**
  * Base widget properties
  */
@@ -94,7 +239,7 @@ export interface HNode {
 	/**
 	 * The properties used to create the VNode
 	 */
-	properties: VNodeProperties;
+	properties: VirtualDomProperties;
 
 	/**
 	 * The type of node

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -31,6 +31,7 @@ export interface ThemeableProperties extends WidgetProperties {
  * Returned by classes function.
  */
 export interface ClassesFunctionChain {
+	(): ClassNameFlags;
 	/**
 	 * The classes to be returned when get() is called
 	 */
@@ -197,7 +198,10 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 				}, {});
 
 			const themeable = this;
-			const classesResponseChain: ClassesFunctionChain = {
+			function classesGetter(this: ClassesFunctionChain) {
+				return this.classes;
+			}
+			const classesFunctionChain = {
 				classes: assign({}, this.allClasses, appliedClasses),
 				fixed(this: ClassesFunctionChain, ...classNames: (string | null)[]) {
 					const filteredClassNames = <string[]> classNames.filter((className) => className !== null);
@@ -206,12 +210,10 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 					themeable.appendToAllClassNames(splitClasses);
 					return this;
 				},
-				get(this: ClassesFunctionChain) {
-					return this.classes;
-				}
+				get: classesGetter
 			};
 
-			return classesResponseChain;
+			return assign(classesGetter.bind(classesFunctionChain), classesFunctionChain);
 		}
 
 		/**

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -106,6 +106,19 @@ registerSuite({
 			assert.equal(hNode.type, HNODE);
 			assert.isTrue(isHNode(hNode));
 			assert.isFalse(isWNode(hNode));
+		},
+		'given a classes function in properties is called to get a classes object'() {
+			const classes = () => {
+				return { foo: true };
+			};
+			const hNode = v('div', { classes });
+			assert.isFunction(hNode.properties.classes);
+			const result = hNode.render();
+			assert.deepEqual(result.properties, {
+				classes: {
+					foo: true
+				}
+			});
 		}
 	},
 	decorator: {

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -99,6 +99,17 @@ registerSuite({
 			});
 
 			assert.isFalse(consoleStub.called);
+		},
+		'can invoke result instead of using .get()'() {
+			themeableInstance = new Test();
+			const { class1, class2 } = baseClasses;
+			const flaggedClasses = themeableInstance.classes(class1, class2)();
+			assert.deepEqual(flaggedClasses, {
+				[ baseClasses.class1 ]: true,
+				[ baseClasses.class2 ]: true
+			});
+
+			assert.isFalse(consoleStub.called);
 		}
 	},
 	'classes.fixed chained function': {
@@ -174,6 +185,14 @@ registerSuite({
 				'adjoinedClassName1': false,
 				'adjoinedClassName2': false
 			}, `adjoiend class names should be false on second call`);
+		},
+		'can invoke result instead of using .get()'() {
+			themeableInstance = new Test();
+			const fixedClassName = 'fixedClassName';
+			const flaggedClasses = themeableInstance.classes().fixed(fixedClassName)();
+			assert.deepEqual(flaggedClasses, {
+				[ fixedClassName ]: true
+			});
 		}
 	},
 	'setting a theme': {
@@ -260,7 +279,7 @@ registerSuite({
 				render() {
 					const { class1 } = baseClasses;
 					return v('div', [
-						v('div', { classes: this.classes(class1).fixed(fixedClassName).get() })
+						v('div', { classes: this.classes(class1).fixed(fixedClassName)() })
 					]);
 				}
 			}

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -279,7 +279,7 @@ registerSuite({
 				render() {
 					const { class1 } = baseClasses;
 					return v('div', [
-						v('div', { classes: this.classes(class1).fixed(fixedClassName)() })
+						v('div', { classes: this.classes(class1).fixed(fixedClassName) })
 					]);
 				}
 			}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
* Adds `VirtualDomProperties`, but doesn’t touch any of the existing `VNode` or `VNodeProperties` in `@dojo/interfaces`. We should raise an issue for removing these later.
* Switches the user facing properties for `v` to be `VirtualDomProperties`

As part of this I decided to implement #367 to prove that the forked interfaces work, which basically means:
* Changes the interface for `classes` in `VirtualDomProperties`
* Implements calling `classes` if its a function on the `VirtualDomProperties` object in `v`
* Make the result from the `this.classes` chain a function in themeable

Resolves #362 #367 
