### PR TITLE
WIP: Add ability to serialize and deserialize to the Projector

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -1,7 +1,8 @@
 import global from '@dojo/core/global';
 import { assign } from '@dojo/core/lang';
 import { Handle } from '@dojo/interfaces/core';
-import { dom, Projection, ProjectionOptions, VNode, VNodeProperties } from 'maquette';
+import { ProjectionOptions, VNode, VNodeProperties } from '@dojo/interfaces/vdom';
+import { dom, Projection } from 'maquette';
 import 'pepjs';
 import cssTransitions from '../animations/cssTransitions';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -76,15 +76,6 @@ export interface ProjectorMixin<P extends WidgetProperties> {
 	scheduleRender(): void;
 
 	/**
-	 * Serializes the current projection
-	 *
-	 * This is intended to make it easy to accomplish server side rendering, where a projection can be serialized and
-	 * transferred to a different context to be re-hydrated by passing it as an argument to `.append()`, `.merge()`, or
-	 * `.replace()`.
-	 */
-	serialize(): VNode;
-
-	/**
 	 * Sets the properties for the widget. Responsible for calling the diffing functions for the properties against the
 	 * previous properties. Runs though any registered specific property diff functions collecting the results and then
 	 * runs the remainder through the catch all diff function. The aggregate of the two sets of the results is then
@@ -98,6 +89,15 @@ export interface ProjectorMixin<P extends WidgetProperties> {
 	 * Sets the widget's children
 	 */
 	setChildren(children: DNode[]): void;
+
+	/**
+	 * Serializes the current projection
+	 *
+	 * This is intended to make it easy to accomplish server side rendering, where a projection can be serialized and
+	 * transferred to a different context to be re-hydrated by passing it as an argument to `.append()`, `.merge()`, or
+	 * `.replace()`.
+	 */
+	toJSON(): VNode;
 
 	/**
 	 * Root element to attach the projector
@@ -275,16 +275,19 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 			return this._root;
 		}
 
-		public serialize(): VNode {
-			return serializeVNode(this._rootVNode);
-		}
-
 		public setChildren(children: DNode[]): void {
 			super.__setChildren__(children);
 		}
 
 		public setProperties(properties: P & { [index: string]: any }): void {
 			super.__setProperties__(properties);
+		}
+
+		public toJSON(): VNode {
+			if (!this._rootVNode) {
+				throw new Error('Projector missing root VNode.');
+			}
+			return serializeVNode(this._rootVNode);
 		}
 
 		public __render__() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This feature adds the ability to make it easy to perform server side rendering.

It adds a method to the `Projector` named `.serialize()` which will return a sanitized `VNode` that is the root of the current projection.  This then can be easily converted to a JSON string, transferred to a different context, and then deserialized by passing it as an argument to one of the attach methods on a projector (`.append()`, `.merge()`, `.replace()`).  During the attachment, this `VNode` will be used instead of rendering the `Projector`.

Resolves #485