### PR TITLE
Decorator system enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The depth of the returned diff is equal to the depth used during the equality co
 
 ##### Custom property diff control
 
-Included in `WidgetBase` is functionality to support targeting a specific property with a custom comparison function using a decorator `diffProperty`. For non-decorator environments (Either JavaScript/ES6 or a TypeScript project that does not have the experimental decorators configuration set to true in the `tsconfig`), the functions need to be registered in the constructor using the `addDecorator` API with `diffProperty` as the key.
+Included in `WidgetBase` is functionality to support targeting a specific property with a custom comparison function using a decorator `diffProperty`. For non-decorator environments (Either JavaScript/ES6 or a TypeScript project that does not have the experimental decorators configuration set to true in the `tsconfig`), the decorator functions can be called directly from the constructor.
 
 e.g. for a property `foo` you would add a function to the widget class and either use the decorator function or register the decorator in the `constructor`.
 
@@ -236,7 +236,7 @@ class MyWidget extends WidgetBase<WidgetProperties> {
 
 	constructor() {
 		super();
-		this.addDecorator('diffProperty', { propertyName: 'foo', diffFunction: this.customFooDiff });
+		diffProperty('foo', DiffType.CUSTOM, this.customFooDiff)(this);
 	}
 
 	customFooDiff(previousProperty: MyComplexObject, newProperty: MyComplexObject) {
@@ -272,7 +272,7 @@ class MyWidget extends WidgetBase<WidgetProperties> {
 
 	constructor() {
 		super();
-		this.addDecorator('onPropertiesChanged', this.myPropChangedListener)
+		onPropertiesChanged(this.myPropChangedListener)(this);
 	}
 
 	myPropChangedListener(evt: PropertiesChangeEvent<this, WidgetProperties>) {
@@ -300,7 +300,7 @@ Finally once all the attached events have been processed, the properties lifecyc
 
 ##### AfterRender
 
-Occassionally, in a mixin or base widget class, it my be required to provide logic that needs to be executed using the result of a widget's `render`. `WidgetBase` supports registering functions that opererate as an after aspect to the `render` function using a provided decorator `afterRender` or in non-decorator environments using the `addDecorator` API with `afterRender` as the key.
+Occassionally, in a mixin or base widget class, it my be required to provide logic that needs to be executed using the result of a widget's `render`. `WidgetBase` supports registering functions that opererate as an after aspect to the `render` function using a provided decorator `afterRender` or in non-decorator environments by calling the decorator method directly.
 
 *Using the `afterRender` decorator*
 
@@ -314,13 +314,13 @@ class MyBaseClass extends WidgetBase<WidgetProperties> {
 }
 ```
 
-*Using the `addDecorator` API*
+*Without using decorators*
 
 ```ts
 class MyBaseClass extends WidgetBase<WidgetProperties> {
 	constructor() {
 		super();
-		this.addDecorator('afterRender', this.myOtherAfterRender);
+		afterRender(this.myOtherAfterRender)(this);
 	}
 
 	myOtherAfterRender(result: DNode): DNode {
@@ -330,7 +330,7 @@ class MyBaseClass extends WidgetBase<WidgetProperties> {
 }
 ```
 
-***Note:*** `afterRender` functions are executed in the order that they are specified from the super class up to the final class. Usage of the `afterRender` decorator and `addDecorator` API should not be mixed.
+***Note:*** `afterRender` functions are executed in the order that they are specified from the super class up to the final class.
 
 #### Projector
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -55,10 +55,6 @@ export function afterRender(): (target: any, propertyKey: string) => void;
 export function afterRender(method?: Function) {
 	return function (target: any, propertyKey: any) {
 		if (typeof target === 'function') {
-			if (!method) {
-				throw new Error('method cannot be blank');
-			}
-
 			target.prototype.addDecorator('afterRender', method);
 		}
 		else {
@@ -66,10 +62,6 @@ export function afterRender(method?: Function) {
 				target.addDecorator('afterRender', target[propertyKey]);
 			}
 			else {
-				if (!method) {
-					throw new Error('method cannot be blank');
-				}
-
 				target.addDecorator('afterRender', method);
 			}
 		}
@@ -121,10 +113,6 @@ export function onPropertiesChanged(): (target: any, propertyKey: any) => void;
 export function onPropertiesChanged(method?: Function) {
 	return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
 		if (typeof target === 'function') {
-			if (!method) {
-				throw new Error('method cannot be blank');
-			}
-
 			target.prototype.addDecorator('onPropertiesChanged', method);
 		}
 		else {
@@ -132,10 +120,6 @@ export function onPropertiesChanged(method?: Function) {
 				target.addDecorator('onPropertiesChanged', target[propertyKey]);
 			}
 			else {
-				if (!method) {
-					throw new Error('method cannot be blank');
-				}
-
 				target.addDecorator('onPropertiesChanged', method);
 			}
 		}

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -94,7 +94,7 @@ export function I18nMixin<T extends Constructor<WidgetBase<I18nProperties>>>(bas
 			}), messages) as LocalizedMessages<T>;
 		}
 
-		@afterRender
+		@afterRender()
 		protected renderDecorator(result: DNode): DNode {
 			if (isHNode(result)) {
 				const { locale, rtl } = this.properties;

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -23,7 +23,7 @@ export function RegistryMixin<T extends Constructor<WidgetBase<RegistryMixinProp
 			};
 		}
 
-		@onPropertiesChanged
+		@onPropertiesChanged()
 		protected onPropertiesChanged(evt: PropertiesChangeEvent<this, RegistryMixinProperties>) {
 			if (includes(evt.changedPropertyKeys, 'registry')) {
 				this.registry = evt.properties.registry;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -1,6 +1,6 @@
-import Map from '@dojo/shim/Map';
-import { includes, find } from '@dojo/shim/array';
 import { assign } from '@dojo/core/lang';
+import { includes, find } from '@dojo/shim/array';
+import Map from '@dojo/shim/Map';
 import { Constructor, WidgetProperties, PropertiesChangeEvent } from './../interfaces';
 import { WidgetBase, onPropertiesChanged } from './../WidgetBase';
 
@@ -70,8 +70,13 @@ export interface ThemeableMixin {
  * Decorator for base css classes
  */
 export function theme (theme: {}) {
-	return function(constructor: Function) {
-		constructor.prototype.addDecorator('baseThemeClasses', theme);
+	return function (constructor: any) {
+		if (typeof constructor === 'function') {
+			constructor.prototype.addDecorator('baseThemeClasses', theme);
+		}
+		else {
+			constructor.addDecorator('baseThemeClasses', theme);
+		}
 	};
 }
 
@@ -213,7 +218,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 		 *
 		 * @param changedPropertyKeys Array of properties that have changed
 		 */
-		@onPropertiesChanged
+		@onPropertiesChanged()
 		protected onPropertiesChanged({ changedPropertyKeys }: PropertiesChangeEvent<this, ThemeableProperties>) {
 			const themeChanged = includes(changedPropertyKeys, 'theme');
 			const overrideClassesChanged = includes(changedPropertyKeys, 'overrideClasses');

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -2,7 +2,7 @@ import { assign } from '@dojo/core/lang';
 import { includes, find } from '@dojo/shim/array';
 import Map from '@dojo/shim/Map';
 import { Constructor, WidgetProperties, PropertiesChangeEvent } from './../interfaces';
-import { WidgetBase, onPropertiesChanged } from './../WidgetBase';
+import { WidgetBase, onPropertiesChanged, handleDecorator } from './../WidgetBase';
 
 /**
  * A representation of the css class names to be applied and
@@ -70,14 +70,9 @@ export interface ThemeableMixin {
  * Decorator for base css classes
  */
 export function theme (theme: {}) {
-	return function (constructor: any) {
-		if (typeof constructor === 'function') {
-			constructor.prototype.addDecorator('baseThemeClasses', theme);
-		}
-		else {
-			constructor.addDecorator('baseThemeClasses', theme);
-		}
-	};
+	return handleDecorator((target) => {
+		target.addDecorator('baseThemeClasses', theme);
+	});
 }
 
 /**

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -560,6 +560,27 @@ registerSuite({
 				test: true
 			});
 			assert.strictEqual(called, 1);
+		},
+
+		'extendable'() {
+			let called = false;
+
+function PropertyLogger() {
+	return onPropertiesChanged(function() {
+		called = true;
+	});
+}
+
+@PropertyLogger()
+class TestWidget extends WidgetBase<any> {
+}
+
+const widget = new TestWidget();
+widget.setProperties({
+	test: true
+});
+
+			assert.strictEqual(called, true);
 		}
 	},
 	render: {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -5,8 +5,8 @@ import * as assert from 'intern/chai!assert';
 import { stub, spy } from 'sinon';
 import { v, w, registry } from '../../src/d';
 import { DNode } from '../../src/interfaces';
-import WidgetRegistry from './../../src/WidgetRegistry';
 import { WidgetBase, diffProperty, DiffType, afterRender, onPropertiesChanged } from '../../src/WidgetBase';
+import WidgetRegistry from './../../src/WidgetRegistry';
 
 registerSuite({
 	name: 'WidgetBase',
@@ -116,11 +116,7 @@ registerSuite({
 
 				constructor() {
 					super();
-					this.addDecorator('diffProperty', {
-						propertyName: 'foo',
-						diffType: DiffType.CUSTOM,
-						diffFunction: this.diffPropertyFoo
-					});
+					diffProperty('foo', DiffType.CUSTOM, this.diffPropertyFoo)(this);
 				}
 
 				diffPropertyFoo(this: any, previousProperty: any, newProperty: any): any {
@@ -145,10 +141,10 @@ registerSuite({
 				constructor() {
 					super();
 
-					this.addDecorator('afterRender', (node: DNode) => {
+					afterRender((node: DNode) => {
 						renderCallCount++;
 						return node;
-					});
+					})(this);
 				}
 
 				render() {
@@ -394,12 +390,13 @@ registerSuite({
 		decorator() {
 			let afterRenderCount = 1;
 			class TestWidget extends WidgetBase<any> {
-				@afterRender
+				@afterRender()
 				firstAfterRender(result: DNode): DNode {
 					assert.strictEqual(afterRenderCount++, 1);
 					return result;
 				}
-				@afterRender
+
+				@afterRender()
 				secondAfterRender(result: DNode): DNode {
 					assert.strictEqual(afterRenderCount++, 2);
 					return result;
@@ -407,7 +404,7 @@ registerSuite({
 			}
 
 			class ExtendedTestWidget extends TestWidget {
-				@afterRender
+				@afterRender()
 				thirdAfterRender(result: DNode): DNode {
 					assert.strictEqual(afterRenderCount, 3);
 					return result;
@@ -424,8 +421,8 @@ registerSuite({
 
 				constructor() {
 					super();
-					this.addDecorator('afterRender', this.firstAfterRender);
-					this.addDecorator('afterRender', [ this.secondAfterRender ]);
+					afterRender()(this, 'firstAfterRender');
+					afterRender()(this, 'secondAfterRender');
 				}
 
 				firstAfterRender(result: DNode): DNode {
@@ -443,7 +440,7 @@ registerSuite({
 
 				constructor() {
 					super();
-					this.addDecorator('afterRender', this.thirdAfterRender);
+					afterRender(this.thirdAfterRender)(this);
 				}
 
 				thirdAfterRender(result: DNode): DNode {
@@ -455,24 +452,60 @@ registerSuite({
 			const widget = new ExtendedTestWidget();
 			widget.__render__();
 			assert.strictEqual(afterRenderCount, 3);
+		},
+		'class level decorator'() {
+			let afterRenderCount = 0;
+
+			@afterRender(function (node: any) {
+				afterRenderCount++;
+				return node;
+			})
+			class TestWidget extends WidgetBase<any> {
+			}
+
+			const widget = new TestWidget();
+			widget.__render__();
+			assert.strictEqual(afterRenderCount, 1);
+		},
+
+		'class level without decorator'() {
+			let afterRenderCount = 0;
+
+			function afterRenderFn(node: any) {
+				afterRenderCount++;
+
+				return node;
+			}
+
+			class TestWidget extends WidgetBase<any> {
+				constructor() {
+					super();
+					afterRender(afterRenderFn)(this);
+				}
+			}
+
+			const widget = new TestWidget();
+			widget.__render__();
+			assert.strictEqual(afterRenderCount, 1);
 		}
 	},
 	'properties:changed event': {
 		decorator() {
 			let onPropertiesChangedCount = 1;
 			class TestWidget extends WidgetBase<any> {
-				@onPropertiesChanged
+				@onPropertiesChanged()
 				firstOnPropertiesChanged() {
 					assert.strictEqual(onPropertiesChangedCount++, 1);
 				}
-				@onPropertiesChanged
+
+				@onPropertiesChanged()
 				secondOnPropertiesChanged() {
 					assert.strictEqual(onPropertiesChangedCount++, 2);
 				}
 			}
 
 			class ExtendedTestWidget extends TestWidget {
-				@onPropertiesChanged
+				@onPropertiesChanged()
 				thirdOnPropertiesChanged() {
 					assert.strictEqual(onPropertiesChangedCount, 3);
 				}
@@ -488,8 +521,8 @@ registerSuite({
 			class TestWidget extends WidgetBase<any> {
 				constructor() {
 					super();
-					this.addDecorator('onPropertiesChanged', this.firstOnPropertiesChanged);
-					this.addDecorator('onPropertiesChanged', this.secondOnPropertiesChanged);
+					onPropertiesChanged(this.firstOnPropertiesChanged)(this);
+					onPropertiesChanged(this.secondOnPropertiesChanged)(this);
 				}
 				firstOnPropertiesChanged() {
 					assert.strictEqual(onPropertiesChangedCount++, 1);
@@ -502,7 +535,7 @@ registerSuite({
 			class ExtendedTestWidget extends TestWidget {
 				constructor() {
 					super();
-					this.addDecorator('onPropertiesChanged', this.thirdOnPropertiesChanged);
+					onPropertiesChanged(this.thirdOnPropertiesChanged)(this);
 				}
 				thirdOnPropertiesChanged() {
 					assert.strictEqual(onPropertiesChangedCount, 3);
@@ -1059,7 +1092,7 @@ registerSuite({
 	},
 	'decorators are cached'() {
 		class TestWidget extends WidgetBase<any> {
-			@afterRender
+			@afterRender()
 			running(result: DNode): DNode {
 				return result;
 			}
@@ -1086,7 +1119,7 @@ registerSuite({
 	},
 	'decorators applied to subclasses are not applied to base classes'() {
 		class TestWidget extends WidgetBase<any> {
-			@afterRender
+			@afterRender()
 			firstRender(result: DNode): DNode {
 				return result;
 			}
@@ -1097,7 +1130,7 @@ registerSuite({
 		}
 
 		class TestWidget2 extends TestWidget {
-			@afterRender
+			@afterRender()
 			secondRender(result: DNode): DNode {
 				return result;
 			}

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -467,7 +467,6 @@ registerSuite({
 			widget.__render__();
 			assert.strictEqual(afterRenderCount, 1);
 		},
-
 		'class level without decorator'() {
 			let afterRenderCount = 0;
 
@@ -545,6 +544,22 @@ registerSuite({
 			const widget = new ExtendedTestWidget();
 			widget.emit({ type: 'properties:changed' });
 			assert.strictEqual(onPropertiesChangedCount, 3);
+		},
+
+		'class level decorator'() {
+			let called = 0;
+
+			@onPropertiesChanged(function () {
+				called++;
+			})
+			class TestWidget extends WidgetBase<any> {
+			}
+
+			const widget = new TestWidget();
+			widget.setProperties({
+				test: true
+			});
+			assert.strictEqual(called, 1);
 		}
 	},
 	render: {

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -36,30 +36,30 @@ class DuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<ThemeableProp
 class NonDecoratorTestWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> {
 	constructor() {
 		super();
-		this.addDecorator('baseThemeClasses', baseThemeClasses1);
+		theme(baseThemeClasses1)(this);
 	}
 }
 
 class NonDecoratorSubClassTestWidget extends NonDecoratorTestWidget {
 	constructor() {
 		super();
-		this.addDecorator('baseThemeClasses', baseThemeClasses2);
+		theme(baseThemeClasses2)(this);
 	}
 }
 
 class NonDecoratorStackedTestWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> {
 	constructor() {
 		super();
-		this.addDecorator('baseThemeClasses', baseThemeClasses1);
-		this.addDecorator('baseThemeClasses', baseThemeClasses2);
+		theme(baseThemeClasses1)(this);
+		theme(baseThemeClasses2)(this);
 	}
 }
 
 class NonDecoratorDuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> {
 	constructor() {
 		super();
-		this.addDecorator('baseThemeClasses', baseThemeClasses1);
-		this.addDecorator('baseThemeClasses', baseThemeClasses3);
+		theme(baseThemeClasses1)(this);
+		theme(baseThemeClasses3)(this);
 	}
 }
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Enhancements to base decorators `theme`, `afterRender`, `onPropertiesChanged`, `diffProperty`.  This removes the usage of `this.addDecorator` and calls decorator methods directly:

```typescript
class MyWidget extends WidgetBase<any> {
    constructor() {
        super();
        afterRender(this.afterFn)(this);
    }

    afterFn(node: any) {
        return node;
    }
}
```

As a side effect, we can also call `onPropertiesChanged` on a class level, rather than just a function level:

```typescript
function PropertyLogger() {
    return onPropertiesChanged(function(event) {
        console.log("Properties Changed", event);
    });
}

@PropertyLogger()
class TestWidget extends WidgetBase<any> {
}
```

**Note that this is a breaking change as it requires all decorators that previously did not require a factory call to now require a factory call.**

```typescript
// Old
class TestWidget extends WidgetBase<any> {
    @afterRender
    myAfterRender() {
    }
}

// New
class TestWidget extends WidgetBase<any> {
    @afterRender()
    myAfterRender() {
    }
}
```

Resolves #402 
