### PR TITLE
Add .sandbox() and .toHtml() to Projector

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
             - [Custom property diff control](#custom-property-diff-control)
             - [The `properties:changed` event](#the-propertieschanged-event)
         - [Projector](#projector)
+		  - [Server Side Rendering](#server-side-rendering)
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
         - [Injecting State](#injecting-state)
@@ -202,7 +203,7 @@ Once the project is configured, `tsx` can be used in a widget's `render` functio
 class MyWidgetWithTsx extends WidgetBase<MyProperties> {
 	protected render(): DNode {
 		const { clear, properties: { completed, count, activeCount, activeFilter } } = this;
-	
+
 		return (
 			<footer classes={this.classes(css.footer)}>
 				<span classes={this.classes(css.count)}>
@@ -457,17 +458,56 @@ const MyProjector = ProjectorMixin(MyWidget);
 
 Projectors behave in the same way as any other widget **except** that they need to be manually instantiated and managed outside of the standard widget lifecycle.
 
-There are 3 ways that a projector widget can be added to the DOM - `.append`, `.merge` or `.replace`, depending on the type of attachment required.
+There are 3 ways that a projector widget can be added to the DOM - `.append`, `.merge`, `.replace`, or `.sandbox`, depending on the type of attachment required.
 
  - `append`  - Creates the widget as a child to the projector's `root` node
  - `merge`   - Merges the widget with the projector's `root` node
  - `replace` - Replace the projector's `root` node with the widget
+ - `sandbox` - Create a document fragment as the projector's `root` node
 
 ```ts
 const MyProjector = ProjectorMixin(MyWidget);
 
 const myProjector = new MyProjector({})
 myProjector.append(root);
+```
+
+##### Server Side Rendering
+
+The `Projector` provides several features which facilitate server side rendering and progressive enhancement.  For rendering on the server, there are the methods `.sandbox()` and `.toHtml()`.
+
+###### .sandbox()
+
+`.sandbox()` does two things.  It creates the `root` of the projector as a `DocumentFragment`.  This ensures that the rendering of the projector does not interfere with the `document`.  In order to server side render, you still need something like `jsdom` though in order to provide the functionality needed to generate the DOM structure which will be shipped to the browser.  Also, when the projector is attached it will render synchronously.  Usually the projector renders asyncronously to ensure that renders have a minimal impact on the user experience, helping eliminate _jank_.  This can cause problems though in that when exporting the HTML, the projector needs to be in a _known_ render state. `.sandbox()` takes a single optional argument which is a `Document`.  If none is supplied, then the global `document` will be used.
+
+An example using [`jsdom`](https://github.com/tmpvar/jsdom):
+
+```ts
+import { JSDOM } from 'jsdom';
+import ProjectorMixin from '@dojo/widget-core/mixins/Projector';
+import App from './widgets/App';
+
+const dom = new JSDOM('', { runScripts: 'dangerously' });
+const projector = new (ProjectorMixin(App))();
+const projector.sandbox(dom.window.document);
+```
+
+###### .toHtml()
+
+`.toHtml()` returns a string which represents the current render of the `Projector`.  While it can be used with any attachment mode, it is most effective when using `.sandbox()`, as this mode operates synronously, ensuring that the string returned accuretly represents the current rendered DOM structure.  Building on the example from above:
+
+```ts
+import { JSDOM } from 'jsdom';
+import ProjectorMixin from '@dojo/widget-core/mixins/Projector';
+import App from './widgets/App';
+
+const dom = new JSDOM('', { runScripts: 'dangerously' });
+const projector = new (ProjectorMixin(App))();
+const projector.sandbox(dom.window.document);
+
+/* set any App properties/children/state */
+const html = projector.toHtml();
+/* `html` contains the rendered HTML */
 ```
 
 #### Event Handling

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -166,7 +166,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 		private _root: Element;
 		private _async = true;
 		private _attachHandle: Handle;
-		private _attachType: AttachType;
 		private _projectionOptions: ProjectionOptions;
 		private _projection: Projection | undefined;
 		private _scheduled: number | undefined;
@@ -343,7 +342,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 					this._attachHandle = { destroy() { } };
 				}
 			});
-			this._attachType = type;
 
 			switch (type) {
 				case AttachType.Append:

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -283,10 +283,10 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 		}
 
 		public toHtml(): string {
-			if (this.projectorState !== ProjectorAttachState.Attached) {
+			if (this.projectorState !== ProjectorAttachState.Attached || !this._projection) {
 				throw new Error('Projector is not attached, cannot return an HTML string of projection.');
 			}
-			return this._projection!.domNode.outerHTML;
+			return this._projection.domNode.outerHTML;
 		}
 
 		public __render__() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -112,7 +112,7 @@ registerSuite({
 				projector.destroy();
 				assert.strictEqual(projector.root, document.body, 'Root should be reverted to document.body');
 			},
-			'operates syncronously'() {
+			'operates synchronously'() {
 				let count = 0;
 				const projector = new class extends TestWidget {
 					render () {
@@ -125,7 +125,7 @@ registerSuite({
 				assert.strictEqual(count, 1, 'render should have been called once');
 				assert.strictEqual(projector.root.firstChild!.textContent, '1', 'should have rendered "1"');
 				projector.invalidate();
-				assert.strictEqual(count, 2, 'render should have been called syncronously');
+				assert.strictEqual(count, 2, 'render should have been called synchronously');
 				assert.strictEqual(projector.root.firstChild!.textContent, '2', 'should have rendered "2"');
 				projector.destroy();
 			},

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -94,6 +94,51 @@ registerSuite({
 			assert.strictEqual(child.tagName.toLowerCase(), 'div');
 			assert.strictEqual(( <HTMLElement> child.firstChild).tagName.toLowerCase(), 'h2');
 		},
+		'sandbox': {
+			'attaching'() {
+				const childNodeLength = document.body.childNodes.length;
+				const projector = new TestWidget();
+				projector.setChildren([ v('h2', [ 'foo' ]) ]);
+
+				projector.sandbox();
+
+				assert.strictEqual(document.body.childNodes.length, childNodeLength, 'No nodes should be added to body');
+				assert.instanceOf(projector.root, global.window.DocumentFragment, 'the root should be a document fragment');
+				const child = projector.root.firstChild as HTMLElement;
+				assert.strictEqual(child.innerHTML, '<h2>foo</h2>');
+				assert.strictEqual(child.tagName.toLocaleLowerCase(), 'div');
+				assert.strictEqual((child.firstChild as HTMLElement).tagName.toLocaleLowerCase(), 'h2');
+
+				projector.destroy();
+				assert.strictEqual(projector.root, document.body, 'Root should be reverted to document.body');
+			},
+			'operates syncronously'() {
+				let count = 0;
+				const projector = new class extends TestWidget {
+					render () {
+						count++;
+						return v('div', [ String(count) ]);
+					}
+				}();
+
+				projector.sandbox();
+				assert.strictEqual(count, 1, 'render should have been called once');
+				assert.strictEqual(projector.root.firstChild!.textContent, '1', 'should have rendered "1"');
+				projector.invalidate();
+				assert.strictEqual(count, 2, 'render should have been called syncronously');
+				assert.strictEqual(projector.root.firstChild!.textContent, '2', 'should have rendered "2"');
+				projector.destroy();
+			},
+			'accepts other documents'() {
+				const doc = {
+					createDocumentFragment: spy(() => document.createDocumentFragment())
+				} as any;
+				const projector = new TestWidget();
+				projector.sandbox(doc);
+				assert.isTrue(doc.createDocumentFragment.called, 'createDocumentFragment should have been called');
+				projector.destroy();
+			}
+		},
 		'replace'() {
 			const projector = new class extends TestWidget {
 				render() {
@@ -246,6 +291,47 @@ registerSuite({
 		projector.destroy();
 		assert.equal(projector.projectorState, ProjectorAttachState.Detached);
 	},
+	'toHtml()': {
+		'appended'() {
+			const projector = new TestWidget();
+			projector.setChildren([ v('h2', [ 'foo' ]) ]);
+
+			projector.append();
+			assert.strictEqual(projector.toHtml(), `<div><h2>foo</h2></div>`);
+			assert.strictEqual(projector.toHtml(), (projector.root.lastChild as Element).outerHTML);
+			projector.destroy();
+		},
+		'replaced'() {
+			const div = document.createElement('div');
+			document.body.appendChild(div);
+
+			const projector = new TestWidget();
+			projector.setChildren([ v('h2', [ 'foo' ]) ]);
+
+			projector.replace(div);
+			assert.strictEqual(projector.toHtml(), `<div><h2>foo</h2></div>`);
+			assert.strictEqual(projector.toHtml(), (document.body.lastChild as Element).outerHTML);
+			projector.destroy();
+		},
+		'merged'() {
+			const div = document.createElement('div');
+			document.body.appendChild(div);
+
+			const projector = new TestWidget();
+			projector.setChildren([ v('h2', [ 'foo' ]) ]);
+
+			projector.merge(div);
+			assert.strictEqual(projector.toHtml(), `<div><h2>foo</h2></div>`);
+			assert.strictEqual(projector.toHtml(), (projector.root as Element).outerHTML);
+			projector.destroy();
+		},
+		'not attached throws'() {
+			const projector = new TestWidget();
+			assert.throws(() => {
+				projector.toHtml();
+			}, Error, 'Projector is not attached, cannot return an HTML string of projection.');
+		}
+	},
 	'destroy'() {
 		const projector: any = new TestWidget();
 		const maquetteProjectorStopSpy = spy(projector, 'pause');
@@ -305,6 +391,13 @@ registerSuite({
 		assert.throws(() => {
 			projector.root = document.body;
 		}, Error, 'already attached');
+	},
+	'sandbox throws when already attached'() {
+		const projector = new TestWidget();
+		projector.append();
+		assert.throws(() => {
+			projector.sandbox();
+		}, Error, 'Projector already attached, cannot create sandbox');
 	},
 	'can attach an event handler'() {
 		let domNode: any;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR provides two additional APIs to the Projector to make it easy to perform server side rendering.

- `.sandbox()` - This will create a `DocumentFragment` that is used as the root for the projection.  This ensures any virtual DOM rendering does not impact the rendering of the global `document`.  It can take a single argument of type `Document` which can be used with something like `jsdom` where there is not a global `document` exposed.  It also switches the `Projector` into synchronous render mode, making it easier to ensure that when the projector is introspected, it is always in a fully rendered state.
- `.toHtml()` - Returns a `string` that provides the full HTML of the projection.  This method will throw if the projector is not attached.

Resolves #493
