### PR TITLE
Bind to the original widget instance for injectors.

### DIFF
--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -57,11 +57,8 @@ export function Injector<C, T extends Constructor<BaseInjector<C>>>(Base: T, con
 		protected decoratateBind(node: DNode) {
 			const { bind } = this.properties;
 			decorate(node, (node: HNode | WNode<DefaultWidgetBaseInterface>) => {
-				const { properties } = node;
-
-				if (!properties.bind) {
-					assign(properties, { bind });
-				}
+				const { properties = {} }: { properties: { bind?: any } } = node;
+				properties.bind = bind;
 			}, (node: DNode) => { return isHNode(node) || isWNode(node); });
 
 			return node;

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -1,6 +1,14 @@
 import { assign } from '@dojo/core/lang';
-import { WidgetBase } from './WidgetBase';
-import { Constructor, DNode, WidgetProperties } from './interfaces';
+import { afterRender, WidgetBase } from './WidgetBase';
+import { decorate, isHNode, isWNode } from './d';
+import {
+	Constructor,
+	HNode,
+	DNode,
+	DefaultWidgetBaseInterface,
+	WNode,
+	WidgetProperties
+} from './interfaces';
 
 export interface GetProperties {
 	<C, P extends WidgetProperties>(inject: C, properties: P): any;
@@ -11,6 +19,7 @@ export interface GetChildren {
 }
 
 export interface InjectorProperties extends WidgetProperties {
+	bind: any;
 	render(): DNode;
 	getProperties: GetProperties;
 	properties: WidgetProperties;
@@ -42,6 +51,20 @@ export function Injector<C, T extends Constructor<BaseInjector<C>>>(Base: T, con
 
 		constructor(...args: any[]) {
 			super(context);
+		}
+
+		@afterRender()
+		protected decoratateBind(node: DNode) {
+			const { bind } = this.properties;
+			decorate(node, (node: HNode | WNode<DefaultWidgetBaseInterface>) => {
+				const { properties } = node;
+
+				if (!properties.bind) {
+					assign(properties, { bind });
+				}
+			}, (node: DNode) => { return isHNode(node) || isWNode(node); });
+
+			return node;
 		}
 
 		protected render(): DNode {

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -1,12 +1,9 @@
 import { assign } from '@dojo/core/lang';
-import { afterRender, WidgetBase } from './WidgetBase';
+import { afterRender, WidgetBase, InternalWNode, InternalHNode } from './WidgetBase';
 import { decorate, isHNode, isWNode } from './d';
 import {
 	Constructor,
-	HNode,
 	DNode,
-	DefaultWidgetBaseInterface,
-	WNode,
 	WidgetProperties
 } from './interfaces';
 
@@ -56,8 +53,8 @@ export function Injector<C, T extends Constructor<BaseInjector<C>>>(Base: T, con
 		@afterRender()
 		protected decoratateBind(node: DNode) {
 			const { bind } = this.properties;
-			decorate(node, (node: HNode | WNode<DefaultWidgetBaseInterface>) => {
-				const { properties = {} }: { properties: { bind?: any } } = node;
+			decorate(node, (node: InternalHNode | InternalWNode) => {
+				const { properties } = node;
 				properties.bind = bind;
 			}, (node: DNode) => { return isHNode(node) || isWNode(node); });
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -33,12 +33,12 @@ interface WidgetCacheWrapper {
 	used: boolean;
 }
 
-interface InternalWNode extends WNode {
+export interface InternalWNode extends WNode {
 	properties: {
 		bind: any;
 	};
 }
-interface InternalHNode extends HNode {
+export interface InternalHNode extends HNode {
 	properties: {
 		bind: any;
 	};

--- a/src/mixins/Container.ts
+++ b/src/mixins/Container.ts
@@ -39,6 +39,7 @@ export function Container<P extends WidgetProperties, T extends Constructor<Widg
 		protected beforeRender(renderFunc: Function, properties: P, children: DNode[]) {
 			return () => {
 				return w<BaseInjector<any>>(name, {
+					bind: this,
 					render: super.render,
 					getProperties,
 					properties,

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -2,12 +2,18 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Injector, { BaseInjector } from './../../src/Injector';
 import { DNode } from './../../src/interfaces';
+import { WidgetBase } from './../../src/WidgetBase';
+import { v, w } from './../../src/d';
 
 class TestInjector<C> extends BaseInjector<C> {
 	public render() {
 		return super.render();
 	}
 }
+
+const bind = {
+	foo: 'bar'
+};
 
 registerSuite({
 	name: 'Injector',
@@ -19,13 +25,30 @@ registerSuite({
 		const testProperties = {
 			qux: 'baz'
 		};
+
+		class TestWidget extends WidgetBase<any> {
+			render() {
+				return v('div', { testFunction: this.properties.testFunction });
+			}
+		}
+
+		function testFunction(this: any) {
+			assert.strictEqual(this, bind);
+		}
+
 		const testChildren: DNode[] = [ 'child' ];
-		const render = (): DNode => { return 'Called Render'; };
+		const render = (): DNode => { return v('div', {}, [
+				w(TestWidget, { testFunction }),
+				v('span'),
+				v('div', { bind: context })
+			]);
+		};
 		const InjectorWidget = Injector(TestInjector, context);
 
 		const injector = new InjectorWidget<any>();
 		injector.__setProperties__({
 			render,
+			bind,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
 				assert.deepEqual(inject, context);
@@ -40,10 +63,13 @@ registerSuite({
 			}
 		});
 
-		const renderedNode = injector.render();
+		const renderedNode: any = injector.__render__();
 		assert.deepEqual(testProperties, { qux: 'baz' });
 		assert.deepEqual(testChildren, [ 'child' ]);
-		assert.strictEqual(renderedNode, 'Called Render');
+		assert.deepEqual(renderedNode.properties, { bind });
+		assert.deepEqual(renderedNode.children[1].properties, { bind });
+		assert.deepEqual(renderedNode.children[2].properties, { bind: context });
+		renderedNode.children[0].properties.testFunction();
 	},
 	'injector ignores constructor arguments'() {
 		const context = {
@@ -59,6 +85,7 @@ registerSuite({
 
 		const injector = new InjectorWidget<any>();
 		injector.__setProperties__({
+			bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
@@ -93,6 +120,7 @@ registerSuite({
 
 		const injector = new InjectorWidget<any>();
 		injector.__setProperties__({
+			bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
@@ -130,6 +158,7 @@ registerSuite({
 
 		const injector = new InjectorWidget<any>();
 		injector.__setProperties__({
+			bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
@@ -160,6 +189,7 @@ registerSuite({
 
 		const injector = new InjectorWidget<any>();
 		injector.__setProperties__({
+			bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -40,7 +40,7 @@ registerSuite({
 		const render = (): DNode => { return v('div', {}, [
 				w(TestWidget, { testFunction }),
 				v('span'),
-				v('div', { bind: context })
+				v('div')
 			]);
 		};
 		const InjectorWidget = Injector(TestInjector, context);
@@ -68,7 +68,7 @@ registerSuite({
 		assert.deepEqual(testChildren, [ 'child' ]);
 		assert.deepEqual(renderedNode.properties, { bind });
 		assert.deepEqual(renderedNode.children[1].properties, { bind });
-		assert.deepEqual(renderedNode.children[2].properties, { bind: context });
+		assert.deepEqual(renderedNode.children[2].properties, { bind });
 		renderedNode.children[0].properties.testFunction();
 	},
 	'injector ignores constructor arguments'() {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Change `bind` to be a mandatory property for the `Injector` and add an `afterRender` to decorate all HNode/WNode with original `bind`.

Resolves #496 
