### PR TITLE
Lazily calculate class object when `get` function is called.

### DIFF
--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -155,6 +155,23 @@ registerSuite({
 			});
 
 			assert.isFalse(consoleStub.called);
+		},
+		'class function is lazily evaluated'() {
+			themeableInstance = new TestWidget();
+			const { class1, class2 } = baseThemeClasses1;
+			const firstClasses = themeableInstance.classes(class1);
+			const secondClasses = themeableInstance.classes(class2);
+
+			assert.deepEqual(secondClasses(), {
+				[ baseThemeClasses1.class2 ]: true
+			});
+
+			assert.deepEqual(firstClasses(), {
+				[ baseThemeClasses1.class1 ]: true,
+				[ baseThemeClasses1.class2 ]: false
+			});
+
+			assert.isFalse(consoleStub.called);
 		}
 	},
 	'classes.fixed chained function': {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

The classes object will be calculated at the point that the `get` function is called not when `this.classes` is called.

```ts
render() {
    const preCalculatedClasses = this.classes(css.classTwo);

    return v('div', { classes: this.classes(css.classOne) }, [
        v('span', { classes: preCalculatedClasses })
    ]);
}
```

Currently this would result in the `div` HNode including the negating class for the `preCalculatedClasses` like `{ classTwo: false, classOne: true }`. This is because `preCalculatedClasses` was created with `this.classes` first, which is confusing given the order of the classes in the render structure.

With this change the calculation is as lazy as possible and the classes will be memorised in an expected order; meaning that the `div` will only contain `{ classOne: true }` and the `span` will contain the negating class that was used in the `div`, `{ classOne: false, classTwo: true }`. 

Resolves #454 
