### PR TITLE
Ensure properties and children are 'reset' each render for a projector

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -1,3 +1,4 @@
+import { assign } from '@dojo/core/lang';
 import global from '@dojo/core/global';
 import { Handle } from '@dojo/interfaces/core';
 import { dom, Projection, ProjectionOptions, VNodeProperties } from 'maquette';
@@ -123,7 +124,7 @@ const eventHandlers = [
 ];
 
 export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T): T & Constructor<ProjectorMixin<P>> {
-	return class extends base {
+	class Projector extends base {
 
 		public projectorState: ProjectorAttachState;
 
@@ -135,6 +136,8 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 		private _paused: boolean;
 		private _boundDoRender: FrameRequestCallback;
 		private _boundRender: Function;
+		private _projectorChildren: DNode[];
+		private _projectorProperties: P;
 
 		constructor(...args: any[]) {
 			super(...args);
@@ -215,14 +218,22 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 		}
 
 		public setChildren(children: DNode[]): void {
+			this._projectorChildren = [ ...children ];
 			super.__setChildren__(children);
 		}
 
 		public setProperties(properties: P & { [index: string]: any }): void {
+			this._projectorProperties = assign({}, properties);
 			super.__setProperties__(properties);
 		}
 
 		public __render__() {
+			if (this._projectorChildren) {
+				this.setChildren(this._projectorChildren);
+			}
+			if (this._projectorProperties) {
+				this.setProperties(this._projectorProperties);
+			}
 			const result = super.__render__();
 			if (typeof result === 'string' || result === null) {
 				throw new Error('Must provide a VNode at the root of a projector');
@@ -290,7 +301,9 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 
 			return this._attachHandle;
 		}
-	};
+	}
+
+	return Projector;
 }
 
 export default ProjectorMixin;

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -6,7 +6,7 @@ import * as assert from 'intern/chai!assert';
 import { spy } from 'sinon';
 import { v } from '../../../src/d';
 import { ProjectorMixin, ProjectorAttachState } from '../../../src/mixins/Projector';
-import { WidgetBase } from '../../../src/WidgetBase';
+import { beforeRender, WidgetBase } from '../../../src/WidgetBase';
 import { waitFor } from '../waitFor';
 
 const Event = global.window.Event;
@@ -199,6 +199,29 @@ registerSuite({
 		const scheduleRender = spy(projector, 'scheduleRender');
 		projector.setProperties({ foo: 'hello' });
 		assert.isTrue(scheduleRender.called);
+	},
+	'properties are reset to original state on render'() {
+		const testProperties = {
+			foo: 'bar'
+		};
+		const testChildren = [ v('div') ];
+		class TestWidget extends ProjectorMixin(WidgetBase) {
+
+			@beforeRender()
+			protected updateProperties(renderFunc: any, props: any, children: any) {
+				assert.deepEqual(props, testProperties);
+				assert.deepEqual(children, testChildren);
+				props.bar = 'foo';
+				children.push(v('span'));
+				return renderFunc;
+			}
+		}
+		const projector = new TestWidget();
+		projector.setProperties(testProperties);
+		projector.setChildren(testChildren);
+		projector.__render__();
+		projector.invalidate();
+		projector.__render__();
 	},
 	'invalidate on setting children'() {
 		const projector = new TestWidget();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure properties and children are reset each render back to the last received set by either `setProperties` or `setChildren`

Resolves #498 
