### PR TITLE
Automatically add `bind` for all children nodes.

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -260,7 +260,9 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 	protected decorateBind(node: DNode): DNode {
 		decorate(node, (node: InternalWNode | InternalHNode) => {
 			const { properties = {} }: { properties: { bind?: any } } = node;
-			properties.bind = this;
+			if (!properties.bind) {
+				properties.bind = this;
+			}
 		}, (node: DNode) => { return isHNode(node) || isWNode(node); });
 		return node;
 	}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -16,7 +16,8 @@ import {
 	PropertyChangeRecord,
 	PropertiesChangeEvent,
 	RegistryLabel,
-	HNode
+	HNode,
+	WNode
 } from './interfaces';
 import { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './WidgetRegistry';
 import RegistryHandler from './RegistryHandler';
@@ -30,6 +31,17 @@ interface WidgetCacheWrapper {
 	child: WidgetBaseInterface<WidgetProperties>;
 	widgetConstructor: WidgetBaseConstructor;
 	used: boolean;
+}
+
+interface InternalWNode extends WNode {
+	properties: {
+		bind: any;
+	};
+}
+interface InternalHNode extends HNode {
+	properties: {
+		bind: any;
+	};
 }
 
 enum WidgetRenderState {
@@ -241,6 +253,15 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 			node.properties.afterUpdate = this.afterUpdateCallback;
 		}, isHNodeWithKey);
 
+		return node;
+	}
+
+	@afterRender()
+	protected decorateBind(node: DNode): DNode {
+		decorate(node, (node: InternalWNode | InternalHNode) => {
+			const { properties = {} }: { properties: { bind?: any } } = node;
+			properties.bind = this;
+		}, (node: DNode) => { return isHNode(node) || isWNode(node); });
 		return node;
 	}
 
@@ -556,10 +577,6 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 				return false;
 			});
 
-			if (!properties.hasOwnProperty('bind')) {
-				properties.bind = this;
-			}
-
 			if (cachedChild) {
 				child = cachedChild.child;
 				child.__setProperties__(properties);
@@ -593,7 +610,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 			return this.dNodeToVNode(child);
 		});
 
-		return dNode.render({ bind: this });
+		return dNode.render();
 	}
 
 	/**

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,7 +1,7 @@
 import { assign } from '@dojo/core/lang';
 import { VNode } from '@dojo/interfaces/vdom';
 import Symbol from '@dojo/shim/Symbol';
-import { h } from 'maquette';
+import { h, VNodeProperties } from 'maquette';
 import {
 	Constructor,
 	DNode,
@@ -108,9 +108,9 @@ export function v(tag: string, propertiesOrChildren: VirtualDomProperties | DNod
 			tag,
 			children,
 			properties,
-			render<T>(this: { vNodes: VNode[], properties: VirtualDomProperties }, options: { bind?: T } = { }) {
+			render(this: { vNodes: VNode[], properties: VNodeProperties }) {
 
-				return h(tag, assign(options, this.properties), this.vNodes);
+				return h(tag, this.properties, this.vNodes);
 			},
 			type: HNODE
 		};

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -113,12 +113,9 @@ export interface VirtualDomProperties {
 	afterUpdate?(element: Element, projectionOptions: ProjectionOptions, vnodeSelector: string, properties: VNodeProperties,
 	children: VNode[]): void;
 	/**
-	 * When specified, the event handlers will be invoked with 'this' pointing to the value.
-	 * This is useful when using the prototype/class based implementation of Components.
-	 *
-	 * When no [[key]] is present, this object is also used to uniquely identify a DOM node.
+	 * Bind should not be defined.
 	 */
-	readonly bind?: Object;
+	readonly bind?: void;
 	/**
 	 * Used to uniquely identify a DOM node among siblings.
 	 * A key is required when there are more children with the same selector and these children are added or removed dynamically.
@@ -226,11 +223,6 @@ export interface WidgetProperties {
 	 * rendering and instance management
 	 */
 	key?: string;
-
-	/**
-	 * The scope to bind all function properties
-	 */
-	bind?: any;
 }
 
 /**

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -392,94 +392,6 @@ registerSuite({
 			testWidget.__render__();
 			assert.strictEqual(testWidget.count, 2);
 		},
-		'widget function properties can be bound to a custom scope'() {
-			class TestChildWidget extends WidgetBase<any> {
-				render() {
-					this.properties.foo();
-					return v('div');
-				}
-			}
-
-			const foo = {
-				count: 0,
-				foo(this: any) {
-					this.count += 1;
-				}
-			};
-
-			class TestWidget extends WidgetBase<any> {
-				count: number;
-				constructor() {
-					super();
-					this.count = 0;
-				}
-
-				foo() {
-					this.count++;
-				}
-
-				render(): DNode {
-					return w(TestChildWidget, {
-						foo: foo.foo,
-						bar: Math.random(),
-						bind: foo
-					});
-				}
-			}
-
-			const testWidget: any = new TestWidget();
-			testWidget.__render__();
-			assert.strictEqual(foo.count, 1);
-			testWidget.invalidate();
-			testWidget.__render__();
-			assert.strictEqual(foo.count, 2);
-		},
-		'widget function properties can have different bound scopes'() {
-			class TestChildWidget extends WidgetBase<any> {
-				render() {
-					this.properties.foo();
-					return v('div');
-				}
-			}
-
-			const foo = {
-				count: 0,
-				foo(this: any) {
-					this.count += 1;
-				}
-			};
-
-			class TestWidget extends WidgetBase<any> {
-				count: number;
-
-				foo(this: any) {
-					this.count++;
-				}
-
-				constructor() {
-					super();
-					this.count = 0;
-				}
-
-				render(): DNode {
-					const bind = this.count ? foo : this;
-					return w(TestChildWidget, {
-						foo: this.foo,
-						bar: Math.random(),
-						bind
-					});
-				}
-			}
-
-			const testWidget: any = new TestWidget();
-			testWidget.__render__();
-			assert.strictEqual(foo.count, 0);
-			assert.strictEqual(testWidget.count, 1);
-			testWidget.invalidate();
-			testWidget.__render__();
-			assert.strictEqual(foo.count, 1);
-			assert.strictEqual(testWidget.count, 1);
-		},
 		'widget function properties do not get re-bound when nested'() {
 			class TestChildWidget extends WidgetBase<any> {
 				render() {
@@ -520,42 +432,6 @@ registerSuite({
 			testWidget.__render__();
 			assert.strictEqual(testWidget.count, 2);
 		},
-		'widget function properties can be un-bound'() {
-			class TestChildWidget extends WidgetBase<any> {
-				render() {
-					this.properties.foo();
-					return v('div');
-				}
-			}
-
-			class TestWidget extends WidgetBase<any> {
-				count: number;
-
-				foo(this: any) {
-					this.count++;
-				}
-
-				constructor() {
-					super();
-					this.count = 0;
-				}
-
-				render(): DNode {
-					return w(TestChildWidget, {
-						foo: this.foo,
-						bar: Math.random(),
-						bind: undefined
-					});
-				}
-			}
-
-			const testWidget: any = new TestWidget();
-			try {
-				testWidget.__render__();
-			} catch (e) {
-				assert.strictEqual(testWidget.count, 0);
-			}
-		},
 		'widget constructors are not bound'() {
 			const widgetConstructorSpy: any = function(this: any) {
 				this.functionIsBound = true;
@@ -572,7 +448,6 @@ registerSuite({
 
 			const testWidget = new TestWidget();
 			const properties = {
-				bind: testWidget,
 				widgetConstructorSpy,
 				functionIsBound: false
 			};
@@ -1110,25 +985,6 @@ widget.__setProperties__({
 			assert.strictEqual(result.children![0].properties!.bind, widget);
 			assert.strictEqual(result.children![0].children![0].properties!.bind, widget);
 		},
-		'bind does not get overriden when specifically configured for the element'() {
-			const customThis = {};
-			class TestWidget extends WidgetBase<any> {
-				render() {
-					return v('div', [
-						v('header', { bind: customThis }, [
-							v('section')
-						])
-					]);
-				}
-			}
-
-			const widget: any = new TestWidget();
-			const result = <VNode> widget.__render__();
-			assert.lengthOf(result.children, 1);
-			assert.strictEqual(result.properties!.bind, widget);
-			assert.strictEqual(result.children![0].properties!.bind, customThis);
-			assert.strictEqual(result.children![0].children![0].properties!.bind, widget);
-		},
 		'render with multiple text node children'() {
 			class TestWidget extends WidgetBase<any> {
 				render() {
@@ -1498,7 +1354,7 @@ widget.__setProperties__({
 		const testWidget = new TestWidget();
 		const testWidget2 = new TestWidget2();
 
-		assert.equal(testWidget.getAfterRenders().length, 2);
-		assert.equal(testWidget2.getAfterRenders().length, 3);
+		assert.equal(testWidget.getAfterRenders().length, 3);
+		assert.equal(testWidget2.getAfterRenders().length, 4);
 	}
 });

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -79,22 +79,6 @@ registerSuite({
 			assert.equal(error.message, 'Must provide a VNode at the root of a projector');
 		}
 	},
-	'render does not attach after create when there are no properties'() {
-		const projector = new class extends TestWidget {
-			render() {
-				return v('div', <any> null);
-			}
-
-			__render__() {
-				const results: any = super.__render__();
-				results.properties = undefined;
-				return results;
-			}
-		}();
-
-		const vnode  = <any> projector.__render__();
-		assert.isUndefined(vnode.properties);
-	},
 	'attach to projector': {
 		'append'() {
 			const childNodeLength = document.body.childNodes.length;

--- a/tests/unit/tsx.ts
+++ b/tests/unit/tsx.ts
@@ -15,7 +15,6 @@ registerSuite({
 		// These will always be undefined but show the type inference of properties.
 		registryWrapper.properties = {};
 		assert.isUndefined(registryWrapper.properties.key);
-		assert.isUndefined(registryWrapper.properties.bind);
 	},
 	tsx: {
 		'tsx generate a HNode'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Remove `bind` from both `WidgetProperties` and `VirtualDomProperties` interfaces and add capability in widget core to decorate all nodes for a widget with a `bind` value of the enclosing widget's scope.

Resolves #499
