### PR TITLE
Enhance property diffing system (refs #404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,20 @@ If a property has a custom diff function then that property is excluded from the
 ##### The 'properties:changed' event
 
 When `diffProperties` has completed, the results are used to update the properties on the widget instance.
-If any properties were changed, then the `properties:changed` event is emitted.
+If any properties were changed, then the `properties:changed` event is emitted. If the new properties do **not** contain keys from the previous properties, the properties are marked as changed.
+
+```typescript
+// set the initial properties
+$widget->setProperties({
+	foo: true,
+	bar: true
+});
+
+// properties:changed will include the "bar" property
+$widget->setProperties({
+	foo: true
+});
+```
 
 Attaching a listener to the event is exposed via a decorator `@onPropertiesChanged`.
 

--- a/README.md
+++ b/README.md
@@ -200,36 +200,61 @@ Properties passed to the `w` function represent the public API for a widget.
 
 The properties lifecycle starts when properties are passed to the widget.
 The properties lifecycle is performed in the widgets `setProperties` function.
-This function uses the widget instance's `diffProperties` function to determine whether any of the properties have changed since the last render cycle.
-By default `diffProperties` provides a shallow comparison of the previous properties and new properties.
+Properties are differenced using `DiffType.AUTO`.
 
-The `diffProperties` function is also responsible for creating a copy (the default implementation uses`Object.assign({}, newProperties)` of all changed properties.
-The depth of the returned diff is equal to the depth used during the equality comparison.
-
-<!-- add example of 'depth' -->
-
-**Note:** If a widget's properties contain complex data structures that you need to diff, then the `diffProperties` function will need to be overridden.
+**Note:** If a widget's properties contain complex data structures that you need to diff, then individual control is required using the `diffProperty` decorator.
 
 ##### Custom property diff control
 
-Included in `WidgetBase` is functionality to support targeting a specific property with a custom comparison function using a decorator `diffProperty`. For non-decorator environments (Either JavaScript/ES6 or a TypeScript project that does not have the experimental decorators configuration set to true in the `tsconfig`), the decorator functions can be called directly from the constructor.
+You can control individual property differencing by using the `@diffProperty` decorator. Properties with a `diffProperty` decorator **will be excluded from automatic differencing**.
 
-e.g. for a property `foo` you would add a function to the widget class and either use the decorator function or register the decorator in the `constructor`.
+###### At the class level
 
-*using the `diffProperty` decorator*
+`@diffProperty(propertyName, diffType)` can be applied at the class level if you want to use a pre-defined diff function.
 
-```ts
+```typescript
+@diffProperty('title', DiffType.REFERENCE)
+class MyWidget extends WidgetBase<MyProperties> {
+}
+```
+
+The following diff functions are provided:
+
+| Type                 | Description                                                                       |
+| -------------------- | ----------------------------------------------------------------------------------|
+| `DiffType.ALWAYS`    | Always report a property as changed.                                              |
+| `DiffType.AUTO`      | Ignore functions, shallow compare objects, and reference compare all other values.|
+| `DiffType.CUSTOM`    | Provide a custom diffing function.                                                |
+| `DiffType.IGNORE`    | Never report a property as changed.                                               |
+| `DiffType.REFERENCE` | Compare values by reference (`old === new`)                                       |
+| `DiffType.SHALLOW`   | Treat the values as objects and compare their immediate values by reference.      |
+
+`DiffType.CUSTOM` is unique in that it takes a third parameter, the diff function. This function has the following signature:
+
+```
+(previousValue: any, newValue: any) => {
+  changed: boolean;
+  value: any;
+}
+```
+
+###### At the method level
+
+You can also provide `DiffType.CUSTOM` diff functions by applying a decorator at the method level.
+
+```typescript
 class MyWidget extends WidgetBase<WidgetProperties> {
-
 	@diffProperty('foo')
-	myComplexDiffFunction(previousProperty: MyComplexObject, newProperty: MyComplexObject) {
-			// can perfom complex comparison logic here between the two property values
-			// or even use externally stored state to assist the comparison
+	myComplexDiffFunction(previousValue: MyComplexObject, newValue: MyComplexObject) {
+		return {
+		  changed: true,
+		  value: newValue
+		};
 	}
 }
 ```
 
-*registering the `diffProperty` function in the constructor*
+For non-decorator environments (Either JavaScript/ES6 or a TypeScript project that does not have the experimental decorators configuration set to true in the `tsconfig`), the functions need to be registered in the constructor using the `addDecorator` API with `diffProperty` as the key.
 
 ```ts
 class MyWidget extends WidgetBase<WidgetProperties> {
@@ -244,7 +269,7 @@ class MyWidget extends WidgetBase<WidgetProperties> {
 }
 ```
 
-If a property has a custom diff function then that property is excluded from those passed to the default `diffProperties` function.
+If a property has a custom diff function then that property is excluded from the default property diff.
 
 ##### The 'properties:changed' event
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -1,5 +1,4 @@
 import { Evented, BaseEventedEvents } from '@dojo/core/Evented';
-import { assign } from '@dojo/core/lang';
 import { EventedListenerOrArray } from '@dojo/interfaces/bases';
 import { Handle } from '@dojo/interfaces/core';
 import { VNode, ProjectionOptions, VNodeProperties } from '@dojo/interfaces/vdom';
@@ -15,7 +14,6 @@ import {
 	WidgetProperties,
 	WidgetBaseInterface,
 	PropertyChangeRecord,
-	PropertiesChangeRecord,
 	PropertiesChangeEvent,
 	HNode
 } from './interfaces';
@@ -181,6 +179,9 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	private _diffPropertyFunctionMap: Map<string, string>;
 
+	/**
+	 * map of decorators that are applied to this widget
+	 */
 	private _decoratorCache: Map<string, any[]>;
 
 	/**
@@ -279,46 +280,73 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	}
 
 	public setProperties(properties: P): void {
-		const diffPropertyResults: { [index: string]: PropertyChangeRecord } = {};
+		const diffPropertyResults: { [index: string]: any } = {};
 		const diffPropertyChangedKeys: string[] = [];
 
 		this.bindFunctionProperties(properties);
 
 		const registeredDiffPropertyConfigs: DiffPropertyConfig[] = this.getDecorator('diffProperty');
 
-		registeredDiffPropertyConfigs.forEach(({ propertyName, diffFunction, diffType }) => {
+		const allProperties = [...Object.keys(this._previousProperties), ...Object.keys(properties)].filter((value, index, self) => {
+			return self.indexOf(value) === index;
+		});
 
-			const previousProperty = this._previousProperties[propertyName];
-			const newProperty = (<any> properties)[propertyName];
-			const meta = {
-				diffFunction: diffFunction,
-				scope: this
+		const propertyDiffHandlers = allProperties.reduce((diffFunctions: any, propertyName) => {
+			diffFunctions[propertyName] = [
+				...registeredDiffPropertyConfigs.filter(value => {
+					return value.propertyName === propertyName;
+				})
+			];
+
+			return diffFunctions;
+		}, {});
+
+		allProperties.forEach(propertyName => {
+			const previousValue = this._previousProperties[propertyName];
+			const newValue = (<any> properties)[propertyName];
+			const diffHandlers = propertyDiffHandlers[propertyName];
+			let result: PropertyChangeRecord = {
+				changed: false,
+				value: newValue
 			};
 
-			const result = diff(propertyName, diffType, previousProperty, newProperty, meta);
+			if (diffHandlers.length) {
+				for (let i = 0; i < diffHandlers.length; i++) {
+					const { diffFunction, diffType } = diffHandlers[i];
 
-			diffPropertyResults[propertyName] = result.value;
+					const meta = {
+						diffFunction: diffFunction,
+						scope: this
+					};
+
+					result = diff(propertyName, diffType, previousValue, newValue, meta);
+
+					if (result.changed) {
+						break;
+					}
+				}
+			}
+			else {
+				result = diff(propertyName, DiffType.AUTO, previousValue, newValue);
+			}
+
+			if (propertyName in properties) {
+				diffPropertyResults[propertyName] = result.value;
+			}
 
 			if (result.changed) {
 				diffPropertyChangedKeys.push(propertyName);
 			}
-
-			// always remove the property from further processing;
-			delete (<any> properties)[propertyName];
-			delete this._previousProperties[propertyName];
 		});
 
-		const diffPropertiesResult = this.diffProperties(this._previousProperties, properties);
-		this._properties = assign(diffPropertiesResult.properties, diffPropertyResults);
+		this._properties = <P> diffPropertyResults;
 
-		const changedPropertyKeys = [...diffPropertiesResult.changedKeys, ...diffPropertyChangedKeys];
-
-		if (changedPropertyKeys.length) {
+		if (diffPropertyChangedKeys.length) {
 			this.emit({
 				type: 'properties:changed',
 				target: this,
 				properties: this.properties,
-				changedPropertyKeys
+				changedPropertyKeys: diffPropertyChangedKeys
 			});
 		}
 		this._previousProperties = this.properties;
@@ -335,17 +363,6 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			type: 'widget:children',
 			target: this
 		});
-	}
-
-	public diffProperties(previousProperties: P & { [index: string]: any }, newProperties: P & { [index: string]: any }): PropertiesChangeRecord<P> {
-		const changedKeys = Object.keys(newProperties).reduce((changedPropertyKeys: string[], propertyKey: string): string[] => {
-			if (previousProperties[propertyKey] !== newProperties[propertyKey]) {
-				changedPropertyKeys.push(propertyKey);
-			}
-			return changedPropertyKeys;
-		}, []);
-
-		return { changedKeys, properties: assign({}, newProperties) };
 	}
 
 	public __render__(): VNode | string | null {

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -122,6 +122,7 @@ function isHNodeWithKey(node: DNode): node is HNode {
 /**
  * Main widget base for all widgets to extend
  */
+@diffProperty('bind', DiffType.REFERENCE)
 export class WidgetBase<P extends WidgetProperties> extends Evented implements WidgetBaseInterface<P> {
 
 	/**

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,6 +1,6 @@
-import { VNode, VNodeProperties, ProjectionOptions } from '@dojo/interfaces/vdom';
-import { EventTypedObject } from '@dojo/interfaces/core';
 import { Evented } from '@dojo/core/Evented';
+import { EventTypedObject } from '@dojo/interfaces/core';
+import { VNode, VNodeProperties, ProjectionOptions } from '@dojo/interfaces/vdom';
 
 /**
  * Generic constructor type
@@ -365,15 +365,6 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	 * Sets the widget's children
 	 */
 	setChildren(children: DNode[]): void;
-
-	/**
-	 * The default diff function for properties, also responsible for cloning the properties.
-	 *
-	 * @param previousProperties The widget's previous properties
-	 * @param newProperties The widget's new properties
-	 * @returns A properties change record for the the diff
-	 */
-	diffProperties(previousProperties: P & { [index: string]: any }, newProperties: P & { [index: string]: any }): PropertiesChangeRecord<P>;
 
 	/**
 	 * Main internal function for dealing with widget rendering

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -1,11 +1,10 @@
+import { VNode } from '@dojo/interfaces/vdom';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { RegistryMixin, RegistryMixinProperties } from '../../../src/mixins/Registry';
-import WidgetRegistry from '../../../src/WidgetRegistry';
-import { WidgetBase } from '../../../src/WidgetBase';
 import { w, v } from '../../../src/d';
-import { VNode } from '@dojo/interfaces/vdom';
-import { spy } from 'sinon';
+import { RegistryMixin, RegistryMixinProperties } from '../../../src/mixins/Registry';
+import { WidgetBase } from '../../../src/WidgetBase';
+import WidgetRegistry from '../../../src/WidgetRegistry';
 
 class TestWithRegistry extends RegistryMixin(WidgetBase)<RegistryMixinProperties> {}
 
@@ -49,14 +48,6 @@ registerSuite({
 				changedPropertyKeys: [ 'foo' ]
 			});
 			assert.equal(instance.registry, registry);
-		},
-		'is excluded from the catch all diffProperties function'() {
-			const registry = new WidgetRegistry();
-			const instance: any = new TestWithRegistry();
-			const diffProps = spy(instance, 'diffProperties');
-			instance.setProperties({ registry });
-			const [ , props ] = diffProps.firstCall.args;
-			assert.deepEqual(props, {});
 		}
 	},
 	integration: {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Changed automatic property diffing to use `DiffType.AUTO`.
- Automatic diff logic is no longer overridable.
- Multiple `@diffProperty` decorators supported on a single property. Decorators run until a changed property is found.

Resolves #404 
