### PR TITLE
Align `w` API with `v` API

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -70,9 +70,19 @@ export const registry = new WidgetRegistry();
 /**
  * Wrapper function for calls to create a widget.
  */
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: P): WNode;
 export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: P, children?: DNode[]): WNode;
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: P, children?: DNode[]): WNode {
+export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: P): WNode;
+export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string): WNode;
+export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, propertiesOrChildren: P | DNode[] = <P> {}, children: DNode[] = []): WNode {
+		let properties: P;
+
+	if (Array.isArray(propertiesOrChildren)) {
+		children = propertiesOrChildren;
+		properties = <P> {};
+	}
+	else {
+		properties = propertiesOrChildren;
+	}
 
 	return {
 		children,
@@ -88,8 +98,8 @@ export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConst
 export function v(tag: string, properties: VirtualDomProperties, children?: DNode[]): HNode;
 export function v(tag: string, children: DNode[]): HNode;
 export function v(tag: string): HNode;
-export function v(tag: string, propertiesOrChildren: VirtualDomProperties = {}, children: DNode[] = []): HNode {
-		let properties = propertiesOrChildren;
+export function v(tag: string, propertiesOrChildren: VirtualDomProperties | DNode[] = {}, children: DNode[] = []): HNode {
+		let properties: VirtualDomProperties = propertiesOrChildren;
 
 		if (Array.isArray(propertiesOrChildren)) {
 			children = propertiesOrChildren;

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -239,7 +239,7 @@ export interface HNode {
 	/**
 	 * Specified children
 	 */
-	children: (DNode | string)[];
+	children: DNode[];
 
 	/**
 	 * render function that wraps returns VNode
@@ -279,7 +279,7 @@ export interface WNode {
 	/**
 	 * DNode children
 	 */
-	children?: DNode[];
+	children: DNode[];
 
 	/**
 	 * The type of node

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -33,32 +33,82 @@ registerSuite({
 		assert.isObject(registry);
 	},
 	w: {
-		'create WNode wrapper'() {
+		'create WNode wrapper with constructor'() {
+			const dNode = w(WidgetBase);
+			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
+			assert.deepEqual(dNode.properties, {});
+			assert.equal(dNode.type, WNODE);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper with label'() {
+			const dNode = w('my-widget');
+
+			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
+			assert.deepEqual(dNode.properties, {});
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper using constructor with properties'() {
 			const properties: any = { id: 'id', classes: [ 'world' ] };
 			const dNode = w(WidgetBase, properties);
+
+			assert.equal(dNode.type, WNODE);
 			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
-			assert.equal(dNode.type, WNODE);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
-		'create WNode wrapper using a factory label'() {
-			registry.define('my-widget', WidgetBase);
+		'create WNode wrapper using label with properties'() {
 			const properties: any = { id: 'id', classes: [ 'world' ] };
 			const dNode = w('my-widget', properties);
-			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
-			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ] });
+
 			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
-		'create WNode wrapper with children'() {
+		'create WNode wrapper using constructor with children'() {
+			const properties: any = { id: 'id', classes: [ 'world' ] };
+			const dNode = w(WidgetBase, [ w(WidgetBase, properties) ]);
+
+			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
+			assert.lengthOf(dNode.children, 1);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper using label with children'() {
+			const properties: any = { id: 'id', classes: [ 'world' ] };
+			const dNode = w('my-widget', [ w(WidgetBase, properties) ]);
+
+			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
+			assert.lengthOf(dNode.children, 1);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper using constructor with properties and children'() {
 			const properties: any = { id: 'id', classes: [ 'world' ] };
 			const dNode = w(WidgetBase, properties, [ w(WidgetBase, properties) ]);
-			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
-			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ] });
-			assert.lengthOf(dNode.children, 1);
+
 			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.lengthOf(dNode.children, 1);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper using label with properties and children'() {
+			const properties: any = { id: 'id', classes: [ 'world' ] };
+			const dNode = w('my-widget', properties, [ w(WidgetBase, properties) ]);
+
+			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Extend `w` to make `properties` optional and allow `children` to be passed as the second parameter.

Resolves #439 
