### PR TITLE
Support for injecting a theme into Themeable widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,38 @@ class MyThemeableWidget extends ThemeableMixin(WidgetBase)<MyThemeableWidgetProp
 
 The theme can be applied to individual widgets or to a project and property passed down to its children.
 
+##### Injecting a theme
+
+The theming system supports injecting a theme configured outside of the usual property passing down the widget tree. 
+
+This is configured using a `ThemeInjectorContext` that is passed to the `Injector` mixin along with the `ThemeInjector` class. Once the theme injector is defined in the registry the `theme` can be changed by called the `ThemeInjectorContext#set(theme: any)` API on the instance of the injector context.
+
+```ts
+// Create the singleton injector context
+const themeInjectorContext = new ThemeInjectorContext(myTheme);
+
+// Create the base ThemeInjector using the singleton context and the Injector mixin
+const ThemeInjectorBase = Injector<ThemeInjectorContext, Constructor<ThemeInjector>>(ThemeInjector, themeInjectorContext);
+
+// Define the created ThemeInjector against the static key exported from `Themeable`
+registry.define(INJECTED_THEME_KEY, ThemeInjectorBase);
+```
+
+Once this is defined any themeable widgets without an explicit `theme` property will be controlled via the theme set within the `themeInjectorContext`. To change the theme simple call `themeInjectorContext.set(myNewTheme)` and all widgets that are using the global theme will be updated to the new theme.
+
+Finally `Themeable` exports a helper function wraps the behaviour defined above and returns the context, with optional parameters for the `theme` and the `registry` to defined the injector in. If no `registry` is provided then the global registry is used.
+
+```ts
+// uses global registry
+const context = registerThemeInjector(myTheme);
+
+// setting the theme
+context.set(myNewTheme);
+
+// uses the user defined registry
+const context = registryThemeInjector(myTheme, myRegistry);
+```
+
 ##### Overriding Theme Classes
 
 As we are using `css-modules` to scope widget css classes, the generated class names cannot be used to target specific nodes and apply custom styling to them. Instead you must use the `extraClasses` property to pass your generated classes to the widget. This will only effect one instance of a widget and will be applied on top of, rather than instead of, theme classes.

--- a/README.md
+++ b/README.md
@@ -742,9 +742,9 @@ The theme can be applied to individual widgets or to a project and property pass
 
 ##### Injecting a theme
 
-The theming system supports injecting a theme that is configured outside of the usual property passing down the widget tree. 
+The theming system supports injecting a theme that is configured externally to the usual mechanism of passing properties down the widget tree.
 
-This is done using a `ThemeInjectorContext` instance that is passed to the `Injector` mixin along with the `ThemeInjector` class. Once the theme injector is defined in the registry the `theme` can be changed by called the `ThemeInjectorContext#set(theme: any)` API on the instance of the injector context.
+This is done using a `ThemeInjectorContext` instance that is passed to the `Injector` mixin along with the `ThemeInjector` class. Once the theme injector is defined in the registry, the `theme` can be changed by calling the `ThemeInjectorContext#set(theme: any)` API on the instance of the injector context.
 
 ```ts
 // Create the singleton injector context
@@ -757,9 +757,9 @@ const ThemeInjectorBase = Injector<ThemeInjectorContext, Constructor<ThemeInject
 registry.define(INJECTED_THEME_KEY, ThemeInjectorBase);
 ```
 
-Once this is defined any themeable widgets without an explicit `theme` property will be controlled via the theme set within the `themeInjectorContext`. To change the theme simply call `themeInjectorContext.set(myNewTheme);` and all widgets that are using the injected theme will be updated to the new theme.
+Once this theme injector is defined, any themeable widgets without an explicit `theme` property will be controlled via the theme set within the `themeInjectorContext`. To change the theme simply call `themeInjectorContext.set(myNewTheme);` and all widgets that are using the injected theme will be updated to the new theme.
 
-To make this even easier `Themeable` exports a helper function wraps the behaviour defined above and returns the context, with a parameter for the `theme` and an optional `registry` to that the injector will be defined in. If a `registry` is not provided then the global `registry` is used.
+To make this even easier, `Themeable` exports a helper function wraps the behavior defined above and returns the context, with a parameter for the `theme` and an optional `registry` for the injector to be defined. If a `registry` is not provided then the global `registry` is used.
 
 ```ts
 // Uses global registry

--- a/README.md
+++ b/README.md
@@ -742,9 +742,9 @@ The theme can be applied to individual widgets or to a project and property pass
 
 ##### Injecting a theme
 
-The theming system supports injecting a theme configured outside of the usual property passing down the widget tree. 
+The theming system supports injecting a theme that is configured outside of the usual property passing down the widget tree. 
 
-This is configured using a `ThemeInjectorContext` that is passed to the `Injector` mixin along with the `ThemeInjector` class. Once the theme injector is defined in the registry the `theme` can be changed by called the `ThemeInjectorContext#set(theme: any)` API on the instance of the injector context.
+This is done using a `ThemeInjectorContext` instance that is passed to the `Injector` mixin along with the `ThemeInjector` class. Once the theme injector is defined in the registry the `theme` can be changed by called the `ThemeInjectorContext#set(theme: any)` API on the instance of the injector context.
 
 ```ts
 // Create the singleton injector context
@@ -757,18 +757,18 @@ const ThemeInjectorBase = Injector<ThemeInjectorContext, Constructor<ThemeInject
 registry.define(INJECTED_THEME_KEY, ThemeInjectorBase);
 ```
 
-Once this is defined any themeable widgets without an explicit `theme` property will be controlled via the theme set within the `themeInjectorContext`. To change the theme simple call `themeInjectorContext.set(myNewTheme)` and all widgets that are using the global theme will be updated to the new theme.
+Once this is defined any themeable widgets without an explicit `theme` property will be controlled via the theme set within the `themeInjectorContext`. To change the theme simply call `themeInjectorContext.set(myNewTheme);` and all widgets that are using the injected theme will be updated to the new theme.
 
-Finally `Themeable` exports a helper function wraps the behaviour defined above and returns the context, with optional parameters for the `theme` and the `registry` to defined the injector in. If no `registry` is provided then the global registry is used.
+To make this even easier `Themeable` exports a helper function wraps the behaviour defined above and returns the context, with a parameter for the `theme` and an optional `registry` to that the injector will be defined in. If a `registry` is not provided then the global `registry` is used.
 
 ```ts
-// uses global registry
+// Uses global registry
 const context = registerThemeInjector(myTheme);
 
-// setting the theme
+// Setting the theme
 context.set(myNewTheme);
 
-// uses the user defined registry
+// Uses the user defined registry
 const context = registryThemeInjector(myTheme, myRegistry);
 ```
 

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -28,7 +28,7 @@ export interface Mappers {
  */
 export const defaultMappers: Mappers = {
 	getProperties(inject: any, properties: any): any {
-		return {};
+		return Object.create(null);
 	},
 	getChildren(inject: any, children: DNode[]): DNode[] {
 		return [];

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -15,12 +15,32 @@ export interface GetChildren {
 	<C>(inject: C, children: DNode[]): DNode[];
 }
 
+/**
+ * The binding mappers for properties and children
+ */
+export interface Mappers {
+	getProperties: GetProperties;
+	getChildren: GetChildren;
+}
+
+/**
+ * Default noop Mappers for the container.
+ */
+export const defaultMappers: Mappers = {
+	getProperties(inject: any, properties: any): any {
+		return {};
+	},
+	getChildren(inject: any, children: DNode[]): DNode[] {
+		return [];
+	}
+};
+
 export interface InjectorProperties extends WidgetProperties {
 	bind: any;
 	render(): DNode;
-	getProperties: GetProperties;
+	getProperties?: GetProperties;
 	properties: WidgetProperties;
-	getChildren: GetChildren;
+	getChildren?: GetChildren;
 	children: DNode[];
 }
 
@@ -65,9 +85,9 @@ export function Injector<C, T extends Constructor<BaseInjector<C>>>(Base: T, con
 			const {
 				render,
 				properties,
-				getProperties,
+				getProperties = defaultMappers.getProperties,
 				children,
-				getChildren
+				getChildren = defaultMappers.getChildren
 			} = this.properties;
 			const injectedChildren = getChildren(this.toInject(), children);
 

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -16,7 +16,7 @@ export interface GetChildren {
 }
 
 /**
- * The binding mappers for properties and children
+ * The binding mappers for properties and children.
  */
 export interface Mappers {
 	getProperties: GetProperties;

--- a/src/mixins/Container.ts
+++ b/src/mixins/Container.ts
@@ -1,27 +1,7 @@
 import { WidgetBase, beforeRender } from './../WidgetBase';
 import { w } from './../d';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';
-import { GetProperties, GetChildren, BaseInjector } from './../Injector';
-
-/**
- * The binding mappers for properties and children
- */
-export interface Mappers {
-	getProperties: GetProperties;
-	getChildren: GetChildren;
-}
-
-/**
- * Default noop Mappers for the container.
- */
-const defaultMappers: Mappers = {
-	getProperties(inject: any, properties: any): any {
-		return {};
-	},
-	getChildren(inject: any, children: DNode[]): DNode[] {
-		return [];
-	}
-};
+import { defaultMappers, BaseInjector } from './../Injector';
 
 /**
  * Given the registered name of an Injector entry with property and child binding mappers, the
@@ -36,11 +16,11 @@ export function Container<P extends WidgetProperties, T extends Constructor<Widg
 
 	class Container extends Base {
 		@beforeRender()
-		protected beforeRender(renderFunc: Function, properties: P, children: DNode[]) {
+		protected beforeRender(renderFunc: () => DNode, properties: P, children: DNode[]) {
 			return () => {
 				return w<BaseInjector<any>>(name, {
 					bind: this,
-					render: super.render,
+					render: renderFunc,
 					getProperties,
 					properties,
 					getChildren,

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -273,6 +273,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 				const hasInjectedTheme = this.registries.has(INJECTED_THEME_KEY);
 				if (hasInjectedTheme) {
 					return w<ThemeInjector>(INJECTED_THEME_KEY, {
+						bind: this,
 						render: renderFunc,
 						getProperties: (inject: ThemeInjectorContext, properties: ThemeableProperties): ThemeableProperties => {
 							if (!properties.theme && this._theme !== properties.injectedTheme) {

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -144,7 +144,7 @@ export class ThemeInjectorContext extends Evented {
 		this.theme = theme;
 		this.emit({ type: 'invalidate' });
 	}
-};
+}
 
 export class ThemeInjector extends BaseInjector<ThemeInjectorContext> {
 	constructor(context: ThemeInjectorContext) {

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -27,6 +27,7 @@ export type ClassNames = {
  * Properties required for the themeable mixin
  */
 export interface ThemeableProperties extends WidgetProperties {
+	injectedTheme?: any;
 	theme?: any;
 	extraClasses?: any;
 }
@@ -273,11 +274,11 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 				if (hasInjectedTheme) {
 					return w<ThemeInjector>(INJECTED_THEME_KEY, {
 						render: renderFunc,
-						getProperties(inject: ThemeInjectorContext, properties: ThemeableProperties): ThemeableProperties {
-							if (!properties.theme) {
-								return { theme: inject.theme };
+						getProperties: (inject: ThemeInjectorContext, properties: ThemeableProperties): ThemeableProperties => {
+							if (!properties.theme && this._theme !== properties.injectedTheme) {
+								this._recalculateClasses = true;
 							}
-							return {};
+							return { injectedTheme: inject.theme };
 						},
 						properties,
 						children
@@ -362,7 +363,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeablePropert
 		 * Recalculate registered classes for current theme.
 		 */
 		private recalculateThemeClasses() {
-			const { properties: { theme = {} } } = this;
+			const { properties: { injectedTheme = {}, theme = injectedTheme } } = this;
 			if (!this._registeredBaseThemes) {
 				this._registeredBaseThemes = [ ...this.getDecorator('baseThemeClasses') ].reverse();
 				this.checkForDuplicates();

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -142,7 +142,7 @@ export class ThemeInjectorContext extends Evented {
 	private _theme: any;
 
 	/**
-	 * @param theme optional theme to initialize the context with
+	 * @param theme optional theme to initialize the context
 	 */
 	constructor(theme?: any) {
 		super({});
@@ -166,7 +166,7 @@ export class ThemeInjectorContext extends Evented {
 }
 
 /**
- * Custom ThemeInjector class that listens to the invalidate event
+ * Custom `ThemeInjector` class that listens to the `invalidate` event
  * from the context to `invalidate` any widgets the have had a theme
  * injected.
  */
@@ -178,8 +178,8 @@ export class ThemeInjector extends BaseInjector<ThemeInjectorContext> {
 }
 
 /**
- * Convience function that given a theme and an optional registry, the theme
- * injector is defined against the registry and the theme context return.
+ * Convenience function that is given a theme and an optional registry, the theme
+ * injector is defined against the registry, returning the theme context.
  *
  * @param theme the theme to set
  * @param themeRegistry registry to define the theme injector against. Defaults

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -59,7 +59,7 @@ type ThemeClasses = { [key: string]: string; };
 
 const THEME_KEY = ' _key';
 
-export const INJECTED_THEME_KEY = 'theme';
+export const INJECTED_THEME_KEY = Symbol('theme');
 
 /**
  * Interface for the ThemeableMixin

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -85,6 +85,7 @@ registerSuite({
 
 		const injector = new InjectorWidget<any>();
 		injector.__setProperties__({
+			bind: context,
 			render,
 			properties: testProperties,
 			children: testChildren

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -71,6 +71,30 @@ registerSuite({
 		assert.deepEqual(renderedNode.children[2].properties, { bind });
 		renderedNode.children[0].properties.testFunction();
 	},
+	'uses default mappers'() {
+		const context = {
+			foo: 1,
+			bar: '2'
+		};
+		const testProperties = {
+			qux: 'baz'
+		};
+		const testChildren: DNode[] = [ 'child' ];
+		const render = (): DNode => { return 'Called Render'; };
+		const InjectorWidget = Injector(TestInjector, context);
+
+		const injector = new InjectorWidget<any>();
+		injector.__setProperties__({
+			render,
+			properties: testProperties,
+			children: testChildren
+		});
+
+		const renderedNode = injector.render();
+		assert.deepEqual(testProperties, { qux: 'baz' });
+		assert.deepEqual(testChildren, [ 'child' ]);
+		assert.strictEqual(renderedNode, 'Called Render');
+	},
 	'injector ignores constructor arguments'() {
 		const context = {
 			foo: 1,

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -7,12 +7,13 @@ import {
 	ThemeableProperties,
 	INJECTED_THEME_KEY,
 	ThemeInjector,
-	ThemeInjectorContext
+	ThemeInjectorContext,
+	registerThemeInjector
 } from '../../../src/mixins/Themeable';
 import { Injector } from './../../../src/Injector';
 import { WidgetBase } from '../../../src/WidgetBase';
 import { WidgetRegistry } from '../../../src/WidgetRegistry';
-import { Constructor, WidgetProperties } from '../../../src/interfaces';
+import { WidgetProperties } from '../../../src/interfaces';
 import { RegistryMixin } from './../../../src/mixins/Registry';
 import { v, w } from '../../../src/d';
 import { stub, SinonStub } from 'sinon';
@@ -401,7 +402,8 @@ registerSuite({
 	'injecting a theme': {
 		'theme can be injected by defining a ThemeInjector with registry'() {
 			const themeInjectorContext = new ThemeInjectorContext(testTheme1);
-			testRegistry.define(INJECTED_THEME_KEY, Injector<ThemeInjectorContext, Constructor<ThemeInjector>>(ThemeInjector, themeInjectorContext));
+			const InjectorBase = Injector(ThemeInjector, themeInjectorContext);
+			testRegistry.define(INJECTED_THEME_KEY, InjectorBase);
 			class InjectedTheme extends TestWidget {
 				render() {
 					return v('div', { classes: this.classes(baseThemeClasses1.class1) });
@@ -414,7 +416,8 @@ registerSuite({
 		},
 		'theme will not be injected if a theme has been passed via a property'() {
 			const themeInjectorContext = new ThemeInjectorContext(testTheme1);
-			testRegistry.define(INJECTED_THEME_KEY, Injector<ThemeInjectorContext, Constructor<ThemeInjector>>(ThemeInjector, themeInjectorContext));
+			const InjectorBase = Injector(ThemeInjector, themeInjectorContext);
+			testRegistry.define(INJECTED_THEME_KEY, InjectorBase);
 			class InjectedTheme extends TestWidget {
 				render() {
 					return v('div', { classes: this.classes(baseThemeClasses1.class1) });
@@ -437,8 +440,7 @@ registerSuite({
 			assert.deepEqual(vNode.properties.classes, { baseClass1: true });
 		},
 		'setting the theme invalidates all "Themeable" widgets and the new theme is used'() {
-			const themeInjectorContext = new ThemeInjectorContext(testTheme1);
-			testRegistry.define(INJECTED_THEME_KEY, Injector<ThemeInjectorContext, Constructor<ThemeInjector>>(ThemeInjector, themeInjectorContext));
+			const themeInjectorContext = registerThemeInjector(testTheme1, testRegistry);
 			let invalidateCallCount = 0;
 			class InjectedTheme extends TestWidget {
 				render() {

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -15,7 +15,7 @@ import { WidgetBase } from '../../../src/WidgetBase';
 import { WidgetRegistry } from '../../../src/WidgetRegistry';
 import { WidgetProperties } from '../../../src/interfaces';
 import { RegistryMixin } from './../../../src/mixins/Registry';
-import { v, w } from '../../../src/d';
+import { v, w, registry } from '../../../src/d';
 import { stub, SinonStub } from 'sinon';
 
 import * as baseThemeClasses1 from './../../support/styles/testWidget1.css';
@@ -475,6 +475,11 @@ registerSuite({
 			assert.deepEqual(vNode.children[0].properties.classes, { theme1Class1: false, theme2Class1: true });
 			assert.deepEqual(vNode.children[1].properties.classes, { theme1Class1: false, theme2Class1: true });
 			assert.strictEqual(invalidateCallCount, 2);
+		},
+		'registerThemeInjector defaults to the global registry'() {
+			assert.isNull(registry.get(INJECTED_THEME_KEY));
+			registerThemeInjector(testTheme1);
+			assert.isOk(registry.get(INJECTED_THEME_KEY));
 		}
 	},
 	'integration': {

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -475,6 +475,12 @@ registerSuite({
 			assert.deepEqual(vNode.children[0].properties.classes, { theme1Class1: false, theme2Class1: true });
 			assert.deepEqual(vNode.children[1].properties.classes, { theme1Class1: false, theme2Class1: true });
 			assert.strictEqual(invalidateCallCount, 2);
+			themeInjectorContext.set(testTheme1);
+			vNode = testWidget.__render__();
+			assert.lengthOf(vNode.children, 2);
+			assert.deepEqual(vNode.children[0].properties.classes, { theme2Class1: false, theme1Class1: true });
+			assert.deepEqual(vNode.children[1].properties.classes, { theme2Class1: false, theme1Class1: true });
+			assert.strictEqual(invalidateCallCount, 4);
 		},
 		'registerThemeInjector defaults to the global registry'() {
 			assert.isNull(registry.get(INJECTED_THEME_KEY));

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -467,7 +467,6 @@ registerSuite({
 			assert.deepEqual(vNode.children[0].properties.classes, { theme1Class1: true });
 			assert.deepEqual(vNode.children[1].properties.classes, { theme1Class1: true });
 			assert.strictEqual(invalidateCallCount, 0);
-			debugger;
 			themeInjectorContext.set(testTheme2);
 			vNode = testWidget.__render__();
 			assert.lengthOf(vNode.children, 2);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for globally defining the `theme` using a `Registry` and `ThemeInjector`. If the `theme` has been defined in the registry, it will inject the theme property into all themeable widgets that have not explicitly received a `theme` property.

When the `theme` is updated using the `.set` API of the theme context, all themeable widgets are invalidated.

Resolves #474 
