### PR TITLE
RegistryHandler abstraction

### DIFF
--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,0 +1,57 @@
+import { Evented } from '@dojo/core/Evented';
+import { WidgetConstructor } from './interfaces';
+import WidgetRegistry from './WidgetRegistry';
+
+export default class RegistryHandler extends Evented {
+	private _registries: { handle?: any, registry: WidgetRegistry }[] = [];
+
+	add(registry: WidgetRegistry) {
+		this._registries.unshift({ registry });
+	}
+
+	remove(registry: WidgetRegistry): boolean {
+		return this._registries.some((registryWrapper, i) => {
+			if (registryWrapper.registry === registry) {
+				registry.destroy();
+				this._registries.splice(i, 1);
+				return true;
+			}
+			return false;
+		});
+	}
+
+	replace(original: WidgetRegistry, replacement: WidgetRegistry): boolean {
+		return this._registries.some((registryWrapper, i) => {
+			if (registryWrapper.registry === original) {
+				original.destroy();
+				registryWrapper.registry = replacement;
+				return true;
+			}
+			return false;
+		});
+	}
+
+	has(widgetLabel: string): boolean {
+		return this._registries.some((registryWrapper) => {
+			return registryWrapper.registry.has(widgetLabel);
+		});
+	}
+
+	get(widgetLabel: string): WidgetConstructor | null {
+		for (let i = 0; i < this._registries.length; i++) {
+			const registryWrapper = this._registries[i];
+			const item = registryWrapper.registry.get(widgetLabel);
+			if (item) {
+				return item;
+			}
+			else if (!registryWrapper.handle) {
+				registryWrapper.handle = registryWrapper.registry.on(`loaded:${widgetLabel}`, () => {
+					this.emit({ type: 'invalidate' });
+					registryWrapper.handle.destroy();
+					registryWrapper.handle = undefined;
+				});
+			}
+		}
+		return null;
+	}
+}

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -1,6 +1,7 @@
 import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
 import Symbol from '@dojo/shim/Symbol';
+import Evented from '@dojo/core/Evented';
 import { WidgetConstructor } from './interfaces';
 
 export type WidgetConstructorFunction = () => Promise<WidgetConstructor>;
@@ -31,7 +32,7 @@ export interface WidgetRegistry {
 	 * @param widgetLabel The label of the widget to return
 	 * @returns The WidgetRegistryItem for the widgetLabel, `null` if no entry exists
 	 */
-	get(widgetLabel: string): WidgetConstructor | Promise<WidgetConstructor> | null;
+	get(widgetLabel: string): WidgetConstructor | null;
 
 	/**
 	 * Returns a boolean if an entry for the label exists
@@ -55,49 +56,71 @@ export function isWidgetBaseConstructor(item: any): item is WidgetConstructor {
 /**
  * The WidgetRegistry implementation
  */
-export class WidgetRegistry implements WidgetRegistry {
+export class WidgetRegistry extends Evented implements WidgetRegistry {
 
 	/**
 	 * internal map of labels and WidgetRegistryItem
 	 */
-	private registry: Map<string, WidgetRegistryItem>;
-
-	constructor() {
-		this.registry = new Map<string, WidgetRegistryItem>();
-	}
+	private registry: Map<string, WidgetRegistryItem> = new Map<string, WidgetRegistryItem>();
 
 	has(widgetLabel: string): boolean {
 		return this.registry.has(widgetLabel);
 	}
 
-	define(widgetLabel: string, registryItem: WidgetRegistryItem): void {
+	define(widgetLabel: string, item: WidgetRegistryItem): void {
 		if (this.registry.has(widgetLabel)) {
 			throw new Error(`widget has already been registered for '${widgetLabel}'`);
 		}
-		this.registry.set(widgetLabel, registryItem);
+
+		this.registry.set(widgetLabel, item);
+
+		if (item instanceof Promise) {
+			item.then((widgetCtor) => {
+				this.registry.set(widgetLabel, widgetCtor);
+				this.emit({
+					type: `loaded:${widgetLabel}`
+				});
+				return widgetCtor;
+			}, (error) => {
+				throw error;
+			});
+		}
+		else {
+			this.emit({
+				type: `loaded:${widgetLabel}`
+			});
+		}
 	}
 
-	get(widgetLabel: string): WidgetConstructor | Promise<WidgetConstructor> | null {
+	get(widgetLabel: string): WidgetConstructor | null {
 		if (!this.has(widgetLabel)) {
 			return null;
 		}
 
 		const item = this.registry.get(widgetLabel);
 
-		if (item instanceof Promise || isWidgetBaseConstructor(item)) {
+		if (isWidgetBaseConstructor(item)) {
 			return item;
 		}
 
-		const promise = (<WidgetConstructorFunction> item)();
+		if (item instanceof Promise) {
+			return null;
+		}
 
+		const promise = (<WidgetConstructorFunction> item)();
 		this.registry.set(widgetLabel, promise);
 
-		return promise.then((widgetCtor) => {
+		promise.then((widgetCtor) => {
 			this.registry.set(widgetLabel, widgetCtor);
+			this.emit({
+				type: `loaded:${widgetLabel}`
+			});
 			return widgetCtor;
 		}, (error) => {
 			throw error;
 		});
+
+		return null;
 	}
 }
 

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -1,9 +1,7 @@
-import { includes } from '@dojo/shim/array';
 import WidgetRegistry from '../WidgetRegistry';
-import { WidgetBase, onPropertiesChanged, diffProperty } from './../WidgetBase';
+import { WidgetBase, diffProperty } from './../WidgetBase';
 import {
 	PropertyChangeRecord,
-	PropertiesChangeEvent,
 	Constructor,
 	WidgetProperties
 } from '../interfaces';
@@ -17,17 +15,19 @@ export function RegistryMixin<T extends Constructor<WidgetBase<RegistryMixinProp
 
 		@diffProperty('registry')
 		public diffPropertyRegistry(previousValue: WidgetRegistry, value: WidgetRegistry): PropertyChangeRecord {
+			let changed = false;
+			if (!previousValue) {
+				this.registries.add(value);
+				changed = true;
+			}
+			else if (previousValue !== value) {
+				this.registries.replace(previousValue, value);
+				changed = true;
+			}
 			return {
-				changed: previousValue !== value,
+				changed,
 				value: value
 			};
-		}
-
-		@onPropertiesChanged()
-		protected onPropertiesChanged(evt: PropertiesChangeEvent<this, RegistryMixinProperties>) {
-			if (includes(evt.changedPropertyKeys, 'registry')) {
-				this.registry = evt.properties.registry;
-			}
 		}
 	};
 	return Registry;

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -1,0 +1,72 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import RegistryHandler from '../../src/RegistryHandler';
+import WidgetRegistry from '../../src/WidgetRegistry';
+import { WidgetBase } from '../../src/WidgetBase';
+
+const registry = new WidgetRegistry();
+registry.define('foo', WidgetBase);
+
+const registryB = new WidgetRegistry();
+registryB.define('bar', WidgetBase);
+
+registerSuite({
+	name: 'RegistryHandler',
+	'add'() {
+		const registryHandler = new RegistryHandler();
+		registryHandler.add(registry);
+		const widget = registry.get('foo');
+		assert.equal(widget, WidgetBase);
+	},
+	'remove': {
+		'existing'() {
+			const registryHandler = new RegistryHandler();
+			registryHandler.add(registry);
+			assert.equal(registry.get('foo'), WidgetBase);
+			registryHandler.remove(registry);
+			assert.isNull(registryHandler.get('foo'));
+		},
+		'non-existing'() {
+			const registryHandler = new RegistryHandler();
+			registryHandler.add(registry);
+			assert.equal(registry.get('foo'), WidgetBase);
+			assert.isFalse(registryHandler.remove(registryB));
+		}
+	},
+	'replace': {
+		'existing'() {
+			const registryHandler = new RegistryHandler();
+			registryHandler.add(registry);
+			assert.equal(registry.get('foo'), WidgetBase);
+			registryHandler.replace(registry, registryB);
+			assert.isNull(registryHandler.get('foo'));
+			assert.equal(registryHandler.get('bar'), WidgetBase);
+		},
+		'non-existing'() {
+			const registryHandler = new RegistryHandler();
+			registryHandler.add(registry);
+			assert.equal(registry.get('foo'), WidgetBase);
+			assert.isFalse(registryHandler.replace(registryB, registry));
+		}
+	},
+	'has'() {
+		const registryHandler = new RegistryHandler();
+		registryHandler.add(registry);
+		registryHandler.add(registryB);
+		assert.isTrue(registryHandler.has('foo'));
+		assert.isTrue(registryHandler.has('bar'));
+	},
+	'get'() {
+		const promise = new Promise((resolve) => {
+			setTimeout(() => {
+				resolve(WidgetBase);
+			}, 1);
+		});
+		const registryHandler = new RegistryHandler();
+		registryHandler.add(registry);
+		registry.define('baz', promise);
+		return promise.then(() => {
+			assert.equal(registryHandler.get('baz'), WidgetBase);
+		});
+	}
+});

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -8,3 +8,4 @@ import './mixins/all';
 import './util/all';
 import './main';
 import './diff';
+import './RegistryHandler';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
This PR makes management and usage of Registries a little easier. The PR adds a few things:

* Support for arbitrary amount of registries, which are abstracted on usage (before we only supported a global and local registry, but then allowed overriding the local via a property using the `RegistryMixin`).
* `Registry.get()` no longer ever returns a promise, it either returns the widget or null.
* We no longer manage waiting on a registry item in `WidgetBase`, it's all dealt with by the `RegistryHandler`.
* You can now use before defining when using a widget from the `Registry` and the containing widget will re-render with it once it is loaded. This aligns more with Custom Elements.

With the above changes we now have a pattern for dealing with Widgets that haven't been loaded yet (over the default of rendering nothing until it's ready). For example:

```typescript
render() {
    const FooOrLoading = this.registries.get('foo') || LoadingSpinner;
    return w(FooOrLoading, {});
}
```

Remaining questions pertaining to this PR are:
* Are multiple registries (over the existing global and local) useful?
* Should we provide the user to be able to get from a specific registry? ie: at the moment the registries are resolved where local wins. It seems in quite a lot of scenario's where we'd take a registry as a property that we'd want that to win?
