### PR TITLE
Revert "`WidgetBase` and `Themeable` Array Optimisations (#372)"

### DIFF
--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -173,24 +173,19 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 				this.recalculateThemeClasses();
 			}
 
-			const appliedClasses = {};
-
-			for (let i = 0; i < classNames.length; i++) {
-				let className = classNames[i];
-				if (className === null) {
-					break;
-				}
-
-				if (!this.baseClassesReverseLookup[className]) {
-					console.warn(`Class name: ${className} is not from baseClasses, use chained 'fixed' method instead`);
-					break;
-				}
-				className = this.baseClassesReverseLookup[className];
-				if (!this.registeredClassesMap.has(className)) {
-					this.registerThemeClass(className);
-				}
-				assign(appliedClasses, this.registeredClassesMap.get(className));
-			}
+			const appliedClasses = classNames
+				.filter((className) => className !== null)
+				.reduce((appliedClasses: {}, className: string) => {
+					if (!this.baseClassesReverseLookup[className]) {
+						console.warn(`Class name: ${className} is not from baseClasses, use chained 'fixed' method instead`);
+						return appliedClasses;
+					}
+					className = this.baseClassesReverseLookup[className];
+					if (!this.registeredClassesMap.has(className)) {
+						this.registerThemeClass(className);
+					}
+					return assign(appliedClasses, this.registeredClassesMap.get(className));
+				}, {});
 
 			const themeable = this;
 			function classesGetter(this: ClassesFunctionChain) {


### PR DESCRIPTION
This reverts commit 661088e5313d4e596c4babefe6565103962e774a.

**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This change reverts the updates through `WidgetBase` and `Themeable` to use `for` loops. The changes were bugged, as `break;` was used where it should have been `continue;` (all unit tests passed 😞). Once these errors had been corrected the benchmark difference was negligible and therefore it is preferable to keep the newer array constructs.