### PR TITLE
Add ownerDocument to Element mock

### DIFF
--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -29,6 +29,7 @@ function createFakeElement(attributes: any, descriptor: CustomElementDescriptor)
 		getEvents() {
 			return events;
 		},
+		ownerDocument: global.document,
 		removeChild(child: any) {
 			removedChildren.push(child);
 		},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

An upstream change in maquette (raised by me) uses the `element.ownerDocument` instead of the global `document` when creating new elements.  This caused a regression in some tests where a mocked element was being used.  This adds the required property to fix those tests.

