### PR TITLE
Adjust behaviour of invalidate during property and render phases

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -148,7 +148,9 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 			this._boundRender = this.__render__.bind(this);
 
 			this.own(this.on('widget:children', this.invalidate));
-			this.own(this.on('properties:changed', this.invalidate));
+			this.own(this.on('properties:changed', () => {
+				this.scheduleRender();
+			}));
 			this.own(this.on('invalidated', this.scheduleRender));
 
 			this.root = document.body;

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -194,17 +194,11 @@ registerSuite({
 
 		assert.isTrue(maquetteProjectorStopSpy.calledOnce);
 	},
-	'invalidate on properties:changed'() {
+	'scheduleRender on properties:changed'() {
 		const projector = new TestWidget();
-		let called = false;
-
-		projector.on('invalidated', () => {
-			called = true;
-		});
-
+		const scheduleRender = spy(projector, 'scheduleRender');
 		projector.setProperties({ foo: 'hello' });
-
-		assert.isTrue(called);
+		assert.isTrue(scheduleRender.called);
 	},
 	'invalidate on setting children'() {
 		const projector = new TestWidget();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Before, calling `invalidate` in either render or property phases (ie `diffProperty`), could cause undesirable behaviour (including infinite loops). We now guard against this by:

a) an `invalidate` during a render phase becomes a no-op.
b) an `invalidate` during the properties phase will mark the widget as dirty, but will not emit the invalidate the `invalidated` event up the tree.