### PR TITLE
Add tag to HNode

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -97,6 +97,7 @@ export function v(tag: string, propertiesOrChildren: VirtualDomProperties = {}, 
 		}
 
 		return {
+			tag,
 			children,
 			properties,
 			render<T>(this: { vNodes: VNode[], properties: VirtualDomProperties }, options: { bind?: T } = { }) {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -252,6 +252,11 @@ export interface HNode {
 	properties: VirtualDomProperties;
 
 	/**
+	 * The tagname used to create the VNode
+	 */
+	tag: string;
+
+	/**
 	 * The type of node
 	 */
 	type: symbol;

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -68,6 +68,7 @@ registerSuite({
 			const hNode = v('div');
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 0);
+			assert.equal(hNode.tag, 'div');
 			assert.equal(hNode.type, HNODE);
 			assert.isTrue(isHNode(hNode));
 			assert.isFalse(isWNode(hNode));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
We currently keep everything but the tag on the `HNode`. The tag may be useful in future for introspection of a `HNode` without having to call the `render` function on it. 
