### PR TITLE
Remove overloaded API and add intersection to WidgetProperties for `w`

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -70,19 +70,7 @@ export const registry = new WidgetRegistry();
 /**
  * Wrapper function for calls to create a widget.
  */
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: P, children?: DNode[]): WNode;
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, children: DNode[]): WNode;
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string): WNode;
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, propertiesOrChildren: P | DNode[] = <P> {}, children: DNode[] = []): WNode {
-		let properties: P;
-
-	if (Array.isArray(propertiesOrChildren)) {
-		children = propertiesOrChildren;
-		properties = <P> {};
-	}
-	else {
-		properties = propertiesOrChildren;
-	}
+export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: WidgetProperties & P, children: DNode[] = []): WNode {
 
 	return {
 		children,

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { assign } from '@dojo/core/lang';
-import { DNode, HNode } from '../../src/interfaces';
+import { DNode, HNode, WidgetProperties } from '../../src/interfaces';
 import { WidgetBase } from '../../src/WidgetBase';
 import { v, w, decorate, registry, WNODE, HNODE, isWNode, isHNode } from '../../src/d';
 import WidgetRegistry from './../../src/WidgetRegistry';
@@ -12,7 +12,11 @@ class TestFactoryRegistry extends WidgetRegistry {
 	}
 }
 
-class TestWidget extends WidgetBase<any> {
+interface TestProperties extends WidgetProperties {
+	mand: boolean;
+}
+
+class TestWidget extends WidgetBase<TestProperties> {
 	render() {
 		return v('outernode', { type: 'mytype' }, [
 			v('child-one'),
@@ -33,23 +37,6 @@ registerSuite({
 		assert.isObject(registry);
 	},
 	w: {
-		'create WNode wrapper with constructor'() {
-			const dNode = w(WidgetBase);
-			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
-			assert.deepEqual(dNode.properties, {});
-			assert.equal(dNode.type, WNODE);
-			assert.isTrue(isWNode(dNode));
-			assert.isFalse(isHNode(dNode));
-		},
-		'create WNode wrapper with label'() {
-			const dNode = w('my-widget');
-
-			assert.equal(dNode.type, WNODE);
-			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
-			assert.deepEqual(dNode.properties, {});
-			assert.isTrue(isWNode(dNode));
-			assert.isFalse(isHNode(dNode));
-		},
 		'create WNode wrapper using constructor with properties'() {
 			const properties: any = { id: 'id', classes: [ 'world' ] };
 			const dNode = w(WidgetBase, properties);
@@ -70,44 +57,24 @@ registerSuite({
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
-		'create WNode wrapper using constructor with children'() {
-			const properties: any = { id: 'id', classes: [ 'world' ] };
-			const dNode = w(WidgetBase, [ w(WidgetBase, properties) ]);
-
-			assert.equal(dNode.type, WNODE);
-			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
-			assert.lengthOf(dNode.children, 1);
-			assert.isTrue(isWNode(dNode));
-			assert.isFalse(isHNode(dNode));
-		},
-		'create WNode wrapper using label with children'() {
-			const properties: any = { id: 'id', classes: [ 'world' ] };
-			const dNode = w('my-widget', [ w(WidgetBase, properties) ]);
-
-			assert.equal(dNode.type, WNODE);
-			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
-			assert.lengthOf(dNode.children, 1);
-			assert.isTrue(isWNode(dNode));
-			assert.isFalse(isHNode(dNode));
-		},
 		'create WNode wrapper using constructor with properties and children'() {
-			const properties: any = { id: 'id', classes: [ 'world' ] };
-			const dNode = w(WidgetBase, properties, [ w(WidgetBase, properties) ]);
+			const properties = { mand: true };
+			const dNode = w(TestWidget, properties, [ w(WidgetBase, properties) ]);
 
 			assert.equal(dNode.type, WNODE);
-			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
-			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.deepEqual(dNode.widgetConstructor, TestWidget);
+			assert.deepEqual(dNode.properties, { mand: true });
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
 		'create WNode wrapper using label with properties and children'() {
-			const properties: any = { id: 'id', classes: [ 'world' ] };
-			const dNode = w('my-widget', properties, [ w(WidgetBase, properties) ]);
+			const properties = { mand: false };
+			const dNode = w<TestProperties>('my-widget', properties, [ w(WidgetBase, properties) ]);
 
 			assert.equal(dNode.type, WNODE);
 			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
-			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.deepEqual(dNode.properties, { mand: false });
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

The overloads on `w` actually remove the typing guards that are desired whilst using `w`. Additionally it seems to get for inference of the generic properties type from a widget class needed to add an intersection to the base `WidgetProperties` (props @matt-gadd)

Resolves #464 
