### PR TITLE
Include Pointer Event Polyfill with Projector

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "sinon": "^1.17.6",
     "tslint": "^3.11.0",
     "typescript": "~2.2.1"
+  },
+  "dependencies": {
+    "pepjs": "^0.4.2"
   }
 }

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -5,6 +5,7 @@ import { dom, Projection, ProjectionOptions, VNodeProperties } from 'maquette';
 import { WidgetBase } from './../WidgetBase';
 import { Constructor, WidgetProperties } from './../interfaces';
 import cssTransitions from '../animations/cssTransitions';
+import 'pepjs';
 
 /**
  * Represents the attach state of the projector

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -17,7 +17,8 @@
 	require.config({
 		packages: [
 			{ name: '@dojo', location: '../../../../../node_modules/@dojo' },
-			{ name: 'maquette', location: '../../../../../node_modules/maquette/dist', main: 'maquette' }
+			{ name: 'maquette', location: '../../../../../node_modules/maquette/dist', main: 'maquette' },
+			{ name: 'pepjs', location: '../../../../../node_modules/pepjs/dist', main: 'pep' }
 		]
 	});
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -66,6 +66,7 @@ export const loaderOptions = {
 		{ name: 'cldrjs', location: 'node_modules/cldrjs' },
 		{ name: 'globalize', location: 'node_modules/globalize', main: 'dist/globalize' },
 		{ name: 'maquette', location: 'node_modules/maquette/dist', main: 'maquette' },
+		{ name: 'pepjs', location: 'node_modules/pepjs/dist', main: 'pep' },
 		{ name: 'grunt-dojo2', location: 'node_modules/grunt-dojo2'},
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	],

--- a/tests/support/loadJsdom.ts
+++ b/tests/support/loadJsdom.ts
@@ -19,6 +19,9 @@ global.document = doc;
 /* Assign a global window as well */
 global.window = doc.defaultView;
 
+/* Needed for Pointer Event Polyfill's incorrect Element detection */
+global.Element = function() {};
+
 /* Polyfill requestAnimationFrame - this can never be called an *actual* polyfill */
 global.requestAnimationFrame = (cb: (...args: any[]) => {}) => {
 	setImmediate(cb);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**

This is to discuss, as its one of the few polyfills we actually have that are external and not from `dojo/shim`. I think we should include it by default in the projector, rather than it being opt-in. We've done similar with css-transitions and the projector, and pepjs is only 6kb min & gzipped.
