### PR TITLE
Prefer dirty over invalidation at points that occur in the rendering cycle

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -153,7 +153,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this.bindFunctionPropertyMap = new WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>();
 
 		this.own(this.on('properties:changed', (evt) => {
-			this.invalidate();
+			this.dirty = true;
 
 			const propertiesChangedListeners = this.getDecorator('onPropertiesChanged') || [];
 			propertiesChangedListeners.forEach((propertiesChangedFunction) => {
@@ -237,6 +237,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 
 	public __render__(): VNode | string | null {
 		if (this.dirty || !this.cachedVNode) {
+			this.dirty = false;
 			let dNode = this.render();
 			const afterRenders = this.getDecorator('afterRender') || [];
 			afterRenders.forEach((afterRenderFunction: Function) => {
@@ -247,7 +248,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			if (widget) {
 				this.cachedVNode = widget;
 			}
-			this.dirty = false;
 			return widget;
 		}
 		return this.cachedVNode;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -212,6 +212,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	}
 
 	public setChildren(children: DNode[]): void {
+		this.dirty = true;
 		this._children = children;
 		this.emit({
 			type: 'widget:children',
@@ -400,7 +401,9 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 				this.emit({ type: 'error', target: this, error: new Error(errorMsg) });
 			}
 
-			child.setChildren(children);
+			if (Array.isArray(children)) {
+				child.setChildren(children);
+			}
 			return child.__render__();
 		}
 

--- a/src/d.ts
+++ b/src/d.ts
@@ -72,7 +72,7 @@ export const registry = new FactoryRegistry();
  */
 export function w<P extends WidgetProperties>(factory: WidgetBaseConstructor<P> | string, properties: P): WNode;
 export function w<P extends WidgetProperties>(factory: WidgetBaseConstructor<P> | string, properties: P, children?: DNode[]): WNode;
-export function w<P extends WidgetProperties>(factory: WidgetBaseConstructor<P> | string, properties: P, children: DNode[] = []): WNode {
+export function w<P extends WidgetProperties>(factory: WidgetBaseConstructor<P> | string, properties: P, children?: DNode[]): WNode {
 
 	return {
 		children,

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -263,7 +263,7 @@ export interface WNode {
 	/**
 	 * DNode children
 	 */
-	children: DNode[];
+	children?: DNode[];
 
 	/**
 	 * The type of node

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -109,6 +109,7 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 			this.boundRender = this.__render__.bind(this);
 
 			this.own(this.on('widget:children', this.invalidate));
+			this.own(this.on('properties:changed', this.invalidate));
 			this.own(this.on('invalidated', this.scheduleRender));
 
 			this.root = document.body;

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -426,29 +426,26 @@ registerSuite({
 		decorator() {
 			let onPropertiesChangedCount = 1;
 			class TestWidget extends WidgetBase<any> {
-				invalidate() {
+				@onPropertiesChanged
+				firstOnPropertiesChanged() {
 					assert.strictEqual(onPropertiesChangedCount++, 1);
 				}
 				@onPropertiesChanged
-				firstOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 2);
-				}
-				@onPropertiesChanged
 				secondOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 3);
+					assert.strictEqual(onPropertiesChangedCount++, 2);
 				}
 			}
 
 			class ExtendedTestWidget extends TestWidget {
 				@onPropertiesChanged
 				thirdOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount, 4);
+					assert.strictEqual(onPropertiesChangedCount, 3);
 				}
 			}
 
 			const widget = new ExtendedTestWidget();
 			widget.emit({ type: 'properties:changed' });
-			assert.strictEqual(onPropertiesChangedCount, 4);
+			assert.strictEqual(onPropertiesChangedCount, 3);
 		},
 		'non decorator'() {
 
@@ -459,14 +456,11 @@ registerSuite({
 					this.addDecorator('onPropertiesChanged', this.firstOnPropertiesChanged);
 					this.addDecorator('onPropertiesChanged', this.secondOnPropertiesChanged);
 				}
-				invalidate() {
+				firstOnPropertiesChanged() {
 					assert.strictEqual(onPropertiesChangedCount++, 1);
 				}
-				firstOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 2);
-				}
 				secondOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 3);
+					assert.strictEqual(onPropertiesChangedCount++, 2);
 				}
 			}
 
@@ -476,13 +470,13 @@ registerSuite({
 					this.addDecorator('onPropertiesChanged', this.thirdOnPropertiesChanged);
 				}
 				thirdOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount, 4);
+					assert.strictEqual(onPropertiesChangedCount, 3);
 				}
 			}
 
 			const widget = new ExtendedTestWidget();
 			widget.emit({ type: 'properties:changed' });
-			assert.strictEqual(onPropertiesChangedCount, 4);
+			assert.strictEqual(onPropertiesChangedCount, 3);
 		}
 	},
 	render: {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -966,5 +966,36 @@ registerSuite({
 		childInvalidate();
 		assert.isTrue(childInvalidateCalled);
 		assert.isTrue(parentInvalidateCalled);
+	},
+	'setting children invalidate enclosing widget'() {
+		class FooWidget extends WidgetBase<any> {
+			render() {
+				return v('div', [ `${this.properties.foo}` ]);
+			}
+		}
+
+		class ContainerWidget extends WidgetBase<any> {
+			render() {
+				return v('div', {}, this.children);
+			}
+		}
+
+		class TestWidget extends WidgetBase<any> {
+			private foo = 0;
+
+			render() {
+				this.foo++;
+				return w(ContainerWidget, {}, [
+					w(FooWidget, { foo: this.foo })
+				]);
+			}
+		}
+
+		const widget: any = new TestWidget();
+		const firstRender = <any> widget.__render__();
+		assert.equal(firstRender.children[0].text, '1');
+		widget.invalidate();
+		const secondRender = <any> widget.__render__();
+		assert.equal(secondRender.children[0].text, '2');
 	}
 });

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -968,9 +968,11 @@ registerSuite({
 		assert.isTrue(parentInvalidateCalled);
 	},
 	'setting children invalidate enclosing widget'() {
+		let foo = 0;
 		class FooWidget extends WidgetBase<any> {
 			render() {
-				return v('div', [ `${this.properties.foo}` ]);
+				foo = this.properties.foo;
+				return v('div', []);
 			}
 		}
 
@@ -992,10 +994,10 @@ registerSuite({
 		}
 
 		const widget: any = new TestWidget();
-		const firstRender = <any> widget.__render__();
-		assert.equal(firstRender.children[0].text, '1');
+		widget.__render__();
+		assert.equal(foo, 1);
 		widget.invalidate();
-		const secondRender = <any> widget.__render__();
-		assert.equal(secondRender.children[0].text, '2');
+		widget.__render__();
+		assert.equal(foo, 2);
 	}
 });

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -241,6 +241,18 @@ registerSuite({
 		});
 
 	},
+	'invalidate on properties:changed'() {
+		const projector = new TestWidget();
+		let called = false;
+
+		projector.on('invalidated', () => {
+			called = true;
+		});
+
+		projector.setProperties({ foo: 'hello' });
+
+		assert.isTrue(called);
+	},
 	'invalidate on setting children'() {
 		const projector = new TestWidget();
 		let called = false;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR tidies up some of our usage of `invalidate`, which should only be really used outside of rendering for example at interaction time.

The only time we now `invalidate` on `properties:changed` is when we use the public `setProperties` function which should only be at a projector level. Resolves #386.

When setting children we now always mark the enclosing widget as `dirty`. Resolves #383.