### PR TITLE
Increasing shim version, issue #477

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/grunt": "0.4.*",
     "@types/jsdom": "2.0.*",
     "@types/sinon": "^1.16.31",
-    "@webcomponents/custom-elements": "^1.0.0-alpha.3",
+    "@webcomponents/custom-elements": "^v1.0.0-rc.3",
     "codecov.io": "0.1.6",
     "glob": "^7.0.6",
     "grunt": "^1.0.1",

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -12,6 +12,7 @@ registerSuite({
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button');
 	},
 	'custom element initial properties are set correctly'(this: any) {
@@ -21,6 +22,7 @@ registerSuite({
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button')
 			.then((element: any) => {
 				return element.getVisibleText();
@@ -36,6 +38,7 @@ registerSuite({
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button')
 			.click()
 			.end()
@@ -51,6 +54,7 @@ registerSuite({
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button')
 			.end()
 			.execute('document.querySelector("test-button").setAttribute("label", "greetings")')
@@ -65,6 +69,7 @@ registerSuite({
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('no-attributes > button')
 			.end()
 			.execute('document.querySelector("no-attributes").buttonLabel = "greetings"')


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Hopeful fix for custom element functional tests not working in Safari 10 and iOS 9.1. Increasing the custom elements shim version was enough to get them to pass in Safari 10 locally, I'm having issues running them in saucelabs, so I'm hoping Travis can do it for me 😛 

Resolves #477 
