### PR TITLE
Maquette checked prop should be boolean

### DIFF
--- a/src/mixins/FormLabel.ts
+++ b/src/mixins/FormLabel.ts
@@ -172,7 +172,7 @@ export function FormLabelMixin<T extends Constructor<WidgetBase<WidgetProperties
 				else if (key === 'describedBy') {
 					nodeAttributes['aria-describedby'] = properties.describedBy;
 				}
-				else if ((key === 'maxLength' || key === 'minLength' || key === 'checked') && typeof properties[key] !== 'string') {
+				else if ((key === 'maxLength' || key === 'minLength') && typeof properties[key] !== 'string') {
 					nodeAttributes[key.toLowerCase()] = '' + properties[key];
 				}
 				else {


### PR DESCRIPTION
**Type:** bug

Maquette's h() actually requires the `checked` property to be a boolean, not a string

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->
