### PR TITLE
Add attribute to sniff and fork addDecorator code depending caller

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -85,8 +85,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	static _type: symbol = WIDGET_BASE_TYPE;
 
-	private _constructed: boolean = true;
-
 	/**
 	 * on for the events defined for widget base
 	 */
@@ -337,7 +335,11 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	protected addDecorator(decoratorKey: string, value: any): void {
 		value = Array.isArray(value) ? value : [ value ];
-		if (!this._constructed) {
+		if (this._properties) {
+			const decorators = this._decoratorCache.get(decoratorKey) || [];
+			this._decoratorCache.set(decoratorKey, [ ...decorators, ...value ]);
+		}
+		else {
 			let decoratorList = decoratorMap.get(this.constructor);
 			if (!decoratorList) {
 				decoratorList = new Map<string, any[]>();
@@ -350,10 +352,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 				decoratorList.set(decoratorKey, specificDecoratorList);
 			}
 			specificDecoratorList.push(...value);
-		}
-		else {
-			const decorators = this._decoratorCache.get(decoratorKey) || [];
-			this._decoratorCache.set(decoratorKey, [ ...decorators, ...value ]);
 		}
 	}
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -85,6 +85,8 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	static _type: symbol = WIDGET_BASE_TYPE;
 
+	private _constructed: boolean = true;
+
 	/**
 	 * on for the events defined for widget base
 	 */
@@ -335,20 +337,24 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	protected addDecorator(decoratorKey: string, value: any): void {
 		value = Array.isArray(value) ? value : [ value ];
+		if (!this._constructed) {
+			let decoratorList = decoratorMap.get(this.constructor);
+			if (!decoratorList) {
+				decoratorList = new Map<string, any[]>();
+				decoratorMap.set(this.constructor, decoratorList);
+			}
 
-		let decoratorList = decoratorMap.get(this.constructor);
-		if (!decoratorList) {
-			decoratorList = new Map<string, any[]>();
-			decoratorMap.set(this.constructor, decoratorList);
+			let specificDecoratorList = decoratorList.get(decoratorKey);
+			if (!specificDecoratorList) {
+				specificDecoratorList = [];
+				decoratorList.set(decoratorKey, specificDecoratorList);
+			}
+			specificDecoratorList.push(...value);
 		}
-
-		let specificDecoratorList = decoratorList.get(decoratorKey);
-		if (!specificDecoratorList) {
-			specificDecoratorList = [];
-			decoratorList.set(decoratorKey, specificDecoratorList);
+		else {
+			const decorators = this._decoratorCache.get(decoratorKey) || [];
+			this._decoratorCache.set(decoratorKey, [ ...decorators, ...value ]);
 		}
-
-		specificDecoratorList.push(...value);
 	}
 
 	/**

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -335,11 +335,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	protected addDecorator(decoratorKey: string, value: any): void {
 		value = Array.isArray(value) ? value : [ value ];
-		if (this._properties) {
-			const decorators = this._decoratorCache.get(decoratorKey) || [];
-			this._decoratorCache.set(decoratorKey, [ ...decorators, ...value ]);
-		}
-		else {
+		if (this.hasOwnProperty('constructor')) {
 			let decoratorList = decoratorMap.get(this.constructor);
 			if (!decoratorList) {
 				decoratorList = new Map<string, any[]>();
@@ -352,6 +348,10 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 				decoratorList.set(decoratorKey, specificDecoratorList);
 			}
 			specificDecoratorList.push(...value);
+		}
+		else {
+			const decorators = this._decoratorCache.get(decoratorKey) || [];
+			this._decoratorCache.set(decoratorKey, [ ...decorators, ...value ]);
 		}
 	}
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -109,6 +109,30 @@ registerSuite({
 			testWidget.setProperties({ foo: 'bar' });
 
 			assert.equal(callCount, 1);
+		},
+		'decorators can be applied at instance level'() {
+			let renderCallCount = 0;
+
+			class TestWidget extends WidgetBase<any> {
+				constructor() {
+					super();
+
+					this.addDecorator('afterRender', (node: DNode) => {
+						renderCallCount++;
+						return node;
+					});
+				}
+
+				render() {
+					return v('div');
+				}
+			}
+
+			new TestWidget();
+			const widget2 = new TestWidget();
+			widget2.__render__();
+
+			assert.equal(renderCallCount, 1);
 		}
 	},
 	setProperties: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fork behaviour for adding decorators functionality depending whether added programmatically or via typescript decorators.

Resolves #406