### PR TITLE
support symbol as a label for registries

### DIFF
--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,6 +1,6 @@
 import { Evented } from '@dojo/core/Evented';
-import { WidgetBaseConstructor } from './interfaces';
-import WidgetRegistry, { RegistryLabel } from './WidgetRegistry';
+import { WidgetBaseConstructor, RegistryLabel } from './interfaces';
+import WidgetRegistry from './WidgetRegistry';
 
 export default class RegistryHandler extends Evented {
 	private _registries: { handle?: any, registry: WidgetRegistry }[] = [];

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,6 +1,6 @@
 import { Evented } from '@dojo/core/Evented';
 import { WidgetBaseConstructor, RegistryLabel } from './interfaces';
-import WidgetRegistry, { getLoadedEventType } from './WidgetRegistry';
+import WidgetRegistry, { WidgetRegistryEventObject } from './WidgetRegistry';
 
 export default class RegistryHandler extends Evented {
 	private _registries: { handle?: any, registry: WidgetRegistry }[] = [];
@@ -45,10 +45,12 @@ export default class RegistryHandler extends Evented {
 				return item;
 			}
 			else if (!registryWrapper.handle) {
-				registryWrapper.handle = registryWrapper.registry.on(getLoadedEventType(widgetLabel), () => {
-					this.emit({ type: 'invalidate' });
-					registryWrapper.handle.destroy();
-					registryWrapper.handle = undefined;
+				registryWrapper.handle = registryWrapper.registry.on(widgetLabel, (event: WidgetRegistryEventObject) => {
+					if (event.action === 'loaded') {
+						this.emit({ type: 'invalidate' });
+						registryWrapper.handle.destroy();
+						registryWrapper.handle = undefined;
+					}
 				});
 			}
 		}

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,6 +1,6 @@
 import { Evented } from '@dojo/core/Evented';
 import { WidgetBaseConstructor } from './interfaces';
-import WidgetRegistry from './WidgetRegistry';
+import WidgetRegistry, { RegistryLabel } from './WidgetRegistry';
 
 export default class RegistryHandler extends Evented {
 	private _registries: { handle?: any, registry: WidgetRegistry }[] = [];
@@ -31,13 +31,13 @@ export default class RegistryHandler extends Evented {
 		});
 	}
 
-	has(widgetLabel: string): boolean {
+	has(widgetLabel: RegistryLabel): boolean {
 		return this._registries.some((registryWrapper) => {
 			return registryWrapper.registry.has(widgetLabel);
 		});
 	}
 
-	get(widgetLabel: string): WidgetBaseConstructor | null {
+	get(widgetLabel: RegistryLabel): WidgetBaseConstructor | null {
 		for (let i = 0; i < this._registries.length; i++) {
 			const registryWrapper = this._registries[i];
 			const item = registryWrapper.registry.get(widgetLabel);

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,6 +1,6 @@
 import { Evented } from '@dojo/core/Evented';
 import { WidgetBaseConstructor, RegistryLabel } from './interfaces';
-import WidgetRegistry from './WidgetRegistry';
+import WidgetRegistry, { getLoadedEventType } from './WidgetRegistry';
 
 export default class RegistryHandler extends Evented {
 	private _registries: { handle?: any, registry: WidgetRegistry }[] = [];
@@ -45,7 +45,7 @@ export default class RegistryHandler extends Evented {
 				return item;
 			}
 			else if (!registryWrapper.handle) {
-				registryWrapper.handle = registryWrapper.registry.on(`loaded:${widgetLabel}`, () => {
+				registryWrapper.handle = registryWrapper.registry.on(getLoadedEventType(widgetLabel), () => {
 					this.emit({ type: 'invalidate' });
 					registryWrapper.handle.destroy();
 					registryWrapper.handle = undefined;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -17,7 +17,7 @@ import {
 	PropertiesChangeEvent,
 	HNode
 } from './interfaces';
-import { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './WidgetRegistry';
+import { isWidgetBaseConstructor, WIDGET_BASE_TYPE, RegistryLabel } from './WidgetRegistry';
 import RegistryHandler from './RegistryHandler';
 
 export { DiffType };
@@ -164,7 +164,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 	/**
 	 * cached chldren map for instance management
 	 */
-	private _cachedChildrenMap: Map<string | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
+	private _cachedChildrenMap: Map<RegistryLabel | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
 
 	/**
 	 * map of specific property diff functions
@@ -519,7 +519,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 			let { widgetConstructor } = dNode;
 			let child: WidgetBaseInterface<WidgetProperties>;
 
-			if (typeof widgetConstructor === 'string') {
+			if (!isWidgetBaseConstructor(widgetConstructor)) {
 				const item = this._registries.get(widgetConstructor);
 				if (item === null) {
 					return null;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -15,9 +15,10 @@ import {
 	WidgetBaseInterface,
 	PropertyChangeRecord,
 	PropertiesChangeEvent,
+	RegistryLabel,
 	HNode
 } from './interfaces';
-import { isWidgetBaseConstructor, WIDGET_BASE_TYPE, RegistryLabel } from './WidgetRegistry';
+import { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './WidgetRegistry';
 import RegistryHandler from './RegistryHandler';
 
 export { DiffType };

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -13,6 +13,8 @@ export type WidgetRegistryItem = WidgetBaseConstructor | Promise<WidgetBaseConst
  */
 export const WIDGET_BASE_TYPE = Symbol('Widget Base');
 
+export type RegistryLabel = string | Symbol;
+
 /**
  * Widget Registry Interface
  */
@@ -24,7 +26,7 @@ export interface WidgetRegistry {
 	 * @param widgetLabel The label of the widget to register
 	 * @param registryItem The registry item to define
 	 */
-	define(widgetLabel: string, registryItem: WidgetRegistryItem): void;
+	define(widgetLabel: RegistryLabel, registryItem: WidgetRegistryItem): void;
 
 	/**
 	 * Return a WidgetRegistryItem for the given label, null if an entry doesn't exist
@@ -32,7 +34,7 @@ export interface WidgetRegistry {
 	 * @param widgetLabel The label of the widget to return
 	 * @returns The WidgetRegistryItem for the widgetLabel, `null` if no entry exists
 	 */
-	get(widgetLabel: string): WidgetBaseConstructor | null;
+	get(widgetLabel: RegistryLabel): WidgetBaseConstructor | null;
 
 	/**
 	 * Returns a boolean if an entry for the label exists
@@ -40,7 +42,7 @@ export interface WidgetRegistry {
 	 * @param widgetLabel The label to search for
 	 * @returns boolean indicating if a widget registry item exists
 	 */
-	has(widgetLabel: string): boolean;
+	has(widgetLabel: RegistryLabel): boolean;
 }
 
 /**
@@ -61,13 +63,13 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 	/**
 	 * internal map of labels and WidgetRegistryItem
 	 */
-	private registry: Map<string, WidgetRegistryItem> = new Map<string, WidgetRegistryItem>();
+	private registry: Map<RegistryLabel, WidgetRegistryItem> = new Map<RegistryLabel, WidgetRegistryItem>();
 
-	has(widgetLabel: string): boolean {
+	has(widgetLabel: RegistryLabel): boolean {
 		return this.registry.has(widgetLabel);
 	}
 
-	define(widgetLabel: string, item: WidgetRegistryItem): void {
+	define(widgetLabel: RegistryLabel, item: WidgetRegistryItem): void {
 		if (this.registry.has(widgetLabel)) {
 			throw new Error(`widget has already been registered for '${widgetLabel}'`);
 		}
@@ -92,7 +94,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		}
 	}
 
-	get(widgetLabel: string): WidgetBaseConstructor | null {
+	get(widgetLabel: RegistryLabel): WidgetBaseConstructor | null {
 		if (!this.has(widgetLabel)) {
 			return null;
 		}

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -2,7 +2,7 @@ import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
 import Symbol from '@dojo/shim/Symbol';
 import Evented from '@dojo/core/Evented';
-import { WidgetBaseConstructor } from './interfaces';
+import { WidgetBaseConstructor, RegistryLabel } from './interfaces';
 
 export type WidgetBaseConstructorFunction = () => Promise<WidgetBaseConstructor>;
 
@@ -12,8 +12,6 @@ export type WidgetRegistryItem = WidgetBaseConstructor | Promise<WidgetBaseConst
  * Widget base symbol type
  */
 export const WIDGET_BASE_TYPE = Symbol('Widget Base');
-
-export type RegistryLabel = string | Symbol;
 
 /**
  * Widget Registry Interface

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -53,7 +53,7 @@ export function isWidgetBaseConstructor(item: any): item is WidgetBaseConstructo
 	return Boolean(item && item._type === WIDGET_BASE_TYPE);
 }
 
-function getEventType(label: RegistryLabel): RegistryLabel {
+export function getLoadedEventType(label: RegistryLabel): RegistryLabel {
 	if (typeof label === 'string') {
 		return `loaded:${label}`;
 	}
@@ -86,7 +86,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 			item.then((widgetCtor) => {
 				this.registry.set(widgetLabel, widgetCtor);
 				this.emit({
-					type: getEventType(widgetLabel)
+					type: getLoadedEventType(widgetLabel)
 				});
 				return widgetCtor;
 			}, (error) => {
@@ -95,7 +95,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		}
 		else {
 			this.emit({
-				type: getEventType(widgetLabel)
+				type: getLoadedEventType(widgetLabel)
 			});
 		}
 	}
@@ -121,7 +121,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		promise.then((widgetCtor) => {
 			this.registry.set(widgetLabel, widgetCtor);
 			this.emit({
-				type: getEventType(widgetLabel)
+				type: getLoadedEventType(widgetLabel)
 			});
 			return widgetCtor;
 		}, (error) => {

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -1,7 +1,6 @@
 import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
 import Symbol from '@dojo/shim/Symbol';
-import { EventedCallback } from '@dojo/interfaces/bases';
 import { Handle } from '@dojo/interfaces/core';
 import Evented, { EventObject, BaseEventedEvents } from '@dojo/core/Evented';
 import { WidgetBaseConstructor, RegistryLabel } from './interfaces';
@@ -19,8 +18,12 @@ export interface WidgetRegistryEventObject extends EventObject {
 	action: string;
 }
 
+export interface WidgetRegistryListener {
+	(event: WidgetRegistryEventObject): void;
+}
+
 export interface WidgetRegistryEvents extends BaseEventedEvents {
-	(type: RegistryLabel, listener: EventedCallback<WidgetRegistryEventObject> | EventedCallback<WidgetRegistryEventObject>[]): Handle;
+	(type: RegistryLabel, listener: WidgetRegistryListener | WidgetRegistryListener[]): Handle;
 }
 
 /**

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -53,6 +53,13 @@ export function isWidgetBaseConstructor(item: any): item is WidgetBaseConstructo
 	return Boolean(item && item._type === WIDGET_BASE_TYPE);
 }
 
+function getEventType(label: RegistryLabel): RegistryLabel {
+	if (typeof label === 'string') {
+		return `loaded:${label}`;
+	}
+	return label;
+}
+
 /**
  * The WidgetRegistry implementation
  */
@@ -69,7 +76,8 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 
 	define(widgetLabel: RegistryLabel, item: WidgetRegistryItem): void {
 		if (this.registry.has(widgetLabel)) {
-			throw new Error(`widget has already been registered for '${widgetLabel}'`);
+			const regsitryLabelDesc = typeof widgetLabel === 'string' ? widgetLabel : widgetLabel.toString();
+			throw new Error(`widget has already been registered for '${regsitryLabelDesc}'`);
 		}
 
 		this.registry.set(widgetLabel, item);
@@ -78,7 +86,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 			item.then((widgetCtor) => {
 				this.registry.set(widgetLabel, widgetCtor);
 				this.emit({
-					type: `loaded:${widgetLabel}`
+					type: getEventType(widgetLabel)
 				});
 				return widgetCtor;
 			}, (error) => {
@@ -87,7 +95,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		}
 		else {
 			this.emit({
-				type: `loaded:${widgetLabel}`
+				type: getEventType(widgetLabel)
 			});
 		}
 	}
@@ -113,7 +121,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		promise.then((widgetCtor) => {
 			this.registry.set(widgetLabel, widgetCtor);
 			this.emit({
-				type: `loaded:${widgetLabel}`
+				type: getEventType(widgetLabel)
 			});
 			return widgetCtor;
 		}, (error) => {

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -76,8 +76,7 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 
 	define(widgetLabel: RegistryLabel, item: WidgetRegistryItem): void {
 		if (this.registry.has(widgetLabel)) {
-			const regsitryLabelDesc = typeof widgetLabel === 'string' ? widgetLabel : widgetLabel.toString();
-			throw new Error(`widget has already been registered for '${regsitryLabelDesc}'`);
+			throw new Error(`widget has already been registered for '${widgetLabel.toString()}'`);
 		}
 
 		this.registry.set(widgetLabel, item);

--- a/src/d.ts
+++ b/src/d.ts
@@ -9,6 +9,7 @@ import {
 	WNode,
 	VirtualDomProperties,
 	WidgetBaseInterface,
+	RegistryLabel,
 	DefaultWidgetBaseInterface
 } from './interfaces';
 import WidgetRegistry from './WidgetRegistry';
@@ -71,7 +72,7 @@ export const registry = new WidgetRegistry();
 /**
  * Wrapper function for calls to create a widget.
  */
-export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<W> | string | Symbol, properties: W['properties'], children: W['children'] = []): WNode<W> {
+export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<W> | RegistryLabel, properties: W['properties'], children: W['children'] = []): WNode<W> {
 
 	return {
 		children,

--- a/src/d.ts
+++ b/src/d.ts
@@ -71,7 +71,7 @@ export const registry = new WidgetRegistry();
 /**
  * Wrapper function for calls to create a widget.
  */
-export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<W> | string, properties: W['properties'], children: W['children'] = []): WNode<W> {
+export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<W> | string | Symbol, properties: W['properties'], children: W['children'] = []): WNode<W> {
 
 	return {
 		children,

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -212,6 +212,11 @@ export interface VirtualDomProperties {
 }
 
 /**
+ * Type of the `WidgetRegistry` label
+ */
+export type RegistryLabel = string | Symbol;
+
+/**
  * Base widget properties
  */
 export interface WidgetProperties {
@@ -269,7 +274,7 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	/**
 	 * Constructor to create a widget or string constructor label
 	 */
-	widgetConstructor: Constructor<W> | string | Symbol;
+	widgetConstructor: Constructor<W> | RegistryLabel;
 
 	/**
 	 * Properties to set against a widget instance

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -269,7 +269,7 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	/**
 	 * Constructor to create a widget or string constructor label
 	 */
-	widgetConstructor: Constructor<W> | string;
+	widgetConstructor: Constructor<W> | string | Symbol;
 
 	/**
 	 * Properties to set against a widget instance

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -214,7 +214,7 @@ export interface VirtualDomProperties {
 /**
  * Type of the `WidgetRegistry` label
  */
-export type RegistryLabel = string | Symbol;
+export type RegistryLabel = string | symbol;
 
 /**
  * Base widget properties

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -113,5 +113,25 @@ registerSuite({
 		return promise.then(() => {
 			assert.isTrue(invalidateCalled);
 		});
+	},
+	'noop when event action is not `loaded`'() {
+		const baz = Symbol();
+		let invalidateCalled = false;
+		let promise: Promise<any> = Promise.resolve();
+		const lazyWidget: any = () => {
+			promise = new Promise((resolve) => {
+			});
+			return promise;
+		};
+		const registryHandler = new RegistryHandler();
+		registryHandler.on('invalidate', () => {
+			invalidateCalled = true;
+		});
+
+		registryHandler.add(registry);
+		registry.define(baz, lazyWidget);
+		registryHandler.get(baz);
+		registry.emit({ type: baz, action: 'other' });
+		assert.isFalse(invalidateCalled);
 	}
 });

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -4,11 +4,16 @@ import RegistryHandler from '../../src/RegistryHandler';
 import WidgetRegistry from '../../src/WidgetRegistry';
 import { WidgetBase } from '../../src/WidgetBase';
 
+const foo = Symbol();
+const bar = Symbol();
+
 const registry = new WidgetRegistry();
 registry.define('foo', WidgetBase);
+registry.define(foo, WidgetBase);
 
 const registryB = new WidgetRegistry();
 registryB.define('bar', WidgetBase);
+registryB.define(bar, WidgetBase);
 
 registerSuite({
 	name: 'RegistryHandler',
@@ -55,6 +60,8 @@ registerSuite({
 		registryHandler.add(registryB);
 		assert.isTrue(registryHandler.has('foo'));
 		assert.isTrue(registryHandler.has('bar'));
+		assert.isTrue(registryHandler.has(foo));
+		assert.isTrue(registryHandler.has(bar));
 	},
 	'get'() {
 		const promise = new Promise((resolve) => {
@@ -67,6 +74,44 @@ registerSuite({
 		registry.define('baz', promise);
 		return promise.then(() => {
 			assert.equal(registryHandler.get('baz'), WidgetBase);
+		});
+	},
+	'get with symbol label'() {
+		const baz = Symbol();
+		const promise = new Promise((resolve) => {
+			setTimeout(() => {
+				resolve(WidgetBase);
+			}, 1);
+		});
+		const registryHandler = new RegistryHandler();
+		registryHandler.add(registry);
+		registry.define(baz, promise);
+		return promise.then(() => {
+			assert.equal(registryHandler.get(baz), WidgetBase);
+		});
+	},
+	'invalidates once registry emits loaded event'() {
+		const baz = Symbol();
+		let promise: Promise<any> = Promise.resolve();
+		let invalidateCalled = false;
+		const lazyWidget = () => {
+			promise = new Promise((resolve) => {
+				setTimeout(() => {
+					resolve(WidgetBase);
+				}, 1);
+			});
+			return promise;
+		};
+		const registryHandler = new RegistryHandler();
+		registryHandler.on('invalidate', () => {
+			invalidateCalled = true;
+		});
+
+		registryHandler.add(registry);
+		registry.define(baz, lazyWidget);
+		registryHandler.get(baz);
+		return promise.then(() => {
+			assert.isTrue(invalidateCalled);
 		});
 	}
 });

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -820,6 +820,28 @@ widget.__setProperties__({
 			result = myWidget.__render__();
 			assert.lengthOf(result.children, 1);
 		},
+		'lazily defined widget using a symbol in registry renders when ready'() {
+			const myHeader = Symbol();
+			class TestWidget extends WidgetBase<any> {
+				render() {
+					return v('div', [
+						w(myHeader, <any> undefined)
+					]);
+				}
+			}
+
+			class TestHeaderWidget extends WidgetBase<any> {
+				render() {
+					return v('header');
+				}
+			}
+			const myWidget: any = new TestWidget();
+			let result = <VNode> myWidget.__render__();
+			assert.lengthOf(result.children, 0);
+			registry.define(myHeader, TestHeaderWidget);
+			result = myWidget.__render__();
+			assert.lengthOf(result.children, 1);
+		},
 		'locally defined widget in registry eventually replaces global one'() {
 			const localRegistry = new WidgetRegistry();
 

--- a/tests/unit/WidgetRegistry.ts
+++ b/tests/unit/WidgetRegistry.ts
@@ -27,8 +27,11 @@ registerSuite({
 			const factoryRegistry = new WidgetRegistry();
 			factoryRegistry.define('my-widget', WidgetBase);
 			factoryRegistry.define('my-lazy-widget', lazyFactory);
+			const symbolLabel = Symbol();
+			factoryRegistry.define(symbolLabel, lazyFactory);
 			assert.isTrue(factoryRegistry.has('my-widget'));
 			assert.isTrue(factoryRegistry.has('my-lazy-widget'));
+			assert.isTrue(factoryRegistry.has(symbolLabel));
 		},
 		'throw an error using a previously registered factory label'() {
 			const factoryRegistry = new WidgetRegistry();
@@ -48,6 +51,13 @@ registerSuite({
 			const factoryRegistry = new WidgetRegistry();
 			factoryRegistry.define('my-widget', WidgetBase);
 			const factory = factoryRegistry.get('my-widget');
+			assert.strictEqual(factory, WidgetBase);
+		},
+		'get a factory registered with a Symbol'() {
+			const symbolLabel = Symbol();
+			const factoryRegistry = new WidgetRegistry();
+			factoryRegistry.define(symbolLabel, WidgetBase);
+			const factory = factoryRegistry.get(symbolLabel);
 			assert.strictEqual(factory, WidgetBase);
 		},
 		'throws an error if factory has not been registered.'() {

--- a/tests/unit/WidgetRegistry.ts
+++ b/tests/unit/WidgetRegistry.ts
@@ -33,7 +33,7 @@ registerSuite({
 			assert.isTrue(factoryRegistry.has('my-lazy-widget'));
 			assert.isTrue(factoryRegistry.has(symbolLabel));
 		},
-		'throw an error using a previously registered factory label'() {
+		'throw an error using a previously registered factory string label'() {
 			const factoryRegistry = new WidgetRegistry();
 			factoryRegistry.define('my-widget', WidgetBase);
 			try {
@@ -43,6 +43,19 @@ registerSuite({
 			catch (error) {
 				assert.isTrue(error instanceof Error);
 				assert.equal(error.message, 'widget has already been registered for \'my-widget\'');
+			}
+		},
+		'throw an error using a previously registered factory symbol label'() {
+			const myWidget = Symbol('symbol registry label');
+			const factoryRegistry = new WidgetRegistry();
+			factoryRegistry.define(myWidget, WidgetBase);
+			try {
+				factoryRegistry.define(myWidget, WidgetBase);
+				assert.fail();
+			}
+			catch (error) {
+				assert.isTrue(error instanceof Error);
+				assert.equal(error.message, 'widget has already been registered for \'Symbol(symbol registry label)\'');
 			}
 		}
 	},

--- a/tests/unit/WidgetRegistry.ts
+++ b/tests/unit/WidgetRegistry.ts
@@ -55,7 +55,8 @@ registerSuite({
 			}
 			catch (error) {
 				assert.isTrue(error instanceof Error);
-				assert.equal(error.message, 'widget has already been registered for \'Symbol(symbol registry label)\'');
+				assert.include(error.message, 'widget has already been registered for');
+				assert.include(error.message, 'symbol registry label');
 			}
 		}
 	},

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -89,12 +89,24 @@ registerSuite({
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
-		'create WNode wrapper using label with properties and children'() {
+		'create WNode wrapper using string label with properties and children'() {
 			const properties: any = { id: 'id', classes: [ 'world' ] };
 			const dNode = w('my-widget', properties, [ w(WidgetBase, properties) ]);
 
 			assert.equal(dNode.type, WNODE);
 			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.lengthOf(dNode.children, 1);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
+		},
+		'create WNode wrapper using symbol label with properties and children'() {
+			const properties: any = { id: 'id', classes: [ 'world' ] };
+			const symbolLabel = Symbol();
+
+			const dNode = w(symbolLabel, properties, [ w(WidgetBase, properties) ]);
+			assert.equal(dNode.type, WNODE);
+			assert.strictEqual(dNode.widgetConstructor, symbolLabel);
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add support to use a `Symbol` as a key for defining an item in the registry and therefore when using `w`.

Requires https://github.com/dojo/core/pull/330

Resolves #478 
