### PR TITLE
Remove an extra space from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ And using the `beforeRender` function for non decorator environments:
 class MyBaseClass extends WidgetBase<WidgetProperties> {
 	constructor() {
 		super();
-		beforeRender(this. myOtherBeforeRender)(this);
+		beforeRender(this.myOtherBeforeRender)(this);
 	}
 
 	myOtherBeforeRender(renderFunc: () => DNode, properties: any, children: DNode[]): () => DNode {


### PR DESCRIPTION
There is an extra space in one of the code examples in the README that at first glance, looks like a period should be a comma.  In fact, the space should not be there.