### PR TITLE
`WidgetBase` and `Themeable` Array Optimisations

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -212,13 +212,14 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	}
 
 	public diffProperties(previousProperties: P & { [index: string]: any }, newProperties: P & { [index: string]: any }): PropertiesChangeRecord<P> {
-		const changedKeys = Object.keys(newProperties).reduce((changedPropertyKeys: string[], propertyKey: string): string[] => {
-			if (previousProperties[propertyKey] !== newProperties[propertyKey]) {
-				changedPropertyKeys.push(propertyKey);
-			}
-			return changedPropertyKeys;
-		}, []);
+		const changedKeys: string[] = [];
+		const propertyKeys = Object.keys(newProperties);
 
+		for (let i = 0; i < propertyKeys.length; i++) {
+			if (previousProperties[propertyKeys[i]] !== newProperties[propertyKeys[i]]) {
+				changedKeys.push(propertyKeys[i]);
+			}
+		}
 		return { changedKeys, properties: assign({}, newProperties) };
 	}
 
@@ -258,8 +259,10 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 * @param properties properties to check for functions
 	 */
 	private bindFunctionProperties(properties: P & { [index: string]: any }): void {
-		Object.keys(properties).forEach((propertyKey) => {
-			const property = properties[propertyKey];
+		const propertyKeys = Object.keys(properties);
+
+		for (let i = 0; i < propertyKeys.length; i++) {
+			const property = properties[propertyKeys[i]];
 			const bind = properties.bind;
 
 			if (typeof property === 'function') {
@@ -270,9 +273,9 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 					boundFunc = property.bind(bind);
 					this.bindFunctionPropertyMap.set(property, { boundFunc, scope: bind });
 				}
-				properties[propertyKey] = boundFunc;
+				properties[propertyKeys[i]] = boundFunc;
 			}
-		});
+		}
 	}
 
 	/**
@@ -359,13 +362,14 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			const childrenMapKey = key || factory;
 			let cachedChildren = this.cachedChildrenMap.get(childrenMapKey) || [];
 			let cachedChild: WidgetCacheWrapper | undefined;
-			cachedChildren.some((cachedChildWrapper) => {
+
+			for (let i = 0; i < cachedChildren.length; i++) {
+				const cachedChildWrapper = cachedChildren[i];
 				if (cachedChildWrapper.factory === factory && !cachedChildWrapper.used) {
 					cachedChild = cachedChildWrapper;
-					return true;
+					break;
 				}
-				return false;
-			});
+			}
 
 			if (!properties.hasOwnProperty('bind')) {
 				properties.bind = this;
@@ -396,11 +400,13 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			return child.__render__();
 		}
 
-		dNode.vNodes = dNode.children
-		.filter((child) => child !== null)
-		.map((child: DNode) => {
-			return this.dNodeToVNode(child);
-		});
+		dNode.vNodes = [];
+		for (let i = 0; i < dNode.children.length; i++) {
+			const child = dNode.children[i];
+			if (child !== null) {
+				dNode.vNodes.push(this.dNodeToVNode(child));
+			}
+		}
 
 		return dNode.render({ bind: this });
 	}
@@ -410,14 +416,15 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	private manageDetachedChildren(): void {
 		this.cachedChildrenMap.forEach((cachedChildren, key) => {
-			const filterCachedChildren = cachedChildren.filter((cachedChild) => {
-				if (cachedChild.used) {
-					cachedChild.used = false;
-					return true;
+			const filterCachedChildren: WidgetCacheWrapper[] = [];
+			for (let i = 0; i < cachedChildren.length; i++) {
+				if (!cachedChildren[i].used) {
+					cachedChildren[i].child.destroy();
+					break;
 				}
-				cachedChild.child.destroy();
-				return false;
-			});
+				cachedChildren[i].used = false;
+				filterCachedChildren.push(cachedChildren[i]);
+			}
 			this.cachedChildrenMap.set(key, filterCachedChildren);
 		});
 	}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -148,9 +148,9 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			this.invalidate();
 
 			const propertiesChangedListeners = this.getDecorator('onPropertiesChanged') || [];
-			propertiesChangedListeners.forEach((propertiesChangedFunction) => {
-				propertiesChangedFunction.call(this, evt);
-			});
+			for (let i = 0; i < propertiesChangedListeners.length; i++) {
+				propertiesChangedListeners[i].call(this, evt);
+			}
 		}));
 	}
 
@@ -166,7 +166,8 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 
 		const registeredDiffPropertyConfigs: DiffPropertyConfig[] = this.getDecorator('diffProperty') || [];
 
-		registeredDiffPropertyConfigs.forEach(({ propertyName, diffFunction }) => {
+		for (let i = 0; i < registeredDiffPropertyConfigs.length; i++) {
+			const { propertyName, diffFunction } = registeredDiffPropertyConfigs[i];
 			const previousProperty = this.previousProperties[propertyName];
 			const newProperty = (<any> properties)[propertyName];
 			const result: PropertyChangeRecord = diffFunction(previousProperty, newProperty);
@@ -181,7 +182,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			delete (<any> properties)[propertyName];
 			delete this.previousProperties[propertyName];
 			diffPropertyResults[propertyName] = result.value;
-		});
+		}
 
 		const diffPropertiesResult = this.diffProperties(this.previousProperties, properties);
 		this._properties = assign(diffPropertiesResult.properties, diffPropertyResults);
@@ -231,9 +232,9 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		if (this.dirty || !this.cachedVNode) {
 			let dNode = this.render();
 			const afterRenders = this.getDecorator('afterRender') || [];
-			afterRenders.forEach((afterRenderFunction: Function) => {
-				dNode = afterRenderFunction.call(this, dNode);
-			});
+			for (let i = 0; i < afterRenders.length; i++) {
+				dNode = afterRenders[i].call(this, dNode);
+			}
 			const widget = this.dNodeToVNode(dNode);
 			this.manageDetachedChildren();
 			if (widget) {

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -173,19 +173,24 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 				this.recalculateThemeClasses();
 			}
 
-			const appliedClasses = classNames
-				.filter((className) => className !== null)
-				.reduce((appliedClasses: {}, className: string) => {
-					if (!this.baseClassesReverseLookup[className]) {
-						console.warn(`Class name: ${className} is not from baseClasses, use chained 'fixed' method instead`);
-						return appliedClasses;
-					}
-					className = this.baseClassesReverseLookup[className];
-					if (!this.registeredClassesMap.has(className)) {
-						this.registerThemeClass(className);
-					}
-					return assign(appliedClasses, this.registeredClassesMap.get(className));
-				}, {});
+			const appliedClasses = {};
+
+			for (let i = 0; i < classNames.length; i++) {
+				let className = classNames[i];
+				if (className === null) {
+					break;
+				}
+
+				if (!this.baseClassesReverseLookup[className]) {
+					console.warn(`Class name: ${className} is not from baseClasses, use chained 'fixed' method instead`);
+					break;
+				}
+				className = this.baseClassesReverseLookup[className];
+				if (!this.registeredClassesMap.has(className)) {
+					this.registerThemeClass(className);
+				}
+				assign(appliedClasses, this.registeredClassesMap.get(className));
+			}
 
 			const themeable = this;
 			function classesGetter(this: ClassesFunctionChain) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Convert uses of array functions `forEach`, `reduce`, `map`, `filter` to simple `for` loops.

Whilst this may seem trivial the `render`, `this.classes` and `setProperties` pipeline can get executed thousands of times each lifecycle.

*Benchmark (20 Runs) - Adding 1000 Todos, Completing Todos (Individually) and Removing Todos (Individually)*

Chrome 56

<img width="796" alt="todomvc_benchmark" src="https://cloud.githubusercontent.com/assets/1982678/23136676/c5640772-f795-11e6-9c1f-8f6a68a69c3e.png">

Safari 10.0.3

<img width="806" alt="todomvc_benchmark" src="https://cloud.githubusercontent.com/assets/1982678/23136701/e0760970-f795-11e6-8c02-5818374b1200.png">

Firefox 51

<img width="841" alt="todomvc_benchmark" src="https://cloud.githubusercontent.com/assets/1982678/23136722/f32fc7ae-f795-11e6-8d0e-e9a9d0a5f4aa.png">

