### PR TITLE
Support both event handlers and event listeners

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -81,6 +81,33 @@ export interface ProjectorMixin {
 	readonly projectorState: ProjectorAttachState;
 }
 
+const eventHandlers = [
+	'ontouchcancel',
+	'ontouchend',
+	'ontouchmove',
+	'ontouchstart',
+	'onblur',
+	'onchange',
+	'onclick',
+	'ondblclick',
+	'onfocus',
+	'oninput',
+	'onkeydown',
+	'onkeypress',
+	'onkeyup',
+	'onload',
+	'onmousedown',
+	'onmouseenter',
+	'onmouseleave',
+	'onmousemove',
+	'onmouseout',
+	'onmouseover',
+	'onmouseup',
+	'onmousewheel',
+	'onscroll',
+	'onsubmit'
+];
+
 export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<ProjectorMixin> {
 	return class extends base {
 
@@ -196,11 +223,18 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 		}
 
 		private eventHandlerInterceptor(propertyName: string, eventHandler: Function, domNode: Element, properties: VNodeProperties) {
-			// remove "on" from event name
-			const eventName = propertyName.substr(2);
-			domNode.addEventListener(eventName, (...args: any[]) => {
-				eventHandler.apply(properties.bind || this, args);
-			});
+			if (eventHandlers.indexOf(propertyName) > -1) {
+				return function(this: Node, ...args: any[]) {
+					return eventHandler.apply(properties.bind || this, args);
+				};
+			}
+			else {
+				// remove "on" from event name
+				const eventName = propertyName.substr(2);
+				domNode.addEventListener(eventName, (...args: any[]) => {
+					eventHandler.apply(properties.bind || this, args);
+				});
+			}
 		}
 
 		private doRender() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -8,6 +8,8 @@ import { ProjectorMixin, ProjectorAttachState } from '../../../src/mixins/Projec
 import { WidgetBase } from '../../../src/WidgetBase';
 import global from '@dojo/core/global';
 
+const Event = global.window.Event;
+
 class TestWidget extends ProjectorMixin(WidgetBase)<any> {}
 
 function dispatchEvent(element: Element, eventType: string) {
@@ -306,10 +308,10 @@ registerSuite({
 			}, Error, 'already attached');
 		});
 	},
-	'can attach an event'() {
+	'can attach an event handler'() {
 		let domNode: any;
 		let domEvent: any;
-		const onclick = (evt: any) => {
+		const oninput = (evt: any) => {
 			domEvent = evt;
 		};
 		const afterCreate = (node: Node) => {
@@ -317,14 +319,45 @@ registerSuite({
 		};
 		const Projector = class extends TestWidget {
 			render() {
-				return v('div', { onclick, afterCreate });
+				return v('div', { oninput, afterCreate });
 			}
 		};
 
 		const projector = new Projector();
 		return projector.append().then(() => {
-			domNode.click();
-			assert.instanceOf(domEvent, global.window.MouseEvent);
+			const event = new Event('input', {
+				'bubbles': true,
+				'cancelable': true
+			});
+
+			domNode.dispatchEvent(event);
+			assert.instanceOf(domEvent, Event);
+		});
+	},
+	'can attach an event listener'() {
+		let domNode: any;
+		let domEvent: any;
+		const onpointermove = (evt: any) => {
+			domEvent = evt;
+		};
+		const afterCreate = (node: Node) => {
+			domNode = node;
+		};
+		const Projector = class extends TestWidget {
+			render() {
+				return v('div', { onpointermove, afterCreate });
+			}
+		};
+
+		const projector = new Projector();
+		return projector.append().then(() => {
+			const event = new Event('pointermove', {
+				'bubbles': true,
+				'cancelable': true
+			});
+
+			domNode.dispatchEvent(event);
+			assert.instanceOf(domEvent, Event);
 		});
 	},
 	async '-active gets appended to enter/exit animations by default'(this: any) {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -325,12 +325,7 @@ registerSuite({
 
 		const projector = new Projector();
 		return projector.append().then(() => {
-			const event = new Event('input', {
-				'bubbles': true,
-				'cancelable': true
-			});
-
-			domNode.dispatchEvent(event);
+			dispatchEvent(domNode, 'input');
 			assert.instanceOf(domEvent, Event);
 		});
 	},
@@ -351,12 +346,7 @@ registerSuite({
 
 		const projector = new Projector();
 		return projector.append().then(() => {
-			const event = new Event('pointermove', {
-				'bubbles': true,
-				'cancelable': true
-			});
-
-			domNode.dispatchEvent(event);
+			dispatchEvent(domNode, 'pointermove');
 			assert.instanceOf(domEvent, Event);
 		});
 	},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves #397 

This adds back using event handlers for all known maquette events (defined in the interface), anything else will use `addEventListener`. This is really a temporary workaround until we get chance to work on a new way of attaching events without using the `eventHandlerIntercepter` (probably via `afterCreates` in `v`)
