### PR TITLE
Do not bind widget constructors passed as parameters

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -17,7 +17,7 @@ import {
 	PropertiesChangeEvent,
 	HNode
 } from './interfaces';
-import WidgetRegistry, { WIDGET_BASE_TYPE } from './WidgetRegistry';
+import WidgetRegistry, { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './WidgetRegistry';
 
 export { DiffType };
 
@@ -486,7 +486,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			const property = properties[propertyKey];
 			const bind = properties.bind;
 
-			if (typeof property === 'function') {
+			if (typeof property === 'function' && !isWidgetBaseConstructor(property)) {
 				const bindInfo = this._bindFunctionPropertyMap.get(property) || {};
 				let { boundFunc, scope } = bindInfo;
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -6,7 +6,7 @@ import { stub, spy } from 'sinon';
 import { v, w, registry } from '../../src/d';
 import { DNode } from '../../src/interfaces';
 import { WidgetBase, diffProperty, DiffType, afterRender, beforeRender, onPropertiesChanged } from '../../src/WidgetBase';
-import WidgetRegistry from './../../src/WidgetRegistry';
+import WidgetRegistry, { WIDGET_BASE_TYPE } from './../../src/WidgetRegistry';
 
 registerSuite({
 	name: 'WidgetBase',
@@ -473,6 +473,31 @@ registerSuite({
 			} catch (e) {
 				assert.strictEqual(testWidget.count, 0);
 			}
+		},
+		'widget constructors are not bound'() {
+			const widgetConstructorSpy: any = function(this: any) {
+				this.functionIsBound = true;
+			};
+			widgetConstructorSpy._type = WIDGET_BASE_TYPE;
+
+			class TestWidget extends WidgetBase<any> {
+				functionIsBound = false;
+
+				public callWidgetSpy() {
+					this.properties.widgetConstructorSpy();
+				}
+			}
+
+			const testWidget = new TestWidget();
+			const properties = {
+				bind: testWidget,
+				widgetConstructorSpy,
+				functionIsBound: false
+			};
+			testWidget.setProperties(properties);
+			testWidget.callWidgetSpy();
+			assert.isFalse(testWidget.functionIsBound);
+			assert.isTrue(testWidget.properties.functionIsBound);
 		}
 	},
 	beforeRender: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Do not bind widget constructors that are passed as parameters, doing so on iOS 9.3 and other older platform/browsers causes the static type used to sniff widget constructors to be erased.

A potentially more robust change would be to create an interface for the registry items, like:

```ts
export interface WidgetRegistryItemWrapper {
	widgetConstructor?: WidgetConstructor | Promise<WidgetConstructor>;
	lazyWidgetConstructor?: WidgetConstructorFunction;
}
```

Which means we can amend the `registry.define` API to accept the wrapper or similar.

```ts
	define(widgetLabel: string, registryItem: WidgetRegistryItemWrapper): void;
```

I'm not sure how to test that a named function hasn't been bound to a scope (called `WidgetConstructor()` errors and `new WidgetConstructor()` gives nothing to test that the class wasn't bound to a scope)

Resolves #442
