### PR TITLE
Support typing of widget children

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "istanbul": "^0.4.5",
     "jsdom": "^9.5.0",
     "sinon": "^1.17.6",
-    "typescript": "~2.2.1"
+    "typescript": "~2.3.2"
   },
   "dependencies": {
     "pepjs": "^0.4.2"

--- a/package.json
+++ b/package.json
@@ -45,10 +45,12 @@
     "glob": "^7.0.6",
     "grunt": "^1.0.1",
     "grunt-dojo2": "beta1",
+    "grunt-tslint": "^5.0.1",
     "intern": "^3.4.1",
     "istanbul": "^0.4.5",
     "jsdom": "^9.5.0",
     "sinon": "^1.17.6",
+    "tslint": "^5.2.0",
     "typescript": "~2.3.2"
   },
   "dependencies": {

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -61,7 +61,7 @@ export function Injector<C, T extends Constructor<BaseInjector<C>>>(Base: T, con
 
 			return render();
 		}
-	};
+	}
 	return Injector;
 }
 

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,5 +1,5 @@
 import { Evented } from '@dojo/core/Evented';
-import { WidgetConstructor } from './interfaces';
+import { WidgetBaseConstructor } from './interfaces';
 import WidgetRegistry from './WidgetRegistry';
 
 export default class RegistryHandler extends Evented {
@@ -37,7 +37,7 @@ export default class RegistryHandler extends Evented {
 		});
 	}
 
-	get(widgetLabel: string): WidgetConstructor | null {
+	get(widgetLabel: string): WidgetBaseConstructor | null {
 		for (let i = 0; i < this._registries.length; i++) {
 			const registryWrapper = this._registries[i];
 			const item = registryWrapper.registry.get(widgetLabel);

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -139,7 +139,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 	/**
 	 * children array
 	 */
-	private _children: C[];
+	private _children: (C | null)[];
 
 	/**
 	 * marker indicating if the widget requires a render
@@ -350,11 +350,11 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 		this._previousProperties = this.properties;
 	}
 
-	public get children(): C[] {
+	public get children(): (C | null)[] {
 		return this._children;
 	}
 
-	public __setChildren__(children: C[]): void {
+	public __setChildren__(children: (C | null)[]): void {
 		this._dirty = true;
 		this._children = children;
 		this.emit({

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -223,7 +223,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 	 * 'afterUpdate' that will in turn call lifecycle methods onElementCreated and onElementUpdated.
 	 */
 	@afterRender()
-	protected attachLifecycleCallbacks (node: DNode) {
+	protected attachLifecycleCallbacks (node: DNode): DNode {
 		// Create vnode afterCreate and afterUpdate callback functions that will only be set on nodes
 		// with "key" properties.
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -10,7 +10,7 @@ import { v, registry, isWNode, isHNode, decorate } from './d';
 import diff, { DiffType } from './diff';
 import {
 	DNode,
-	WidgetConstructor,
+	WidgetBaseConstructor,
 	WidgetProperties,
 	WidgetBaseInterface,
 	PropertyChangeRecord,
@@ -27,7 +27,7 @@ export { DiffType };
  */
 interface WidgetCacheWrapper {
 	child: WidgetBaseInterface<WidgetProperties>;
-	widgetConstructor: WidgetConstructor;
+	widgetConstructor: WidgetBaseConstructor;
 	used: boolean;
 }
 
@@ -124,7 +124,7 @@ function isHNodeWithKey(node: DNode): node is HNode {
  * Main widget base for all widgets to extend
  */
 @diffProperty('bind', DiffType.REFERENCE)
-export class WidgetBase<P extends WidgetProperties> extends Evented implements WidgetBaseInterface<P> {
+export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends DNode = DNode> extends Evented implements WidgetBaseInterface<P, C> {
 
 	/**
 	 * static identifier
@@ -139,7 +139,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	/**
 	 * children array
 	 */
-	private _children: DNode[];
+	private _children: C[];
 
 	/**
 	 * marker indicating if the widget requires a render
@@ -164,7 +164,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 	/**
 	 * cached chldren map for instance management
 	 */
-	private _cachedChildrenMap: Map<string | Promise<WidgetConstructor> | WidgetConstructor, WidgetCacheWrapper[]>;
+	private _cachedChildrenMap: Map<string | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
 
 	/**
 	 * map of specific property diff functions
@@ -198,7 +198,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this._decoratorCache = new Map<string, any[]>();
 		this._properties = <P> {};
 		this._previousProperties = <P> {};
-		this._cachedChildrenMap = new Map<string | Promise<WidgetConstructor> | WidgetConstructor, WidgetCacheWrapper[]>();
+		this._cachedChildrenMap = new Map<string | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>();
 		this._diffPropertyFunctionMap = new Map<string, string>();
 		this._renderDecorators = new Set<string>();
 		this._bindFunctionPropertyMap = new WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>();
@@ -350,11 +350,11 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 		this._previousProperties = this.properties;
 	}
 
-	public get children(): DNode[] {
+	public get children(): C[] {
 		return this._children;
 	}
 
-	public __setChildren__(children: DNode[]): void {
+	public __setChildren__(children: C[]): void {
 		this._dirty = true;
 		this._children = children;
 		this.emit({
@@ -524,7 +524,7 @@ export class WidgetBase<P extends WidgetProperties> extends Evented implements W
 				if (item === null) {
 					return null;
 				}
-				widgetConstructor = <WidgetConstructor> item;
+				widgetConstructor = <WidgetBaseConstructor> item;
 			}
 
 			const childrenMapKey = key || widgetConstructor;

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -2,11 +2,11 @@ import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
 import Symbol from '@dojo/shim/Symbol';
 import Evented from '@dojo/core/Evented';
-import { WidgetConstructor } from './interfaces';
+import { WidgetBaseConstructor } from './interfaces';
 
-export type WidgetConstructorFunction = () => Promise<WidgetConstructor>;
+export type WidgetBaseConstructorFunction = () => Promise<WidgetBaseConstructor>;
 
-export type WidgetRegistryItem = WidgetConstructor | Promise<WidgetConstructor> | WidgetConstructorFunction;
+export type WidgetRegistryItem = WidgetBaseConstructor | Promise<WidgetBaseConstructor> | WidgetBaseConstructorFunction;
 
 /**
  * Widget base symbol type
@@ -32,7 +32,7 @@ export interface WidgetRegistry {
 	 * @param widgetLabel The label of the widget to return
 	 * @returns The WidgetRegistryItem for the widgetLabel, `null` if no entry exists
 	 */
-	get(widgetLabel: string): WidgetConstructor | null;
+	get(widgetLabel: string): WidgetBaseConstructor | null;
 
 	/**
 	 * Returns a boolean if an entry for the label exists
@@ -47,9 +47,9 @@ export interface WidgetRegistry {
  * Checks is the item is a subclass of WidgetBase (or a WidgetBase)
  *
  * @param item the item to check
- * @returns true/false indicating if the item is a WidgetConstructor
+ * @returns true/false indicating if the item is a WidgetBaseConstructor
  */
-export function isWidgetBaseConstructor(item: any): item is WidgetConstructor {
+export function isWidgetBaseConstructor(item: any): item is WidgetBaseConstructor {
 	return Boolean(item && item._type === WIDGET_BASE_TYPE);
 }
 
@@ -92,7 +92,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		}
 	}
 
-	get(widgetLabel: string): WidgetConstructor | null {
+	get(widgetLabel: string): WidgetBaseConstructor | null {
 		if (!this.has(widgetLabel)) {
 			return null;
 		}
@@ -107,7 +107,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 			return null;
 		}
 
-		const promise = (<WidgetConstructorFunction> item)();
+		const promise = (<WidgetBaseConstructorFunction> item)();
 		this.registry.set(widgetLabel, promise);
 
 		promise.then((widgetCtor) => {

--- a/src/d.ts
+++ b/src/d.ts
@@ -3,12 +3,15 @@ import { VNode } from '@dojo/interfaces/vdom';
 import Symbol from '@dojo/shim/Symbol';
 import { h } from 'maquette';
 import {
+	Constructor,
 	DNode,
 	HNode,
 	WNode,
 	VirtualDomProperties,
 	WidgetProperties,
-	WidgetBaseConstructor
+	WidgetBaseConstructor,
+	WidgetBaseInterface,
+	DefaultWidgetBaseInterface
 } from './interfaces';
 import WidgetRegistry from './WidgetRegistry';
 
@@ -25,7 +28,7 @@ export const HNODE = Symbol('Identifier for a HNode.');
 /**
  * Helper function that returns true if the `DNode` is a `WNode` using the `type` property
  */
-export function isWNode(child: DNode): child is WNode {
+export function isWNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterface>(child: DNode<W>): child is WNode<W> {
 	return Boolean(child && (typeof child !== 'string') && child.type === WNODE);
 }
 
@@ -70,7 +73,7 @@ export const registry = new WidgetRegistry();
 /**
  * Wrapper function for calls to create a widget.
  */
-export function w<P extends WidgetProperties>(widgetConstructor: WidgetBaseConstructor<P> | string, properties: WidgetProperties & P, children: DNode[] = []): WNode {
+export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<W> | string, properties: W['properties'], children: W['children'] = []): WNode<W> {
 
 	return {
 		children,

--- a/src/d.ts
+++ b/src/d.ts
@@ -8,8 +8,6 @@ import {
 	HNode,
 	WNode,
 	VirtualDomProperties,
-	WidgetProperties,
-	WidgetBaseConstructor,
 	WidgetBaseInterface,
 	DefaultWidgetBaseInterface
 } from './interfaces';

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -326,8 +326,6 @@ export interface PropertiesChangeRecord<P extends WidgetProperties> {
 	properties: P;
 }
 
-
-
 /**
  * WidgetBase constructor type
  */

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -350,7 +350,7 @@ export interface WidgetBaseInterface<
 	/**
 	 * Returns the widget's children
 	 */
-	readonly children: C[];
+	readonly children: (C | null)[];
 
 	/**
 	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
@@ -365,7 +365,7 @@ export interface WidgetBaseInterface<
 	/**
 	 * Sets the widget's children
 	 */
-	__setChildren__(children: C[]): void;
+	__setChildren__(children: (C | null)[]): void;
 
 	/**
 	 * Main internal function for dealing with widget rendering

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -265,21 +265,21 @@ export interface HNode {
 /**
  * Wrapper for `w`
  */
-export interface WNode {
+export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> {
 	/**
 	 * Constructor to create a widget or string constructor label
 	 */
-	widgetConstructor: WidgetConstructor | string;
+	widgetConstructor: Constructor<W> | string;
 
 	/**
 	 * Properties to set against a widget instance
 	 */
-	properties: WidgetProperties;
+	properties: W['properties'];
 
 	/**
 	 * DNode children
 	 */
-	children: DNode[];
+	children: W['children'];
 
 	/**
 	 * The type of node
@@ -290,7 +290,7 @@ export interface WNode {
 /**
  * union type for all possible return types from render
  */
-export type DNode = HNode | WNode | string | null;
+export type DNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> = HNode | WNode<W> | string | null;
 
 /**
  * the event emitted on properties:changed
@@ -326,20 +326,23 @@ export interface PropertiesChangeRecord<P extends WidgetProperties> {
 	properties: P;
 }
 
-/**
- *
- */
-export type WidgetBaseConstructor<P extends WidgetProperties> = Constructor<WidgetBaseInterface<P>>;
+
 
 /**
  * WidgetBase constructor type
  */
-export type WidgetConstructor = WidgetBaseConstructor<WidgetProperties>;
+export type WidgetBaseConstructor<
+	P extends WidgetProperties = WidgetProperties,
+	C extends DNode = DNode> = Constructor<WidgetBaseInterface<P, C>>;
+
+export interface DefaultWidgetBaseInterface extends WidgetBaseInterface<WidgetProperties, DNode<DefaultWidgetBaseInterface>> {}
 
 /**
  * The interface for WidgetBase
  */
-export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented {
+export interface WidgetBaseInterface<
+	P extends WidgetProperties = WidgetProperties,
+	C extends DNode = DNode<DefaultWidgetBaseInterface>> extends Evented {
 
 	/**
 	 * Widget properties
@@ -349,7 +352,7 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	/**
 	 * Returns the widget's children
 	 */
-	readonly children: DNode[];
+	readonly children: C[];
 
 	/**
 	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
@@ -364,7 +367,7 @@ export interface WidgetBaseInterface<P extends WidgetProperties> extends Evented
 	/**
 	 * Sets the widget's children
 	 */
-	__setChildren__(children: DNode[]): void;
+	__setChildren__(children: C[]): void;
 
 	/**
 	 * Main internal function for dealing with widget rendering

--- a/src/mixins/Container.ts
+++ b/src/mixins/Container.ts
@@ -1,7 +1,7 @@
 import { WidgetBase, beforeRender } from './../WidgetBase';
 import { w } from './../d';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';
-import { GetProperties, GetChildren, InjectorProperties } from './../Injector';
+import { GetProperties, GetChildren, BaseInjector } from './../Injector';
 
 /**
  * The binding mappers for properties and children
@@ -38,7 +38,7 @@ export function Container<P extends WidgetProperties, T extends Constructor<Widg
 		@beforeRender()
 		protected beforeRender(renderFunc: Function, properties: P, children: DNode[]) {
 			return () => {
-				return w<InjectorProperties>(name, {
+				return w<BaseInjector<any>>(name, {
 					render: super.render,
 					getProperties,
 					properties,

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -139,7 +139,7 @@ export function I18nMixin<T extends Constructor<WidgetBase<I18nProperties>>>(bas
 				this.invalidate();
 			});
 		}
-	};
+	}
 
 	return I18n;
 }

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -12,7 +12,7 @@ import { WidgetBase } from './../WidgetBase';
 export enum ProjectorAttachState {
 	Attached = 1,
 	Detached
-};
+}
 
 /**
  * Attach type for the projector
@@ -21,7 +21,7 @@ export enum AttachType {
 	Append = 1,
 	Merge = 2,
 	Replace = 3
-};
+}
 
 export interface AttachOptions {
 

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -29,7 +29,7 @@ export function RegistryMixin<T extends Constructor<WidgetBase<RegistryMixinProp
 				value: value
 			};
 		}
-	};
+	}
 	return Registry;
 }
 

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -335,7 +335,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 			}
 			return duplicate;
 		}
-	};
+	}
 
 	return Themeable;
 }

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -4,9 +4,19 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { stub, spy } from 'sinon';
 import { v, w, registry } from '../../src/d';
-import { DNode } from '../../src/interfaces';
+import { DNode, WidgetProperties } from '../../src/interfaces';
 import { WidgetBase, diffProperty, DiffType, afterRender, beforeRender, onPropertiesChanged } from '../../src/WidgetBase';
 import WidgetRegistry, { WIDGET_BASE_TYPE } from './../../src/WidgetRegistry';
+
+interface TestProperties extends WidgetProperties {
+	id: string;
+	foo: string;
+	bar?: null | string;
+	baz?: number;
+	qux?: boolean;
+}
+
+class TestWidget extends WidgetBase<TestProperties> {}
 
 registerSuite({
 	name: 'WidgetBase',
@@ -37,7 +47,7 @@ registerSuite({
 	},
 	diffProperties: {
 		'no updated properties'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
@@ -47,7 +57,7 @@ registerSuite({
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 		},
 		'updated properties'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
@@ -57,7 +67,7 @@ registerSuite({
 			widgetBase.__setProperties__({ id: 'id', foo: 'baz' });
 		},
 		'new properties'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
@@ -67,7 +77,7 @@ registerSuite({
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar', bar: 'baz' });
 		},
 		'updated / new properties with falsy values'() {
-			const widgetBase = new WidgetBase();
+			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { assign } from '@dojo/core/lang';
-import { DNode, HNode, WidgetProperties } from '../../src/interfaces';
+import { DNode, HNode, WNode, WidgetProperties } from '../../src/interfaces';
 import { WidgetBase } from '../../src/WidgetBase';
 import { v, w, decorate, registry, WNODE, HNODE, isWNode, isHNode } from '../../src/d';
 import WidgetRegistry from './../../src/WidgetRegistry';
@@ -12,11 +12,21 @@ class TestFactoryRegistry extends WidgetRegistry {
 	}
 }
 
-interface TestProperties extends WidgetProperties {
-	mand: boolean;
+interface ChildProperties extends WidgetProperties {
+	myChildProperty: string;
 }
 
-class TestWidget extends WidgetBase<TestProperties> {
+interface TestProperties extends WidgetProperties {
+	required: boolean;
+}
+
+class TestChildWidget extends WidgetBase<ChildProperties> {
+	render() {
+		return v('div');
+	}
+}
+
+class TestWidget extends WidgetBase<TestProperties, WNode<TestChildWidget>> {
 	render() {
 		return v('outernode', { type: 'mytype' }, [
 			v('child-one'),
@@ -57,24 +67,42 @@ registerSuite({
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
-		'create WNode wrapper using constructor with properties and children'() {
-			const properties = { mand: true };
-			const dNode = w(TestWidget, properties, [ w(WidgetBase, properties) ]);
+		'create WNode wrapper using constructor with children'() {
+			const dNode = w(TestWidget, { required: true }, [ w(TestChildWidget, { myChildProperty: '' }) ]);
 
 			assert.equal(dNode.type, WNODE);
 			assert.deepEqual(dNode.widgetConstructor, TestWidget);
-			assert.deepEqual(dNode.properties, { mand: true });
+			assert.lengthOf(dNode.children, 1);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper using constructor with VNode children'() {
+			const dNode = w(TestChildWidget, { myChildProperty: '' }, [ v('div') ]);
+
+			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, TestChildWidget);
+			assert.lengthOf(dNode.children, 1);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper using constructor with properties and children'() {
+			const properties: any = { id: 'id', classes: [ 'world' ] };
+			const dNode = w(WidgetBase, properties, [ w(WidgetBase, properties) ]);
+
+			assert.equal(dNode.type, WNODE);
+			assert.deepEqual(dNode.widgetConstructor, WidgetBase);
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
 		'create WNode wrapper using label with properties and children'() {
-			const properties = { mand: false };
-			const dNode = w<TestProperties>('my-widget', properties, [ w(WidgetBase, properties) ]);
+			const properties: any = { id: 'id', classes: [ 'world' ] };
+			const dNode = w('my-widget', properties, [ w(WidgetBase, properties) ]);
 
 			assert.equal(dNode.type, WNODE);
 			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
-			assert.deepEqual(dNode.properties, { mand: false });
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -39,7 +39,7 @@ class TestWidget extends WidgetBase<TestProperties, WNode<TestChildWidget>> {
 			w(WidgetBase, { myProperty: true })
 		]);
 	}
-};
+}
 
 registerSuite({
 	name: 'd',

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -4,13 +4,6 @@ import { assign } from '@dojo/core/lang';
 import { DNode, HNode, WNode, WidgetProperties } from '../../src/interfaces';
 import { WidgetBase } from '../../src/WidgetBase';
 import { v, w, decorate, registry, WNODE, HNODE, isWNode, isHNode } from '../../src/d';
-import WidgetRegistry from './../../src/WidgetRegistry';
-
-class TestFactoryRegistry extends WidgetRegistry {
-	clear(this: any) {
-		this.registry.clear();
-	}
-}
 
 interface ChildProperties extends WidgetProperties {
 	myChildProperty: string;

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -57,7 +57,7 @@ registerSuite({
 			class IntegrationTest extends TestWithRegistry {
 				render() {
 					return v('div', [
-						w('test', { id: `${Math.random()}` })
+						w<any>('test', { id: `${Math.random()}` })
 					]);
 				}
 			}

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -33,28 +33,6 @@ class StackedTestWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> 
 @theme(baseThemeClasses1)
 class DuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> { }
 
-class NonDecoratorTestWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> {
-	constructor() {
-		super();
-		theme(baseThemeClasses1)(this);
-	}
-}
-
-class NonDecoratorSubClassTestWidget extends NonDecoratorTestWidget {
-	constructor() {
-		super();
-		theme(baseThemeClasses2)(this);
-	}
-}
-
-class NonDecoratorStackedTestWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> {
-	constructor() {
-		super();
-		theme(baseThemeClasses1)(this);
-		theme(baseThemeClasses2)(this);
-	}
-}
-
 class NonDecoratorDuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> {
 	constructor() {
 		super();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
 		"moduleResolution": "node",
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,7 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
+		"no-unused-variable": [ true ],
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
@@ -58,7 +58,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
 		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
 		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
 	}

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,6 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": [ true ],
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Enhance the existing typings to enable the expected children of a widget to be typed; This includes the widget and the properties for the widget.

`WidgetBase` supports a second generic type for `children` and defaults to `DNode` but can be restricted to `WNode` (any widget or properties) or more specifically `WNode<MyChildWidget>`.

This change includes adding a default of `WidgetProperties` for the 1st generic argument, `P` in both `WidgetBase` and `WidgetBaseInterface`.

<p><details>
  <summary><b>Examples</b></summary>
  <div>

```ts
import { WidgetBase } from './WidgetBase';
import { WidgetProperties, WNode } from './interfaces';
import { w, v } from './d';

interface MyWidgetProperties extends WidgetProperties {
	foo: string;
}
interface MyOtherWidgetProperties extends WidgetProperties {
	baz: boolean;
}
class MyWidget extends WidgetBase<MyWidgetProperties> {}
class MyOtherWidget extends WidgetBase<MyOtherWidgetProperties> {}
class MyCustomisedWidget extends WidgetBase<WidgetProperties> {
	doSomthingWidgety() { }
}
class AnotherCustomisedWidget extends WidgetBase<WidgetProperties> {
	doSomthingWidgety() { }
}
class MyContainer extends WidgetBase {}
class MyWidgetContainer extends WidgetBase<WidgetProperties, WNode<MyWidget>> {}
class MyCustomisedWidgetContainer extends WidgetBase<WidgetProperties, WNode<MyCustomisedWidget>> {}

// Correctly reports the the properties for `MyWidget` have not been fulfilled.
w(MyContainer, {}, [
	v('div'),
	w(MyWidget, { })
]);

// The errors are now resolved due after providing the requried properties for `MyWidget`
w(MyContainer, {}, [
	w(MyWidget, { foo: '' }),
	v('div')
]);

// Correct reports errors as `MyOtherWidget` does not duck type to `MyWidget`
w(MyWidgetContainer, {}, [
	w(MyOtherWidget, { baz: true }),
	w(MyWidget, { foo: '' })
]);

// Errors resolved when all children match the correct duck type
w(MyWidgetContainer, {}, [
	w(MyWidget, { foo: '' })
]);

// Correct reports errors as `WidgetBase` does not duck type to `MyCustomisedWidget`, missing `doSomthingWidgety`.
w(MyCustomisedWidgetContainer, {}, [
	w(WidgetBase, { }),
	w(MyCustomisedWidget, { })
]);

// Errors resolved when all children match the correct duck type
w(MyCustomisedWidgetContainer, {}, [
	w(MyCustomisedWidget, { key: '' }),
	w(AnotherCustomisedWidget, {}),
	w<MyCustomisedWidget>('customised-widget', {}) // when using registry string, need to pass widget type.
]);
```
</div></details></p>

**IDE errors:**

<img width="745" alt="typingexamples_ts_-_widget-core" src="https://cloud.githubusercontent.com/assets/1982678/25651640/19c64e8c-2fdc-11e7-9235-08c79bae4ac6.png">

Resolves #465
