### PR TITLE
Re-add registry mixin diff function lost with move to decorators

### DIFF
--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -1,6 +1,6 @@
 import { includes } from '@dojo/shim/array';
 import FactoryRegistry from '../FactoryRegistry';
-import { WidgetBase, onPropertiesChanged } from './../WidgetBase';
+import { WidgetBase, onPropertiesChanged, diffProperty } from './../WidgetBase';
 import {
 	PropertyChangeRecord,
 	PropertiesChangeEvent,
@@ -14,6 +14,8 @@ export interface RegistryMixinProperties extends WidgetProperties {
 
 export function RegistryMixin<T extends Constructor<WidgetBase<RegistryMixinProperties>>>(base: T): T {
 	class Registry extends base {
+
+		@diffProperty('registry')
 		public diffPropertyRegistry(previousValue: FactoryRegistry, value: FactoryRegistry): PropertyChangeRecord {
 			return {
 				changed: previousValue !== value,

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -5,6 +5,7 @@ import FactoryRegistry from '../../../src/FactoryRegistry';
 import { WidgetBase } from '../../../src/WidgetBase';
 import { w, v } from '../../../src/d';
 import { VNode } from '@dojo/interfaces/vdom';
+import { spy } from 'sinon';
 
 class TestWithRegistry extends RegistryMixin(WidgetBase)<RegistryMixinProperties> {}
 
@@ -36,7 +37,7 @@ registerSuite({
 			});
 			assert.equal(instance.registry, newRegistry);
 		},
-		'different property passed on property change should not affect registy'() {
+		'different property passed on property change should not affect registry'() {
 			const registry = new FactoryRegistry();
 			const instance: any = new TestWithRegistry();
 			instance.setProperties({ registry });
@@ -48,6 +49,14 @@ registerSuite({
 				changedPropertyKeys: [ 'foo' ]
 			});
 			assert.equal(instance.registry, registry);
+		},
+		'is excluded from the catch all diffProperties function'() {
+			const registry = new FactoryRegistry();
+			const instance: any = new TestWithRegistry();
+			const diffProps = spy(instance, 'diffProperties');
+			instance.setProperties({ registry });
+			const [ , props ] = diffProps.firstCall.args;
+			assert.deepEqual(props, {});
 		}
 	},
 	integration: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

The excluding from the main diff functionality was lost when we moved over to decorators. I've added the appropriate decorator and a unit test to prove the fix.