### PR TITLE
Generic typings for children and default `WidgetProperties` generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "istanbul": "^0.4.5",
     "jsdom": "^9.5.0",
     "sinon": "^1.17.6",
-    "typescript": "~2.2.1"
+    "typescript": "~2.3.1"
   },
   "dependencies": {
     "pepjs": "^0.4.2"

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,5 +1,5 @@
 import { Evented } from '@dojo/core/Evented';
-import { WidgetConstructor } from './interfaces';
+import { WidgetBaseConstructor } from './interfaces';
 import WidgetRegistry from './WidgetRegistry';
 
 export default class RegistryHandler extends Evented {
@@ -37,7 +37,7 @@ export default class RegistryHandler extends Evented {
 		});
 	}
 
-	get(widgetLabel: string): WidgetConstructor | null {
+	get(widgetLabel: string): WidgetBaseConstructor | null {
 		for (let i = 0; i < this._registries.length; i++) {
 			const registryWrapper = this._registries[i];
 			const item = registryWrapper.registry.get(widgetLabel);

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -124,7 +124,7 @@ function isHNodeWithKey(node: DNode): node is HNode {
  * Main widget base for all widgets to extend
  */
 @diffProperty('bind', DiffType.REFERENCE)
-export class WidgetBase<P extends WidgetProperties = WidgetProperties, C = any> extends Evented implements WidgetBaseInterface<P, C> {
+export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends WidgetProperties = WidgetProperties> extends Evented implements WidgetBaseInterface<P, C> {
 
 	/**
 	 * static identifier

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -10,7 +10,7 @@ import { v, registry, isWNode, isHNode, decorate } from './d';
 import diff, { DiffType } from './diff';
 import {
 	DNode,
-	WidgetConstructor,
+	WidgetBaseConstructor,
 	WidgetProperties,
 	WidgetBaseInterface,
 	PropertyChangeRecord,
@@ -27,7 +27,7 @@ export { DiffType };
  */
 interface WidgetCacheWrapper {
 	child: WidgetBaseInterface<WidgetProperties>;
-	widgetConstructor: WidgetConstructor;
+	widgetConstructor: WidgetBaseConstructor;
 	used: boolean;
 }
 
@@ -124,7 +124,7 @@ function isHNodeWithKey(node: DNode): node is HNode {
  * Main widget base for all widgets to extend
  */
 @diffProperty('bind', DiffType.REFERENCE)
-export class WidgetBase<P extends WidgetProperties> extends Evented implements WidgetBaseInterface<P> {
+export class WidgetBase<P extends WidgetProperties = WidgetProperties, C = any> extends Evented implements WidgetBaseInterface<P, C> {
 
 	/**
 	 * static identifier
@@ -139,7 +139,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	/**
 	 * children array
 	 */
-	private _children: DNode[];
+	private _children: DNode<C>[];
 
 	/**
 	 * marker indicating if the widget requires a render
@@ -164,7 +164,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	/**
 	 * cached chldren map for instance management
 	 */
-	private _cachedChildrenMap: Map<string | Promise<WidgetConstructor> | WidgetConstructor, WidgetCacheWrapper[]>;
+	private _cachedChildrenMap: Map<string | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
 
 	/**
 	 * map of specific property diff functions
@@ -198,7 +198,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this._decoratorCache = new Map<string, any[]>();
 		this._properties = <P> {};
 		this._previousProperties = <P> {};
-		this._cachedChildrenMap = new Map<string | Promise<WidgetConstructor> | WidgetConstructor, WidgetCacheWrapper[]>();
+		this._cachedChildrenMap = new Map<string | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>();
 		this._diffPropertyFunctionMap = new Map<string, string>();
 		this._renderDecorators = new Set<string>();
 		this._bindFunctionPropertyMap = new WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>();
@@ -350,11 +350,11 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this._previousProperties = this.properties;
 	}
 
-	public get children(): DNode[] {
+	public get children(): DNode<C>[] {
 		return this._children;
 	}
 
-	public __setChildren__(children: DNode[]): void {
+	public __setChildren__(children: DNode<C>[]): void {
 		this._dirty = true;
 		this._children = children;
 		this.emit({
@@ -524,7 +524,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 				if (item === null) {
 					return null;
 				}
-				widgetConstructor = <WidgetConstructor> item;
+				widgetConstructor = <WidgetBaseConstructor> item;
 			}
 
 			const childrenMapKey = key || widgetConstructor;

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -2,11 +2,11 @@ import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
 import Symbol from '@dojo/shim/Symbol';
 import Evented from '@dojo/core/Evented';
-import { WidgetConstructor } from './interfaces';
+import { WidgetBaseConstructor } from './interfaces';
 
-export type WidgetConstructorFunction = () => Promise<WidgetConstructor>;
+export type WidgetConstructorFunction = () => Promise<WidgetBaseConstructor>;
 
-export type WidgetRegistryItem = WidgetConstructor | Promise<WidgetConstructor> | WidgetConstructorFunction;
+export type WidgetRegistryItem = WidgetBaseConstructor | Promise<WidgetBaseConstructor> | WidgetConstructorFunction;
 
 /**
  * Widget base symbol type
@@ -32,7 +32,7 @@ export interface WidgetRegistry {
 	 * @param widgetLabel The label of the widget to return
 	 * @returns The WidgetRegistryItem for the widgetLabel, `null` if no entry exists
 	 */
-	get(widgetLabel: string): WidgetConstructor | null;
+	get(widgetLabel: string): WidgetBaseConstructor | null;
 
 	/**
 	 * Returns a boolean if an entry for the label exists
@@ -49,7 +49,7 @@ export interface WidgetRegistry {
  * @param item the item to check
  * @returns true/false indicating if the item is a WidgetConstructor
  */
-export function isWidgetBaseConstructor(item: any): item is WidgetConstructor {
+export function isWidgetBaseConstructor(item: any): item is WidgetBaseConstructor {
 	return Boolean(item && item._type === WIDGET_BASE_TYPE);
 }
 
@@ -92,7 +92,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		}
 	}
 
-	get(widgetLabel: string): WidgetConstructor | null {
+	get(widgetLabel: string): WidgetBaseConstructor | null {
 		if (!this.has(widgetLabel)) {
 			return null;
 		}

--- a/src/d.ts
+++ b/src/d.ts
@@ -25,7 +25,7 @@ export const HNODE = Symbol('Identifier for a HNode.');
 /**
  * Helper function that returns true if the `DNode` is a `WNode` using the `type` property
  */
-export function isWNode(child: DNode): child is WNode {
+export function isWNode<P extends WidgetProperties, C>(child: DNode<P, C>): child is WNode<P, C> {
 	return Boolean(child && (typeof child !== 'string') && child.type === WNODE);
 }
 
@@ -70,19 +70,7 @@ export const registry = new WidgetRegistry();
 /**
  * Wrapper function for calls to create a widget.
  */
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: P, children?: DNode[]): WNode;
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, children: DNode[]): WNode;
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string): WNode;
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, propertiesOrChildren: P | DNode[] = <P> {}, children: DNode[] = []): WNode {
-		let properties: P;
-
-	if (Array.isArray(propertiesOrChildren)) {
-		children = propertiesOrChildren;
-		properties = <P> {};
-	}
-	else {
-		properties = propertiesOrChildren;
-	}
+export function w<P extends WidgetProperties = WidgetProperties, C extends WidgetProperties = WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P, C> | string, properties: WidgetProperties & P, children: DNode<C>[] = []): WNode<P, C> {
 
 	return {
 		children,

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -265,21 +265,21 @@ export interface HNode {
 /**
  * Wrapper for `w`
  */
-export interface WNode {
+export interface WNode<P extends WidgetProperties = WidgetProperties, C extends WidgetProperties = WidgetProperties> {
 	/**
 	 * Constructor to create a widget or string constructor label
 	 */
-	widgetConstructor: WidgetConstructor | string;
+	widgetConstructor: WidgetBaseConstructor | string;
 
 	/**
 	 * Properties to set against a widget instance
 	 */
-	properties: WidgetProperties;
+	properties: P;
 
 	/**
 	 * DNode children
 	 */
-	children: DNode[];
+	children: DNode<C>[];
 
 	/**
 	 * The type of node
@@ -290,7 +290,7 @@ export interface WNode {
 /**
  * union type for all possible return types from render
  */
-export type DNode = HNode | WNode | string | null;
+export type DNode<P extends WidgetProperties = WidgetProperties, C = any> = HNode | WNode<P, C> | string | null;
 
 /**
  * the event emitted on properties:changed
@@ -329,17 +329,12 @@ export interface PropertiesChangeRecord<P extends WidgetProperties> {
 /**
  *
  */
-export type WidgetBaseConstructor<P extends WidgetProperties> = Constructor<WidgetBaseInterface<P>>;
-
-/**
- * WidgetBase constructor type
- */
-export type WidgetConstructor = WidgetBaseConstructor<WidgetProperties>;
+export type WidgetBaseConstructor<P extends WidgetProperties = WidgetProperties, C extends WidgetProperties = WidgetProperties> = Constructor<WidgetBaseInterface<P, C>>;
 
 /**
  * The interface for WidgetBase
  */
-export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented {
+export interface WidgetBaseInterface<P extends WidgetProperties = WidgetProperties, C extends WidgetProperties = WidgetProperties> extends Evented {
 
 	/**
 	 * Widget properties
@@ -349,7 +344,7 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	/**
 	 * Returns the widget's children
 	 */
-	readonly children: DNode[];
+	readonly children: DNode<C>[];
 
 	/**
 	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
@@ -364,7 +359,7 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	/**
 	 * Sets the widget's children
 	 */
-	__setChildren__(children: DNode[]): void;
+	__setChildren__(children: DNode<C>[]): void;
 
 	/**
 	 * Main internal function for dealing with widget rendering

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -290,7 +290,7 @@ export interface WNode<P extends WidgetProperties = WidgetProperties, C extends 
 /**
  * union type for all possible return types from render
  */
-export type DNode<P extends WidgetProperties = WidgetProperties, C = any> = HNode | WNode<P, C> | string | null;
+export type DNode<P extends WidgetProperties = WidgetProperties, C extends WidgetProperties = WidgetProperties> = HNode | WNode<P, C> | string | null;
 
 /**
  * the event emitted on properties:changed

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -4,7 +4,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { stub, spy } from 'sinon';
 import { v, w, registry } from '../../src/d';
-import { DNode } from '../../src/interfaces';
+import { DNode, WidgetBaseConstructor } from '../../src/interfaces';
 import { WidgetBase, diffProperty, DiffType, afterRender, beforeRender, onPropertiesChanged } from '../../src/WidgetBase';
 import WidgetRegistry, { WIDGET_BASE_TYPE } from './../../src/WidgetRegistry';
 
@@ -37,7 +37,7 @@ registerSuite({
 	},
 	diffProperties: {
 		'no updated properties'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new WidgetBase<any>();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
@@ -47,7 +47,7 @@ registerSuite({
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 		},
 		'updated properties'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new WidgetBase<any>();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
@@ -57,7 +57,7 @@ registerSuite({
 			widgetBase.__setProperties__({ id: 'id', foo: 'baz' });
 		},
 		'new properties'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new WidgetBase<any>();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
@@ -67,7 +67,7 @@ registerSuite({
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar', bar: 'baz' });
 		},
 		'updated / new properties with falsy values'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new WidgetBase<any>();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
@@ -847,7 +847,7 @@ widget.__setProperties__({
 		'async factories only initialise once'() {
 			let resolveFunction: any;
 			const loadFunction = () => {
-				return new Promise((resolve) => {
+				return new Promise<WidgetBaseConstructor>((resolve) => {
 					resolveFunction = resolve;
 				});
 			};
@@ -895,7 +895,7 @@ widget.__setProperties__({
 		'render with async factory'() {
 			let resolveFunction: any;
 			const loadFunction = () => {
-				return new Promise((resolve) => {
+				return new Promise<WidgetBaseConstructor>((resolve) => {
 					resolveFunction = resolve;
 				});
 			};

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -80,17 +80,7 @@ registerSuite({
 			const dNode = w(TestChildWidget, { myChildProperty: '' }, [ v('div') ]);
 
 			assert.equal(dNode.type, WNODE);
-			assert.deepEqual(dNode.widgetConstructor, TestWidget);
-			assert.lengthOf(dNode.children, 1);
-			assert.isTrue(isWNode(dNode));
-			assert.isFalse(isHNode(dNode));
-		},
-		'create WNode wrapper using label with children'() {
-			const properties: any = { id: 'id', classes: [ 'world' ] };
-			const dNode = w('my-widget', [ w(WidgetBase, properties) ]);
-
-			assert.equal(dNode.type, WNODE);
-			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
+			assert.deepEqual(dNode.widgetConstructor, TestChildWidget);
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add support for typing children defaulting the generic to the any widget. Add support to default `WidgetProperties` generic type.

Resolves #???
