### PR TITLE
Call to create classes outside the render in 'v' when creating a 'HNode'

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -109,7 +109,7 @@ export function v(tag: string, propertiesOrChildren: VirtualDomProperties = {}, 
 			properties,
 			render<T>(this: { vNodes: VNode[], properties: VirtualDomProperties }, options: { bind?: T } = { }) {
 
-				return h(tag, assign(options, properties), this.vNodes);
+				return h(tag, assign(options, this.properties), this.vNodes);
 			},
 			type: HNODE
 		};

--- a/src/d.ts
+++ b/src/d.ts
@@ -96,19 +96,18 @@ export function v(tag: string, propertiesOrChildren: VirtualDomProperties = {}, 
 			properties = {};
 		}
 
+		if (properties) {
+			let { classes } = properties;
+			if (typeof classes === 'function') {
+				classes = classes();
+				properties = assign(properties, { classes });
+			}
+		}
+
 		return {
 			children,
 			properties,
 			render<T>(this: { vNodes: VNode[], properties: VirtualDomProperties }, options: { bind?: T } = { }) {
-				let properties = this.properties;
-
-				if (this.properties) {
-					let { classes } = this.properties;
-					if (typeof classes === 'function') {
-						classes = classes();
-						properties = assign(this.properties, { classes });
-					}
-				}
 
 				return h(tag, assign(options, properties), this.vNodes);
 			},

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -112,9 +112,7 @@ registerSuite({
 				return { foo: true };
 			};
 			const hNode = v('div', { classes });
-			assert.isFunction(hNode.properties.classes);
-			const result = hNode.render();
-			assert.deepEqual(result.properties, {
+			assert.deepEqual(hNode.properties, {
 				classes: {
 					foo: true
 				}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Moves the call to `properties.classes` when it's a function to outside the `render` on a `HNode`.

Resolves #433 
