### PR TITLE
Update `setChildren` & `setProperties` to use the double underscore naming convention.

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -588,7 +588,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 			}
 
 			if (Array.isArray(children)) {
-				child.setChildren(children);
+				child.__setChildren__(children);
 			}
 			return child.__render__();
 		}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -280,7 +280,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		return this._properties;
 	}
 
-	public setProperties(properties: P): void {
+	public __setProperties__(properties: P): void {
 		const diffPropertyResults: { [index: string]: any } = {};
 		const diffPropertyChangedKeys: string[] = [];
 
@@ -357,7 +357,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		return this._children;
 	}
 
-	public setChildren(children: DNode[]): void {
+	public __setChildren__(children: DNode[]): void {
 		this._dirty = true;
 		this._children = children;
 		this.emit({

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -568,12 +568,12 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 
 			if (cachedChild) {
 				child = cachedChild.child;
-				child.setProperties(properties);
+				child.__setProperties__(properties);
 				cachedChild.used = true;
 			}
 			else {
 				child = new widgetConstructor();
-				child.setProperties(properties);
+				child.__setProperties__(properties);
 				child.own(child.on('invalidated', () => {
 					this.invalidate();
 				}));

--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -176,7 +176,7 @@ export function initializeElement(element: CustomElement) {
 			},
 			set(value: any) {
 				const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attribute.attributeName, value, attribute);
-				element.getWidgetInstance().setProperties(assign({}, element.getWidgetInstance().properties, {
+				element.getWidgetInstance().__setProperties__(assign({}, element.getWidgetInstance().properties, {
 					[propertyName]: propertyValue
 				}));
 			}
@@ -196,7 +196,7 @@ export function initializeElement(element: CustomElement) {
 			},
 
 			set(value: any) {
-				element.getWidgetInstance().setProperties(assign(
+				element.getWidgetInstance().__setProperties__(assign(
 					{},
 					element.getWidgetInstance().properties,
 					{ [widgetPropertyName]: setValue ? setValue(value) : value }
@@ -242,7 +242,7 @@ export function initializeElement(element: CustomElement) {
 	const projector = ProjectorMixin(element.getWidgetConstructor());
 
 	const widgetInstance = new projector();
-	widgetInstance.setProperties(initialProperties);
+	widgetInstance.__setProperties__(initialProperties);
 	widgetInstance.__setChildren__(children);
 	element.setWidgetInstance(widgetInstance);
 
@@ -263,7 +263,7 @@ export function handleAttributeChanged(element: CustomElement, name: string, new
 	attributes.forEach((attribute) => {
 		if (attribute.attributeName === name) {
 			const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(name, newValue, attribute);
-			element.getWidgetInstance().setProperties(assign(
+			element.getWidgetInstance().__setProperties__(assign(
 				{},
 				element.getWidgetInstance().properties,
 				{ [propertyName]: propertyValue }

--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -243,7 +243,7 @@ export function initializeElement(element: CustomElement) {
 
 	const widgetInstance = new projector();
 	widgetInstance.setProperties(initialProperties);
-	widgetInstance.setChildren(children);
+	widgetInstance.__setChildren__(children);
 	element.setWidgetInstance(widgetInstance);
 
 	widgetInstance.append(element);

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -359,12 +359,12 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	 *
 	 * @param properties The new widget properties
 	 */
-	setProperties(properties: P & { [index: string]: any }): void;
+	__setProperties__(properties: P & { [index: string]: any }): void;
 
 	/**
 	 * Sets the widget's children
 	 */
-	setChildren(children: DNode[]): void;
+	__setChildren__(children: DNode[]): void;
 
 	/**
 	 * Main internal function for dealing with widget rendering

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -3,7 +3,7 @@ import { Handle } from '@dojo/interfaces/core';
 import { dom, Projection, ProjectionOptions, VNodeProperties } from 'maquette';
 import 'pepjs';
 import cssTransitions from '../animations/cssTransitions';
-import { Constructor, WidgetProperties } from './../interfaces';
+import { Constructor, DNode, WidgetProperties } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
 
 /**
@@ -37,7 +37,7 @@ export interface AttachOptions {
 	root?: Element;
 }
 
-export interface ProjectorMixin {
+export interface ProjectorMixin<P extends WidgetProperties> {
 
 	/**
 	 * Append the projector to the root.
@@ -68,6 +68,21 @@ export interface ProjectorMixin {
 	 * Schedule a render.
 	 */
 	scheduleRender(): void;
+
+	/**
+	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
+	 * previous properties. Runs though any registered specific property diff functions collecting the results and then
+	 * runs the remainder through the catch all diff function. The aggregate of the two sets of the results is then
+	 * set as the widget's properties
+	 *
+	 * @param properties The new widget properties
+	 */
+	setProperties(properties: P & { [index: string]: any }): void;
+
+	/**
+	 * Sets the widget's children
+	 */
+	setChildren(children: DNode[]): void;
 
 	/**
 	 * Root element to attach the projector
@@ -107,7 +122,7 @@ const eventHandlers = [
 	'onsubmit'
 ];
 
-export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<ProjectorMixin> {
+export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T): T & Constructor<ProjectorMixin<P>> {
 	return class extends base {
 
 		public projectorState: ProjectorAttachState;
@@ -195,6 +210,14 @@ export function ProjectorMixin<T extends Constructor<WidgetBase<WidgetProperties
 
 		public get root(): Element {
 			return this._root;
+		}
+
+		public setChildren(children: DNode[]): void {
+			super.__setChildren__(children);
+		}
+
+		public setProperties(properties: P & { [index: string]: any }): void {
+			super.__setProperties__(properties);
 		}
 
 		public __render__() {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -25,7 +25,7 @@ registerSuite({
 		});
 
 		assert.lengthOf(widget.children, 0);
-		widget.setChildren([expectedChild]);
+		widget.__setChildren__([expectedChild]);
 		assert.lengthOf(widget.children, 1);
 		assert.strictEqual(widget.children[0], expectedChild);
 		assert.isTrue(childrenEventEmitted);

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -38,44 +38,44 @@ registerSuite({
 	diffProperties: {
 		'no updated properties'() {
 			const widgetBase = new WidgetBase();
-			widgetBase.setProperties({ id: 'id', foo: 'bar' });
+			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
 				assert.lengthOf(result.changedPropertyKeys, 0);
 			});
 
-			widgetBase.setProperties({ id: 'id', foo: 'bar' });
+			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 		},
 		'updated properties'() {
 			const widgetBase = new WidgetBase();
-			widgetBase.setProperties({ id: 'id', foo: 'bar' });
+			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
 				assert.lengthOf(result.changedPropertyKeys, 1);
 			});
 
-			widgetBase.setProperties({ id: 'id', foo: 'baz' });
+			widgetBase.__setProperties__({ id: 'id', foo: 'baz' });
 		},
 		'new properties'() {
 			const widgetBase = new WidgetBase();
-			widgetBase.setProperties({ id: 'id', foo: 'bar' });
+			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
 				assert.lengthOf(result.changedPropertyKeys, 1);
 			});
 
-			widgetBase.setProperties({ id: 'id', foo: 'bar', bar: 'baz' });
+			widgetBase.__setProperties__({ id: 'id', foo: 'bar', bar: 'baz' });
 		},
 		'updated / new properties with falsy values'() {
 			const widgetBase = new WidgetBase();
-			widgetBase.setProperties({ id: 'id', foo: 'bar' });
+			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
 				assert.lengthOf(result.changedPropertyKeys, 4);
 				assert.deepEqual(result.changedPropertyKeys, ['foo', 'bar', 'baz', 'qux']);
 			});
 
-			widgetBase.setProperties({ id: 'id', foo: '', bar: null, baz: 0, qux: false });
+			widgetBase.__setProperties__({ id: 'id', foo: '', bar: null, baz: 0, qux: false });
 		}
 	},
 	diffProperty: {
@@ -98,7 +98,7 @@ registerSuite({
 				}
 
 				const testWidget = new TestWidget();
-				testWidget.setProperties({ foo: 'bar' });
+				testWidget.__setProperties__({ foo: 'bar' });
 				testWidget.__render__();
 				assert.equal(callCount, 1);
 				assert.equal(value, 'new-value');
@@ -120,7 +120,7 @@ registerSuite({
 			}
 
 			const testWidget = new TestWidget();
-			testWidget.setProperties({ foo: 'bar' });
+			testWidget.__setProperties__({ foo: 'bar' });
 
 			assert.equal(callCount, 1);
 		},
@@ -145,7 +145,7 @@ registerSuite({
 			}
 
 			const testWidget = new TestWidget();
-			testWidget.setProperties({ foo: 'bar' });
+			testWidget.__setProperties__({ foo: 'bar' });
 
 			assert.equal(callCount, 1);
 		},
@@ -201,7 +201,7 @@ registerSuite({
 			}
 
 			const widget = new SubWidget();
-			widget.setProperties({
+			widget.__setProperties__({
 				prop: true
 			});
 
@@ -224,7 +224,7 @@ registerSuite({
 				assert.deepEqual(result.changedPropertyKeys, ['anotherProp']);
 			});
 
-			widget.setProperties({
+			widget.__setProperties__({
 				prop: true,
 				anotherProp: true
 			});
@@ -232,7 +232,7 @@ registerSuite({
 
 		'properties that are deleted dont get returned'() {
 			const widget = new WidgetBase<any>();
-			widget.setProperties({
+			widget.__setProperties__({
 				a: 1,
 				b: 2,
 				c: 3
@@ -240,7 +240,7 @@ registerSuite({
 
 			assert.deepEqual(widget.properties, { a: 1, b: 2, c: 3 });
 
-			widget.setProperties({
+			widget.__setProperties__({
 				a: 4,
 				c: 5
 			});
@@ -270,14 +270,14 @@ registerSuite({
 			}
 
 			const widget = new TestWidget();
-			widget.setProperties({ foo: 'bar', baz: 'qux' });
+			widget.__setProperties__({ foo: 'bar', baz: 'qux' });
 
 			widget.on('properties:changed', (event: any) => {
 				assert.include(event.changedPropertyKeys, 'foo');
 				assert.notInclude(event.changedPropertyKeys, 'baz');
 			});
 
-			widget.setProperties({ foo: 'bar', baz: 'bar' });
+			widget.__setProperties__({ foo: 'bar', baz: 'bar' });
 		},
 		'widgets function properties are bound to the parent by default'() {
 			class TestChildWidget extends WidgetBase<any> {
@@ -494,7 +494,7 @@ registerSuite({
 				widgetConstructorSpy,
 				functionIsBound: false
 			};
-			testWidget.setProperties(properties);
+			testWidget.__setProperties__(properties);
 			testWidget.callWidgetSpy();
 			assert.isFalse(testWidget.functionIsBound);
 			assert.isTrue(testWidget.properties.functionIsBound);
@@ -730,7 +730,7 @@ registerSuite({
 			}
 
 			const widget = new TestWidget();
-			widget.setProperties({
+			widget.__setProperties__({
 				test: true
 			});
 			assert.strictEqual(called, 1);
@@ -750,7 +750,7 @@ class TestWidget extends WidgetBase<any> {
 }
 
 const widget = new TestWidget();
-widget.setProperties({
+widget.__setProperties__({
 	test: true
 });
 
@@ -1035,7 +1035,7 @@ widget.setProperties({
 			const secondRenderChild: any = secondRenderResult.children && secondRenderResult.children[0];
 			assert.strictEqual(secondRenderChild.vnodeSelector, 'footer');
 
-			widget.setProperties(<any> { hide: true });
+			widget.__setProperties__(<any> { hide: true });
 			widget.invalidate();
 
 			const thirdRenderResult = <VNode> widget.__render__();
@@ -1043,7 +1043,7 @@ widget.setProperties({
 			assert.strictEqual(countWidgetDestroyed, 4);
 			assert.lengthOf(thirdRenderResult.children, 0);
 
-			widget.setProperties(<any> { hide: false });
+			widget.__setProperties__(<any> { hide: false });
 			widget.invalidate();
 
 			const lastRenderResult = <VNode> widget.__render__();
@@ -1087,13 +1087,13 @@ widget.setProperties({
 			};
 
 			const myWidget = new WidgetBase<any>();
-			myWidget.setProperties(properties);
+			myWidget.__setProperties__(properties);
 			assert.deepEqual((<any> myWidget.properties).items, [ 'a', 'b' ]);
 			properties.items.push('c');
-			myWidget.setProperties(properties);
+			myWidget.__setProperties__(properties);
 			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c' ]);
 			properties.items.push('d');
-			myWidget.setProperties(properties);
+			myWidget.__setProperties__(properties);
 			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c', 'd' ]);
 		},
 		'__render__ with internally updated array state'() {
@@ -1104,16 +1104,16 @@ widget.setProperties({
 			};
 
 			const myWidget: any = new WidgetBase();
-			myWidget.setProperties(properties);
+			myWidget.__setProperties__(properties);
 			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.properties).items, [ 'a', 'b' ]);
-			myWidget.setProperties(<any> { items: [ 'a', 'b', 'c'] });
+			myWidget.__setProperties__(<any> { items: [ 'a', 'b', 'c'] });
 			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c' ]);
 		},
 		'__render__() and invalidate()'() {
 			const widgetBase: any = new WidgetBase();
-			widgetBase.setProperties({ id: 'foo', label: 'foo' });
+			widgetBase.__setProperties__({ id: 'foo', label: 'foo' });
 			const result1 = <VNode> widgetBase.__render__();
 			const result2 = <VNode> widgetBase.__render__();
 			widgetBase.invalidate();

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -172,7 +172,7 @@ registerSuite({
 			});
 
 			initializeElement(element);
-			element.getWidgetInstance().setProperties({
+			element.getWidgetInstance().__setProperties__({
 				a: 'test'
 			});
 
@@ -194,7 +194,7 @@ registerSuite({
 			});
 
 			initializeElement(element);
-			element.getWidgetInstance().setProperties({
+			element.getWidgetInstance().__setProperties__({
 				test: 'test'
 			});
 
@@ -215,7 +215,7 @@ registerSuite({
 			});
 
 			initializeElement(element);
-			element.getWidgetInstance().setProperties({
+			element.getWidgetInstance().__setProperties__({
 				a: 4
 			});
 

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -49,7 +49,7 @@ registerSuite({
 
 		'Uses `properties.locale` when available'() {
 			localized = new Localized();
-			localized.setProperties({ locale: 'fr' });
+			localized.__setProperties__({ locale: 'fr' });
 			return i18n(bundle, 'fr').then(() => {
 				const messages = localized.localizeBundle(bundle);
 				assert.strictEqual(messages.hello, 'Bonjour');
@@ -96,7 +96,7 @@ registerSuite({
 
 		'Does not update when `locale` property is set'() {
 			localized = new Localized();
-			localized.setProperties({ locale: 'en' });
+			localized.__setProperties__({ locale: 'en' });
 			sinon.spy(localized, 'invalidate');
 
 			switchLocale('fr');
@@ -112,7 +112,7 @@ registerSuite({
 		}
 
 		localized = new LocalizedExtended();
-		localized.setProperties({locale: 'ar-JO'});
+		localized.__setProperties__({locale: 'ar-JO'});
 
 		const result = <VNode> localized.__render__();
 		assert.isOk(result);
@@ -121,7 +121,7 @@ registerSuite({
 	'`properties.locale` updates the widget node\'s `lang` property': {
 		'when non-empty'() {
 			localized = new Localized();
-			localized.setProperties({locale: 'ar-JO'});
+			localized.__setProperties__({locale: 'ar-JO'});
 
 			const result = <VNode> localized.__render__();
 			assert.isOk(result);
@@ -140,7 +140,7 @@ registerSuite({
 	'`properties.rtl`': {
 		'The `dir` attribute is "rtl" when true'() {
 			localized = new Localized();
-			localized.setProperties({ rtl: true });
+			localized.__setProperties__({ rtl: true });
 
 			const result = localized.__render__();
 			assert.isOk(result);
@@ -149,7 +149,7 @@ registerSuite({
 
 		'The `dir` attribute is "ltr" when false'() {
 			localized = new Localized();
-			localized.setProperties({ rtl: false });
+			localized.__setProperties__({ rtl: false });
 
 			const result = localized.__render__();
 			assert.isOk(result);

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -100,7 +100,7 @@ registerSuite({
 			const childNodeLength = document.body.childNodes.length;
 			const projector = new TestWidget();
 
-			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
+			projector.__setChildren__([ v('h2', [ 'foo' ] ) ]);
 
 			projector.append();
 
@@ -117,7 +117,7 @@ registerSuite({
 				}
 			}();
 
-			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
+			projector.__setChildren__([ v('h2', [ 'foo' ] ) ]);
 
 			projector.replace();
 
@@ -130,7 +130,7 @@ registerSuite({
 			const childNodeLength = document.body.childNodes.length;
 			const projector = new TestWidget();
 
-			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
+			projector.__setChildren__([ v('h2', [ 'foo' ] ) ]);
 
 			projector.merge();
 
@@ -214,7 +214,7 @@ registerSuite({
 			called = true;
 		});
 
-		projector.setChildren([ v('div') ]);
+		projector.__setChildren__([ v('div') ]);
 
 		assert.isTrue(called);
 	},

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -202,7 +202,7 @@ registerSuite({
 			called = true;
 		});
 
-		projector.setProperties({ foo: 'hello' });
+		projector.__setProperties__({ foo: 'hello' });
 
 		assert.isTrue(called);
 	},

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -100,7 +100,7 @@ registerSuite({
 			const childNodeLength = document.body.childNodes.length;
 			const projector = new TestWidget();
 
-			projector.__setChildren__([ v('h2', [ 'foo' ] ) ]);
+			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
 			projector.append();
 
@@ -117,7 +117,7 @@ registerSuite({
 				}
 			}();
 
-			projector.__setChildren__([ v('h2', [ 'foo' ] ) ]);
+			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
 			projector.replace();
 
@@ -130,7 +130,7 @@ registerSuite({
 			const childNodeLength = document.body.childNodes.length;
 			const projector = new TestWidget();
 
-			projector.__setChildren__([ v('h2', [ 'foo' ] ) ]);
+			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
 			projector.merge();
 
@@ -202,7 +202,7 @@ registerSuite({
 			called = true;
 		});
 
-		projector.__setProperties__({ foo: 'hello' });
+		projector.setProperties({ foo: 'hello' });
 
 		assert.isTrue(called);
 	},
@@ -214,7 +214,7 @@ registerSuite({
 			called = true;
 		});
 
-		projector.__setChildren__([ v('div') ]);
+		projector.setChildren([ v('div') ]);
 
 		assert.isTrue(called);
 	},

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -14,19 +14,19 @@ registerSuite({
 		'passed registry is available via getter'() {
 			const registry = new WidgetRegistry();
 			const instance: any = new TestWithRegistry();
-			instance.setProperties({ registry });
+			instance.__setProperties__({ registry });
 			assert.equal(instance.registry, registry);
 		},
 		'no passed registry, nothing available via getter'() {
 			const instance: any = new TestWithRegistry();
-			instance.setProperties(<any> {});
+			instance.__setProperties__(<any> {});
 			assert.equal(instance.registry, undefined);
 		},
 		'passed registry updated on property change'() {
 			const registry = new WidgetRegistry();
 			const newRegistry = new WidgetRegistry();
 			const instance: any = new TestWithRegistry();
-			instance.setProperties({ registry });
+			instance.__setProperties__({ registry });
 			assert.equal(instance.registry, registry);
 			instance.emit({
 				type: 'properties:changed',
@@ -39,7 +39,7 @@ registerSuite({
 		'different property passed on property change should not affect registry'() {
 			const registry = new WidgetRegistry();
 			const instance: any = new TestWithRegistry();
-			instance.setProperties({ registry });
+			instance.__setProperties__({ registry });
 			assert.equal(instance.registry, registry);
 			instance.emit({
 				type: 'properties:changed',
@@ -74,7 +74,7 @@ registerSuite({
 			registry.define('test', Header);
 
 			const instance: any = new IntegrationTest();
-			instance.setProperties({ registry });
+			instance.__setProperties__({ registry });
 
 			let result = <VNode> instance.__render__();
 			assert.lengthOf(result.children, 1);
@@ -83,7 +83,7 @@ registerSuite({
 			const newRegistry = new WidgetRegistry();
 			newRegistry.define('test', Span);
 
-			instance.setProperties({ registry: newRegistry });
+			instance.__setProperties__({ registry: newRegistry });
 
 			result = <VNode> instance.__render__();
 			assert.lengthOf(result.children, 1);

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -111,7 +111,7 @@ registerSuite({
 		},
 		'should split adjoined classes into multiple classes'() {
 			themeableInstance = new TestWidget();
-			themeableInstance.setProperties({ theme: testTheme3 });
+			themeableInstance.__setProperties__({ theme: testTheme3 });
 			const { class1, class2 } = baseThemeClasses1;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -123,9 +123,9 @@ registerSuite({
 		'should remove adjoined classes when they are no longer provided'() {
 			const { class1, class2 } = baseThemeClasses1;
 			themeableInstance = new TestWidget();
-			themeableInstance.setProperties({ theme: testTheme3 });
+			themeableInstance.__setProperties__({ theme: testTheme3 });
 			let flaggedClasses = themeableInstance.classes(class1, class2).get();
-			themeableInstance.setProperties({ theme: testTheme1 });
+			themeableInstance.__setProperties__({ theme: testTheme1 });
 			flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ testTheme1.testPath1.class1 ]: true,
@@ -243,7 +243,7 @@ registerSuite({
 	'setting a theme': {
 		'should override basetheme classes with theme classes'() {
 			themeableInstance = new TestWidget();
-			themeableInstance.setProperties({ theme: testTheme1 });
+			themeableInstance.__setProperties__({ theme: testTheme1 });
 			const { class1, class2 } = baseThemeClasses1;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -254,9 +254,9 @@ registerSuite({
 		'should negate old theme class when a new theme is set'() {
 			const { class1, class2 } = baseThemeClasses1;
 			themeableInstance = new TestWidget();
-			themeableInstance.setProperties({ theme: testTheme1 });
+			themeableInstance.__setProperties__({ theme: testTheme1 });
 			themeableInstance.classes(class1).get();
-			themeableInstance.setProperties({ theme: testTheme2 });
+			themeableInstance.__setProperties__({ theme: testTheme2 });
 
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -267,7 +267,7 @@ registerSuite({
 		},
 		'will not regenerate theme classes if theme changed property is not set'() {
 			themeableInstance = new TestWidget();
-			themeableInstance.setProperties({ theme: testTheme1 });
+			themeableInstance.__setProperties__({ theme: testTheme1 });
 			themeableInstance.emit({
 				type: 'properties:changed',
 				properties: {
@@ -287,7 +287,7 @@ registerSuite({
 	'setting override classes': {
 		'should supplement basetheme classes with override classes'() {
 			themeableInstance = new TestWidget();
-			themeableInstance.setProperties({ overrideClasses: overrideClasses1 });
+			themeableInstance.__setProperties__({ overrideClasses: overrideClasses1 });
 			const { class1, class2 } = baseThemeClasses1;
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
@@ -299,9 +299,9 @@ registerSuite({
 		'should set override classes to false when they are changed'() {
 			const { class1, class2 } = baseThemeClasses1;
 			themeableInstance = new TestWidget();
-			themeableInstance.setProperties({ overrideClasses: overrideClasses1 });
+			themeableInstance.__setProperties__({ overrideClasses: overrideClasses1 });
 			themeableInstance.classes(class1, class2).get();
-			themeableInstance.setProperties({ overrideClasses: overrideClasses2 });
+			themeableInstance.__setProperties__({ overrideClasses: overrideClasses2 });
 			const flaggedClasses = themeableInstance.classes(class1, class2).get();
 			assert.deepEqual(flaggedClasses, {
 				[ baseThemeClasses1.class1 ]: true,
@@ -407,7 +407,7 @@ registerSuite({
 			}
 
 			const themeableWidget: any = new IntegrationTest();
-			themeableWidget.setProperties({ theme: testTheme1 });
+			themeableWidget.__setProperties__({ theme: testTheme1 });
 
 			const result = <VNode> themeableWidget.__render__();
 			assert.deepEqual(result.children![0].properties!.classes, {
@@ -415,7 +415,7 @@ registerSuite({
 				[ fixedClassName ]: true
 			});
 
-			themeableWidget.setProperties({ theme: testTheme2 });
+			themeableWidget.__setProperties__({ theme: testTheme2 });
 
 			const result2 = <VNode> themeableWidget.__render__();
 			assert.deepEqual(result2.children![0].properties!.classes, {

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -40,7 +40,7 @@ registerSuite({
 		};
 
 		let domWrapper: any = new DomWrapper();
-		domWrapper.setProperties({ domNode: <any> mock });
+		domWrapper.__setProperties__({ domNode: <any> mock });
 
 		domWrapper._dirty = false;
 		domWrapper._cachedVNode = {
@@ -63,7 +63,7 @@ registerSuite({
 		};
 
 		let domWrapper: any = new DomWrapper();
-		domWrapper.setProperties({ domNode: <any> 'test' });
+		domWrapper.__setProperties__({ domNode: <any> 'test' });
 
 		domWrapper._dirty = false;
 		domWrapper._cachedVNode = {
@@ -75,7 +75,7 @@ registerSuite({
 
 	'Nothing bad happens if there if node is a string'() {
 		let domWrapper: any = new DomWrapper();
-		domWrapper.setProperties({ domNode: <any> 'test' });
+		domWrapper.__setProperties__({ domNode: <any> 'test' });
 
 		domWrapper._dirty = false;
 		domWrapper._cachedVNode = {
@@ -87,7 +87,7 @@ registerSuite({
 
 	'updates with no renders don\'t do anything'() {
 		let domWrapper: any = new DomWrapper();
-		domWrapper.setProperties({ domNode: <any> undefined });
+		domWrapper.__setProperties__({ domNode: <any> undefined });
 		domWrapper._dirty = false;
 		domWrapper._cachedVNode = {
 			domNode: null
@@ -106,7 +106,7 @@ registerSuite({
 		};
 
 		let domWrapper: any = new DomWrapper();
-		domWrapper.setProperties({ domNode: <any> undefined });
+		domWrapper.__setProperties__({ domNode: <any> undefined });
 		domWrapper._dirty = false;
 		domWrapper._cachedVNode = {
 			domNode: parentNode
@@ -117,7 +117,7 @@ registerSuite({
 
 	'render aspect is ok if we dont return an hnode'() {
 		let domWrapper: any = new DomWrapper();
-		domWrapper.setProperties({ domNode: <any> undefined });
+		domWrapper.__setProperties__({ domNode: <any> undefined });
 		domWrapper._dirty = false;
 		domWrapper._cachedVNode = {
 			domNode: 'test'


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Renames `setChildren` and `setProperties` to use the double underscore convention to indicate that even though they are public (through the need for widget-core to use them externally) they should not be called or overridden by consumers.

The projector is the only widget that requires direct use of either of these APIs and as such proxy methods `setProperties` and `setChildren` have been added to the API.

Resolves #447 
