### PR TITLE
Removing render:scheduled event

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -182,10 +182,6 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 
 		public scheduleRender() {
 			if (this.projectorState === ProjectorAttachState.Attached && !this._scheduled && !this._paused) {
-				this.emit({
-					type: 'render:scheduled',
-					target: this
-				});
 				this._scheduled = global.requestAnimationFrame(this._boundDoRender);
 			}
 		}

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -148,26 +148,13 @@ registerSuite({
 		assert.equal(projector.root, root);
 	},
 	'pause'() {
-
-		let called = false;
-
-		class RenderCapturingWidget extends TestWidget {
-			public scheduleRender() {
-				super.scheduleRender();
-
-				if ((<any> this)._scheduled) {
-					called = true;
-				}
-			}
-		}
-
-		const projector = new RenderCapturingWidget();
+		const projector = new TestWidget();
 
 		projector.append();
 
 		projector.pause();
 		projector.scheduleRender();
-		assert.isFalse(called);
+		assert.isFalse(rafSpy.called);
 	},
 	'pause cancels animation frame if scheduled'() {
 		const projector = new TestWidget();
@@ -232,43 +219,18 @@ registerSuite({
 		assert.isTrue(called);
 	},
 	'invalidate before attached'() {
-
-		let called = false;
-
-		class RenderCapturingWidget extends TestWidget {
-			public scheduleRender() {
-				super.scheduleRender();
-
-				if ((<any> this)._scheduled) {
-					called = true;
-				}
-			}
-		}
-
-		const projector: any = new RenderCapturingWidget();
+		const projector: any = new TestWidget();
 
 		projector.invalidate();
 
-		assert.isFalse(called);
+		assert.isFalse(rafSpy.called);
 	},
 	'invalidate after attached'() {
-		let called = false;
-
-		class RenderCapturingWidget extends TestWidget {
-			public scheduleRender() {
-				super.scheduleRender();
-
-				if ((<any> this)._scheduled) {
-					called = true;
-				}
-			}
-		}
-
-		const projector: any = new RenderCapturingWidget();
+		const projector: any = new TestWidget();
 
 		projector.append();
 		projector.invalidate();
-		assert.isTrue(called);
+		assert.isTrue(rafSpy.called);
 	},
 	'reattach'() {
 		const root = document.createElement('div');

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -148,11 +148,20 @@ registerSuite({
 		assert.equal(projector.root, root);
 	},
 	'pause'() {
-		const projector = new TestWidget();
+
 		let called = false;
-		projector.on('render:scheduled', () => {
-			called = true;
-		});
+
+		class RenderCapturingWidget extends TestWidget {
+			public scheduleRender() {
+				super.scheduleRender();
+
+				if ((<any> this)._scheduled) {
+					called = true;
+				}
+			}
+		}
+
+		const projector = new RenderCapturingWidget();
 
 		projector.append();
 
@@ -223,24 +232,39 @@ registerSuite({
 		assert.isTrue(called);
 	},
 	'invalidate before attached'() {
-		const projector: any = new TestWidget();
+
 		let called = false;
 
-		projector.on('render:scheduled', () => {
-			called = true;
-		});
+		class RenderCapturingWidget extends TestWidget {
+			public scheduleRender() {
+				super.scheduleRender();
+
+				if ((<any> this)._scheduled) {
+					called = true;
+				}
+			}
+		}
+
+		const projector: any = new RenderCapturingWidget();
 
 		projector.invalidate();
 
 		assert.isFalse(called);
 	},
 	'invalidate after attached'() {
-		const projector: any = new TestWidget();
 		let called = false;
 
-		projector.on('render:scheduled', () => {
-			called = true;
-		});
+		class RenderCapturingWidget extends TestWidget {
+			public scheduleRender() {
+				super.scheduleRender();
+
+				if ((<any> this)._scheduled) {
+					called = true;
+				}
+			}
+		}
+
+		const projector: any = new RenderCapturingWidget();
 
 		projector.append();
 		projector.invalidate();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removing `render:scheduled` event from the projector. Since it was only used for testing, we can get away with reproducing the functionality with subclasses.

Resolves #430 

