### PR TITLE
Allow re-use of DOM when merging on Projector

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/grunt": "0.4.*",
     "@types/jsdom": "2.0.*",
     "@types/sinon": "^1.16.31",
-    "@webcomponents/custom-elements": "^1.0.0-alpha.3",
+    "@webcomponents/custom-elements": "^v1.0.0-rc.3",
     "codecov.io": "0.1.6",
     "glob": "^7.0.6",
     "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "@dojo/core": "beta1",
     "@dojo/has": "beta1",
     "@dojo/i18n": "beta1",
-    "@dojo/shim": "beta1",
-    "maquette": "2.5.0"
+    "@dojo/shim": "beta1"
   },
   "devDependencies": {
     "@dojo/interfaces": "beta1",
@@ -54,6 +53,7 @@
     "typescript": "~2.3.2"
   },
   "dependencies": {
+    "maquette": "~2.5.0",
     "pepjs": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@dojo/has": "beta1",
     "@dojo/i18n": "beta1",
     "@dojo/shim": "beta1",
-    "maquette": "2.4.3"
+    "maquette": "2.5.0"
   },
   "devDependencies": {
     "@dojo/interfaces": "beta1",

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -123,16 +123,15 @@ const eventHandlers = [
 	'onsubmit'
 ];
 
-function setDomNodes(vnode: VNode, root: Node | null = null) {
-	vnode.domNode = root;
-	if (vnode.children && root) {
-		const childNodes: Node[] = [];
-		for (let i = 0; i < root.childNodes.length; i++) {
-			if (root.childNodes[i].nodeType === 1) {
-				childNodes.push(root.childNodes[i]);
-			}
-		}
-		vnode.children.forEach((child, i) => setDomNodes(child, childNodes[i]));
+/**
+ * Internal function that maps existing DOM Elements to virtual DOM nodes.
+ * @param vnode The virtual DOM node
+ * @param domNode The Element, if any, to set on the virtual DOM node
+ */
+function setDomNodes(vnode: VNode, domNode: Element | null = null) {
+	vnode.domNode = domNode;
+	if (vnode.children && domNode) {
+		vnode.children.forEach((child, i) => setDomNodes(child, domNode.children[i]));
 	}
 }
 

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -47,6 +47,10 @@ export interface ProjectorMixin<P extends WidgetProperties> {
 
 	/**
 	 * Merge the projector onto the root.
+	 *
+	 * The `root` and any of its `children` will be re-used.  Any excess DOM nodes will be ignored and any missing DOM nodes
+	 * will be created.
+	 * @param root The root element that the root virtual DOM node will be merged with.  Defaults to `document.body`.
 	 */
 	merge(root?: Element): Handle;
 
@@ -125,6 +129,10 @@ const eventHandlers = [
 
 /**
  * Internal function that maps existing DOM Elements to virtual DOM nodes.
+ *
+ * The funtion does not presume DOM will be there.  It does assume that if a DOM `Element` exists that the `VNode`s are in
+ * the same DOM order as the `Element`s.  If a DOM Element does not exist, it will set the `vnode.domNode` to `null` and
+ * not descend further into the `VNode` children which will cause the maquette projection to create the Element anew.
  * @param vnode The virtual DOM node
  * @param domNode The Element, if any, to set on the virtual DOM node
  */

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -6,21 +6,23 @@ registerSuite({
 	name: 'registerCustomElement',
 
 	'custom elements are registered'(this: any) {
-		if (this.remote.session.capabilities.browserName === 'internet explorer' && this.remote.session.capabilities.version === '10') {
-			this.skip('not compatible with IE 10');
+		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
+			this.skip('not compatible with iOS 9.1');
 		}
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button');
 	},
 	'custom element initial properties are set correctly'(this: any) {
-		if (this.remote.session.capabilities.browserName === 'internet explorer' && this.remote.session.capabilities.version === '10') {
-			this.skip('not compatible with IE 10');
+		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
+			this.skip('not compatible with iOS 9.1');
 		}
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button')
 			.then((element: any) => {
 				return element.getVisibleText();
@@ -30,12 +32,13 @@ registerSuite({
 			});
 	},
 	'custom element event handlers are registered'(this: any) {
-		if (this.remote.session.capabilities.browserName === 'internet explorer' && this.remote.session.capabilities.version === '10') {
-			this.skip('not compatible with IE 10');
+		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
+			this.skip('not compatible with iOS 9.1');
 		}
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button')
 			.click()
 			.end()
@@ -45,12 +48,13 @@ registerSuite({
 			});
 	},
 	'setting custom element attribute updates properties'(this: any) {
-		if (this.remote.session.capabilities.browserName === 'internet explorer' && this.remote.session.capabilities.version === '10') {
-			this.skip('not compatible with IE 10');
+		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
+			this.skip('not compatible with iOS 9.1');
 		}
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button')
 			.end()
 			.execute('document.querySelector("test-button").setAttribute("label", "greetings")')
@@ -59,12 +63,13 @@ registerSuite({
 			}, undefined, 1000), undefined);
 	},
 	'setting custom element properties updates widget'(this: any) {
-		if (this.remote.session.capabilities.browserName === 'internet explorer' && this.remote.session.capabilities.version === '10') {
-			this.skip('not compatible with IE 10');
+		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
+			this.skip('not compatible with iOS 9.1');
 		}
 
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
 			.findByCssSelector('no-attributes > button')
 			.end()
 			.execute('document.querySelector("no-attributes").buttonLabel = "greetings"')

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -126,18 +126,96 @@ registerSuite({
 			assert.strictEqual(child.innerHTML, 'foo');
 			assert.strictEqual(child.tagName.toLowerCase(), 'h2');
 		},
-		'merge'() {
-			const childNodeLength = document.body.childNodes.length;
-			const projector = new TestWidget();
+		'merge': {
+			'standard'() {
+				const div = document.createElement('div');
+				document.body.appendChild(div);
+				const projector = new TestWidget();
 
-			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
+				projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
-			projector.merge();
+				projector.merge(div);
 
-			assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
-			const child = <HTMLElement> document.body.lastChild;
-			assert.strictEqual(child.innerHTML, 'foo');
-			assert.strictEqual(child.tagName.toLowerCase(), 'h2');
+				assert.strictEqual(div.childNodes.length, 1, 'child should have been added');
+				const child = <HTMLElement> div.lastChild;
+				assert.strictEqual(child.innerHTML, 'foo');
+				assert.strictEqual(child.tagName.toLowerCase(), 'h2');
+				document.body.removeChild(div);
+			},
+			'pre rendered DOM used'() {
+				const iframe = document.createElement('iframe');
+				document.body.appendChild(iframe);
+				iframe.contentDocument.write(`
+					<div class="foo">
+						<label for="baz">Select Me:</label>
+						<select type="text" name="baz" id="baz" disabled="disabled">
+							<option value="foo">label foo</option>
+							<option value="bar" selected="">label bar</option>
+							<option value="baz">label baz</option>
+						</select>
+						<button type="button" disabled="disabled">Click Me!</button>
+					</div>`);
+				iframe.contentDocument.close();
+				const root = iframe.contentDocument.body.firstChild as HTMLElement;
+				const childElementCount = root.childElementCount;
+				const select = root.childNodes[3] as HTMLSelectElement;
+				const button = root.childNodes[5] as HTMLButtonElement;
+				assert.strictEqual((root.childNodes[3] as HTMLSelectElement).value, 'bar', 'bar should be selected');
+				const onchangeListener = spy();
+				const onclickListener = spy();
+				const projector = new class extends TestWidget {
+					render() {
+						return v('div', {
+							classes: { foo: true, bar: true }
+						}, [
+							v('label', {
+								for: 'baz'
+							}, [ 'Select Me:' ]),
+							v('select', {
+								type: 'text',
+								name: 'baz',
+								id: 'baz',
+								disabled: false,
+								onchange: onchangeListener
+							}, [
+								v('option', { value: 'foo', selected: true }, [ 'label foo' ]),
+								v('option', { value: 'bar', selected: false }, [ 'label bar' ]),
+								v('option', { value: 'baz', selected: false }, [ 'label baz' ])
+							]),
+							v('button', {
+								type: 'button',
+								disabled: false,
+								onclick: onclickListener
+							}, [ 'Click Me!' ])
+						]);
+					}
+				}();
+				projector.merge(root);
+				assert.strictEqual(root.className, 'foo bar', 'should have added bar class');
+				assert.strictEqual(root.childElementCount, childElementCount, 'should have the same number of children');
+				assert.strictEqual(select, root.childNodes[3], 'should have been reused');
+				assert.strictEqual(button, root.childNodes[5], 'should have been reused');
+				assert.isFalse(select.disabled);
+				assert.isFalse(button.disabled);
+
+				assert.strictEqual(select.value, 'foo', 'foo should be selected');
+				assert.strictEqual(select.children.length, 3, 'should have 3 children');
+
+				assert.isFalse(onchangeListener.called);
+				assert.isFalse(onclickListener.called);
+
+				const changeEvent = document.createEvent('CustomEvent');
+				changeEvent.initEvent('change', true, true);
+				select.dispatchEvent(changeEvent);
+				assert.isTrue(onchangeListener.called);
+
+				const clickEvent = document.createEvent('CustomEvent');
+				clickEvent.initEvent('click', true, true);
+				button.dispatchEvent(clickEvent);
+				assert.isTrue(onclickListener.called);
+
+				document.body.removeChild(iframe);
+			}
 		}
 	},
 	'get root'() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -195,24 +195,24 @@ registerSuite({
 				assert.strictEqual(root.childElementCount, childElementCount, 'should have the same number of children');
 				assert.strictEqual(select, root.childNodes[3], 'should have been reused');
 				assert.strictEqual(button, root.childNodes[5], 'should have been reused');
-				assert.isFalse(select.disabled);
-				assert.isFalse(button.disabled);
+				assert.isFalse(select.disabled, 'select should be enabled');
+				assert.isFalse(button.disabled, 'button shound be enabled');
 
 				assert.strictEqual(select.value, 'foo', 'foo should be selected');
 				assert.strictEqual(select.children.length, 3, 'should have 3 children');
 
-				assert.isFalse(onchangeListener.called);
-				assert.isFalse(onclickListener.called);
+				assert.isFalse(onchangeListener.called, 'onchangeListener should not have been called');
+				assert.isFalse(onclickListener.called, 'onclickListener should not have been called');
 
-				const changeEvent = document.createEvent('CustomEvent');
+				const changeEvent = document.createEvent('Event');
 				changeEvent.initEvent('change', true, true);
-				select.dispatchEvent(changeEvent);
-				assert.isTrue(onchangeListener.called);
+				select.onchange(changeEvent); // firefox doesn't like to dispatch this event
+				assert.isTrue(onchangeListener.called, 'onchangeListener should have been called');
 
 				const clickEvent = document.createEvent('CustomEvent');
 				clickEvent.initEvent('click', true, true);
 				button.dispatchEvent(clickEvent);
-				assert.isTrue(onclickListener.called);
+				assert.isTrue(onclickListener.called, 'onclickListener should have been called');
 
 				document.body.removeChild(iframe);
 			}

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -206,7 +206,10 @@ registerSuite({
 
 				const changeEvent = document.createEvent('Event');
 				changeEvent.initEvent('change', true, true);
-				select.onchange(changeEvent); // firefox doesn't like to dispatch this event
+				select.onchange(changeEvent); // firefox doesn't like to dispatch this event, either due to trust issues or
+											  // that firefox doesn't generally dispatch this event until the element is blurred
+											  // which is different than other browsers.  Either way this is not material to testing
+											  // the functionality of this test, so calling the listener directly.
 				assert.isTrue(onchangeListener.called, 'onchangeListener should have been called');
 
 				const clickEvent = document.createEvent('CustomEvent');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR provides the ability to re-use the DOM when using `projector.merge()`.  This requires AFASSoftware/maquette#99.

When merging, it will automatically _hydrate_ the render with the DOM nodes.  It is obviously incumbent upon the developer to ensure that the DOM that is being merged follows the same structure of the virtual DOM.  If any of the DOM is missing, but described in the virtual DOM, maquette will create those DOM nodes.

An example.  It will initially render with the button disabled when it receives the HTML, but when the app loads and is merged, the button will become active.  In addition the text will change from `Hello!` to `Hello, Dojo World!`.  The DOM nodes will be reused:

**index.html**

```html
<!DOCTYPE html>
<html>
<head>
	<title>dojo-test-app</title>
</head>
<body>
	<p>Welcome to dojo-test-app</p>
	<div id="my-app">
		<button type="button" disabled="">Click Me</button>
		<span>Hello!</span>
	</div>
</body>
</html>
```

**main.ts**

```ts
import { ProjectorMixin, AttachType } from '@dojo/widget-core/mixins/Projector';
import HelloWorld from './widgets/HelloWorld';

const root = document.getElementById('my-app') as HTMLDivElement;

const Projector = ProjectorMixin(HelloWorld);
const projector = new Projector();

projector.merge(root);
console.log('Merged!');
```

**widgets/HelloWorld.ts**

```ts
import { WidgetBase } from '@dojo/widget-core/WidgetBase';
import { WidgetProperties } from '@dojo/widget-core/interfaces';
import { v } from '@dojo/widget-core/d';

export default class HelloWorld extends WidgetBase<WidgetProperties> {
	render() {
		return v('div', {
			key: 'one'
		}, [ v('button', {
			type: 'button',
			disabled: false,
			onclick() {
				console.log('I was clicked!')
			}
		}, [ 'Click Me' ]),
		v('span', [ 'Hello, Dojo World!' ])]);
	}
}
```

Resolves #486 
