### PR TITLE
Correct the typings for registries

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -181,7 +181,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	 */
 	private _renderDecorators: Set<string>;
 
-	private _registries: any;
+	private _registries: RegistryHandler;
 
 	/**
 	 * Map of functions properties for the bound function
@@ -496,7 +496,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		});
 	}
 
-	protected get registries() {
+	protected get registries(): RegistryHandler {
 		return this._registries;
 	}
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**

Corrects the typings for `registries`
