### PR TITLE
Adding a render:rendered event, issue #409

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ w('my-widget', properties, children);
 The example above that uses a string for the `widgetConstructor `, is taking advantage of our [widget registry](#widget-registry) functionality.
 The widget registry allows for the lazy instantiation of widgets.
 
+### Responding to Render Events
+
+Sometimes you may want to be notified when a widget is rendered. Widgets will emit a `render:rendered` event with the result of the render operation.
+
+```typescript
+widget.on('render:rendered', event => {
+    // handle render event
+});
+```
+
 ### Writing Custom Widgets
 
 The `WidgetBase` class provides the functionality needed to create Custom Widgets.

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -17,7 +17,8 @@ import {
 	PropertyChangeRecord,
 	PropertiesChangeRecord,
 	PropertiesChangeEvent,
-	HNode
+	HNode,
+	RenderRenderedEvent
 } from './interfaces';
 import WidgetRegistry, { WIDGET_BASE_TYPE } from './WidgetRegistry';
 
@@ -43,6 +44,7 @@ interface DiffPropertyConfig {
 
 export interface WidgetBaseEvents<P extends WidgetProperties> extends BaseEventedEvents {
 	(type: 'properties:changed', handler: EventedListenerOrArray<WidgetBase<P>, PropertiesChangeEvent<WidgetBase<P>, P>>): Handle;
+	(type: 'render:rendered', handler: EventedListenerOrArray<WidgetBase<P>, RenderRenderedEvent<WidgetBase<P>, P>>): Handle;
 }
 
 const decoratorMap = new Map<Function, Map<string, any[]>>();
@@ -350,8 +352,21 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			if (widget) {
 				this._cachedVNode = widget;
 			}
+
+			this.emit({
+				type: 'render:rendered',
+				result: widget,
+				target: this
+			});
+
 			return widget;
 		}
+
+		this.emit({
+			type: 'render:rendered',
+			result: this._cachedVNode,
+			target: this
+		});
 		return this._cachedVNode;
 	}
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -352,22 +352,17 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			if (widget) {
 				this._cachedVNode = widget;
 			}
-
-			this.emit({
-				type: 'render:rendered',
-				result: widget,
-				target: this
-			});
-
-			return widget;
 		}
+
+		const result = this._cachedVNode || null;
 
 		this.emit({
 			type: 'render:rendered',
-			result: this._cachedVNode,
+			result,
 			target: this
 		});
-		return this._cachedVNode;
+
+		return result;
 	}
 
 	public invalidate(): void {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,6 +1,6 @@
-import { VNode, VNodeProperties, ProjectionOptions } from '@dojo/interfaces/vdom';
-import { EventTypedObject } from '@dojo/interfaces/core';
 import { Evented } from '@dojo/core/Evented';
+import { EventTypedObject } from '@dojo/interfaces/core';
+import { VNode, VNodeProperties, ProjectionOptions } from '@dojo/interfaces/vdom';
 
 /**
  * Generic constructor type
@@ -304,6 +304,20 @@ export interface PropertiesChangeEvent<T, P extends WidgetProperties> extends Ev
 	 * the changed properties between setProperty calls
 	 */
 	changedPropertyKeys: string[];
+	/**
+	 * the target (this)
+	 */
+	target: T;
+}
+
+/**
+ * The event emitted on render:rendered
+ */
+export interface RenderRenderedEvent<T, P extends WidgetProperties> extends EventTypedObject<'render:rendered'> {
+	/**
+	 * The result of the render operation
+	 */
+	result: VNode | string | undefined;
 	/**
 	 * the target (this)
 	 */

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1177,5 +1177,29 @@ widget.setProperties({
 
 		assert.equal(testWidget.getAfterRenders().length, 2);
 		assert.equal(testWidget2.getAfterRenders().length, 3);
+	},
+
+	'render:rendered'() {
+		const callOrder: string[] = [];
+
+		class TestWidget extends WidgetBase<any> {
+			render() {
+				callOrder.push('render');
+				return 'test';
+			}
+		}
+
+		const widget = new TestWidget();
+
+		widget.on('render:rendered', event => {
+			callOrder.push('render:rendered');
+
+			assert.strictEqual(event.target, widget);
+			assert.strictEqual(event.result, 'test');
+		});
+
+		widget.__render__();
+
+		assert.deepEqual(callOrder, ['render', 'render:rendered']);
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding a `render:rendered` event that is emitted with the final result of the `__render__` method.

```typescript
widget.on('render:rendered', event => {
    console.log('rendered ', event.result);
});
```

Note that this will get emitted whether or not the result was cached. Calling `__render__` will **always** emit this event.

Resolves #409 
