### PR TITLE
Support NodeJS for animations/cssTransitions

### DIFF
--- a/src/animations/cssTransitions.ts
+++ b/src/animations/cssTransitions.ts
@@ -8,7 +8,7 @@ export interface VNodeProperties {
 	exitAnimationActive?: string;
 }
 
-hasAdd('css-transitions', has('host-node') || 'transition' in document.createElement('div').style);
+hasAdd('css-transitions', 'transition' in document.createElement('div').style);
 
 function runAndCleanUp(element: HTMLElement, startAnimation: () => void, finishAnimation: () => void) {
 	/* istanbul ignore if */

--- a/src/animations/cssTransitions.ts
+++ b/src/animations/cssTransitions.ts
@@ -1,41 +1,28 @@
-let browserSpecificTransitionEndEventName = '';
-let browserSpecificAnimationEndEventName = '';
+import has, { add as hasAdd } from '@dojo/has/has';
+
+const TRANSISTION_END_EVENT_NAME = 'transitionend';
+const ANIMATION_END_EVENT_NAME = 'animationend';
 
 export interface VNodeProperties {
 	enterAnimationActive?: string;
 	exitAnimationActive?: string;
 }
 
-function determineBrowserStyleNames(element: HTMLElement) {
-	if ('WebkitTransition' in element.style) {
-		browserSpecificTransitionEndEventName = 'webkitTransitionEnd';
-		browserSpecificAnimationEndEventName = 'webkitAnimationEnd';
-	}
-	else if (('transition' in element.style) || ('MozTransition' in element.style)) {
-		browserSpecificTransitionEndEventName = 'transitionend';
-		browserSpecificAnimationEndEventName = 'animationend';
-	}
-	else {
-		throw new Error('Your browser is not supported');
-	}
-}
-
-function initialize(element: HTMLElement) {
-	if (browserSpecificAnimationEndEventName === '') {
-		determineBrowserStyleNames(element);
-	}
-}
+hasAdd('css-transitions', has('host-node') || 'transition' in document.createElement('div').style);
 
 function runAndCleanUp(element: HTMLElement, startAnimation: () => void, finishAnimation: () => void) {
-	initialize(element);
+	/* istanbul ignore if */
+	if (!has('css-transitions')) {
+		throw new Error('Environment does not support CSS transistions');
+	}
 
 	let finished = false;
 
 	let transitionEnd = function () {
 		if (!finished) {
 			finished = true;
-			element.removeEventListener(browserSpecificTransitionEndEventName, transitionEnd);
-			element.removeEventListener(browserSpecificAnimationEndEventName, transitionEnd);
+			element.removeEventListener(TRANSISTION_END_EVENT_NAME, transitionEnd);
+			element.removeEventListener(ANIMATION_END_EVENT_NAME, transitionEnd);
 
 			finishAnimation();
 		}
@@ -43,8 +30,8 @@ function runAndCleanUp(element: HTMLElement, startAnimation: () => void, finishA
 
 	startAnimation();
 
-	element.addEventListener(browserSpecificAnimationEndEventName, transitionEnd);
-	element.addEventListener(browserSpecificTransitionEndEventName, transitionEnd);
+	element.addEventListener(ANIMATION_END_EVENT_NAME, transitionEnd);
+	element.addEventListener(TRANSISTION_END_EVENT_NAME, transitionEnd);
 }
 
 function exit(node: HTMLElement, properties: VNodeProperties, exitAnimation: string, removeNode: () => void) {

--- a/tests/support/dispatchSyntheticEvent.ts
+++ b/tests/support/dispatchSyntheticEvent.ts
@@ -1,0 +1,34 @@
+import has, { add as hasAdd } from '@dojo/has/has';
+
+hasAdd('customevent-constructor', () => {
+	try {
+		new window.CustomEvent('foo');
+		return true;
+	}
+	catch (e) {
+		return false;
+	}
+});
+
+/**
+ * Create a custom event and dispatch it to the target node
+ * @param target The target the event should be dispatched to
+ * @param eventType The string name of the event
+ * @param eventInit Any event initialisation parameters
+ * @param beforeDispatch An optional function that will be called with the event before it is dispatched
+ */
+export default function (target: Element, eventType: string, eventInit?: CustomEventInit, beforeDispatch?: (evt: CustomEvent) => void) {
+	let event: CustomEvent;
+	if (has('customevent-constructor')) {
+		event = new window.CustomEvent(eventType, eventInit);
+	}
+	else {
+		event = document.createEvent('CustomEvent');
+		const { bubbles, cancelable } = eventInit || { bubbles: false, cancelable: false };
+		event.initCustomEvent(eventType, bubbles || false, cancelable || false, {});
+	}
+	if (beforeDispatch) {
+		beforeDispatch(event);
+	}
+	target.dispatchEvent(event);
+}

--- a/tests/support/loadJsdom.ts
+++ b/tests/support/loadJsdom.ts
@@ -1,6 +1,12 @@
 import * as jsdom from 'jsdom';
 import global from '@dojo/core/global';
 
+declare global {
+	interface Window {
+		CustomEvent: typeof CustomEvent;
+	}
+}
+
 /* In order to have the tests work under Node.js, we need to load JSDom and polyfill
  * requestAnimationFrame */
 

--- a/tests/support/loadJsdom.ts
+++ b/tests/support/loadJsdom.ts
@@ -28,6 +28,13 @@ global.window = doc.defaultView;
 /* Needed for Pointer Event Polyfill's incorrect Element detection */
 global.Element = function() {};
 
+/* Patch feature detection of CSS Animations */
+Object.defineProperty(
+	(<any> window).CSSStyleDeclaration.prototype,
+	'transition',
+	Object.getOwnPropertyDescriptor((<any> window).CSSStyleDeclaration.prototype, 'webkitTransition')
+);
+
 /* Polyfill requestAnimationFrame - this can never be called an *actual* polyfill */
 global.requestAnimationFrame = (cb: (...args: any[]) => {}) => {
 	setImmediate(cb);

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -4,6 +4,7 @@ import './WidgetRegistry';
 import './lifecycle';
 import './customElements';
 import './d';
+import './animations/all';
 import './mixins/all';
 import './util/all';
 import './main';

--- a/tests/unit/animations/all.ts
+++ b/tests/unit/animations/all.ts
@@ -1,0 +1,1 @@
+import './cssTransitions';

--- a/tests/unit/animations/cssTransitions.ts
+++ b/tests/unit/animations/cssTransitions.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import dispatchSyntheticEvent from '../../support/dispatchSyntheticEvent';
 import cssTransistions from '../../../src/animations/cssTransitions';
 
 registerSuite({
@@ -17,14 +18,10 @@ registerSuite({
 				assert.lengthOf(div.classList, 2);
 				assert.isTrue(div.classList.contains('foo-active'));
 
-				const evt = new window.CustomEvent('transitionend', {
-					bubbles: true,
-					cancelable: true
-				});
-				div.dispatchEvent(evt);
+				dispatchSyntheticEvent(div, 'transitionend', { bubbles: true, cancelable: true });
 
 				assert.lengthOf(div.classList, 0);
-			}), 10);
+			}), 20);
 		},
 
 		'animationend'(this: any) {
@@ -38,14 +35,10 @@ registerSuite({
 				assert.lengthOf(div.classList, 2);
 				assert.isTrue(div.classList.contains('foo-active'));
 
-				const evt = new window.CustomEvent('animationend', {
-					bubbles: true,
-					cancelable: false
-				});
-				div.dispatchEvent(evt);
+				dispatchSyntheticEvent(div, 'animationend', { bubbles: true, cancelable: false });
 
 				assert.lengthOf(div.classList, 0);
-			}), 10);
+			}), 20);
 		}
 	},
 
@@ -65,12 +58,8 @@ registerSuite({
 				assert.lengthOf(div.classList, 2);
 				assert.isTrue(div.classList.contains('foo-active'));
 
-				const evt = new window.CustomEvent('transitionend', {
-					bubbles: true,
-					cancelable: true
-				});
-				div.dispatchEvent(evt);
-			}, 10);
+				dispatchSyntheticEvent(div, 'transitionend', { bubbles: true, cancelable: true });
+			}, 20);
 		},
 
 		'animationend'(this: any) {
@@ -88,12 +77,8 @@ registerSuite({
 				assert.lengthOf(div.classList, 2);
 				assert.isTrue(div.classList.contains('foo-active'));
 
-				const evt = new window.CustomEvent('animationend', {
-					bubbles: true,
-					cancelable: false
-				});
-				div.dispatchEvent(evt);
-			}, 10);
+				dispatchSyntheticEvent(div, 'animationend', { bubbles: true, cancelable: false });
+			}, 20);
 		}
 	}
 });

--- a/tests/unit/animations/cssTransitions.ts
+++ b/tests/unit/animations/cssTransitions.ts
@@ -1,0 +1,99 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import cssTransistions from '../../../src/animations/cssTransitions';
+
+registerSuite({
+	name: 'animations/cssTransistions',
+
+	'enter': {
+		'transitionend'(this: any) {
+			const dfd = this.async();
+			const div = document.createElement('div');
+			cssTransistions.enter(div, {}, 'foo');
+			assert.lengthOf(div.classList, 1);
+			assert.isTrue(div.classList.contains('foo'));
+
+			setInterval(dfd.callback(() => {
+				assert.lengthOf(div.classList, 2);
+				assert.isTrue(div.classList.contains('foo-active'));
+
+				const evt = new window.CustomEvent('transitionend', {
+					bubbles: true,
+					cancelable: true
+				});
+				div.dispatchEvent(evt);
+
+				assert.lengthOf(div.classList, 0);
+			}), 10);
+		},
+
+		'animationend'(this: any) {
+			const dfd = this.async();
+			const div = document.createElement('div');
+			cssTransistions.enter(div, {}, 'foo');
+			assert.lengthOf(div.classList, 1);
+			assert.isTrue(div.classList.contains('foo'));
+
+			setInterval(dfd.callback(() => {
+				assert.lengthOf(div.classList, 2);
+				assert.isTrue(div.classList.contains('foo-active'));
+
+				const evt = new window.CustomEvent('animationend', {
+					bubbles: true,
+					cancelable: false
+				});
+				div.dispatchEvent(evt);
+
+				assert.lengthOf(div.classList, 0);
+			}), 10);
+		}
+	},
+
+	'exit': {
+		'transitionend'(this: any) {
+			const dfd = this.async();
+			const div = document.createElement('div');
+			cssTransistions.exit(div, {}, 'foo', dfd.callback(() => {
+				assert.lengthOf(div.classList, 2);
+				assert.isTrue(div.classList.contains('foo-active'));
+			}));
+
+			assert.lengthOf(div.classList, 1);
+			assert.isTrue(div.classList.contains('foo'));
+
+			setInterval(() => {
+				assert.lengthOf(div.classList, 2);
+				assert.isTrue(div.classList.contains('foo-active'));
+
+				const evt = new window.CustomEvent('transitionend', {
+					bubbles: true,
+					cancelable: true
+				});
+				div.dispatchEvent(evt);
+			}, 10);
+		},
+
+		'animationend'(this: any) {
+			const dfd = this.async();
+			const div = document.createElement('div');
+			cssTransistions.exit(div, {}, 'foo', dfd.callback(() => {
+				assert.lengthOf(div.classList, 2);
+				assert.isTrue(div.classList.contains('foo-active'));
+			}));
+
+			assert.lengthOf(div.classList, 1);
+			assert.isTrue(div.classList.contains('foo'));
+
+			setInterval(() => {
+				assert.lengthOf(div.classList, 2);
+				assert.isTrue(div.classList.contains('foo-active'));
+
+				const evt = new window.CustomEvent('animationend', {
+					bubbles: true,
+					cancelable: false
+				});
+				div.dispatchEvent(evt);
+			}, 10);
+		}
+	}
+});

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -8,27 +8,17 @@ import { ProjectorMixin, ProjectorAttachState } from '../../../src/mixins/Projec
 import { WidgetBase } from '../../../src/WidgetBase';
 import global from '@dojo/core/global';
 import { waitFor } from '../waitFor';
+import dispatchSyntheticEvent from '../../support/dispatchSyntheticEvent';
 
 const Event = global.window.Event;
 
 class TestWidget extends ProjectorMixin(WidgetBase)<any> {}
 
-function dispatchEvent(element: Element, eventType: string) {
-	try {
-		element.dispatchEvent(new CustomEvent(eventType));
-	}
-	catch (e) {
-		const event = document.createEvent('CustomEvent');
-		event.initCustomEvent(eventType, false, false, {});
-		element.dispatchEvent(event);
-	}
-}
-
 function sendAnimationEndEvents(element: Element) {
-	dispatchEvent(element, 'webkitTransitionEnd');
-	dispatchEvent(element, 'webkitAnimationEnd');
-	dispatchEvent(element, 'transitionend');
-	dispatchEvent(element, 'animationend');
+	dispatchSyntheticEvent(element, 'webkitTransitionEnd', { bubbles: true, cancelable: true });
+	dispatchSyntheticEvent(element, 'webkitAnimationEnd', { bubbles: true, cancelable: false });
+	dispatchSyntheticEvent(element, 'transitionend', { bubbles: true, cancelable: true });
+	dispatchSyntheticEvent(element, 'animationend', { bubbles: true, cancelable: false });
 }
 
 let rafSpy: any;
@@ -302,7 +292,7 @@ registerSuite({
 
 		const projector = new Projector();
 		return projector.append().then(() => {
-			dispatchEvent(domNode, 'input');
+			dispatchSyntheticEvent(domNode, 'input');
 			assert.instanceOf(domEvent, Event);
 		});
 	},
@@ -323,7 +313,7 @@ registerSuite({
 
 		const projector = new Projector();
 		return projector.append().then(() => {
-			dispatchEvent(domNode, 'pointermove');
+			dispatchSyntheticEvent(domNode, 'pointermove');
 			assert.instanceOf(domEvent, Event);
 		});
 	},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR provides support for NodeJS/jsdom for animations/cssTransitions.  It also changes the
feature test to use `has()` as well as removes the unnecessary name switching of event names.
It also add full unit test coverage for the module.

Resolves #412 
