### PR TITLE
Use addEventListener over traditional event handlers

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -193,10 +193,12 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 			return result;
 		}
 
-		private eventHandlerInterceptor(propertyName: string, eventHandler: Function, domNode: Node, properties: VNodeProperties) {
-			return function(this: Node, ...args: any[]) {
-				return eventHandler.apply(properties.bind || this, args);
-			};
+		private eventHandlerInterceptor(propertyName: string, eventHandler: Function, domNode: Element, properties: VNodeProperties) {
+			// remove "on" from event name
+			const eventName = propertyName.substr(2);
+			domNode.addEventListener(eventName, (...args: any[]) => {
+				eventHandler.apply(properties.bind || this, args);
+			});
 		}
 
 		private doRender() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**
Switch to using event listeners over traditional handlers. The reasoning being so we can use polyfills such as the pointer events polyfill which don't support traditional handlers. Their is no tearing down of these listeners as maquette provides no mechanism, but they should be garbage collected on node removal anyway. No checking is done on whether the event is already added either, as the only time this would happen would be if the event handler function changed, in which maquette throws an error anyway (rule 1 of maquette http://maquettejs.org/docs/rules.html)

There are already unit tests which cover the event functionality, so none added in this PR
