### PR TITLE
Better Error for using widgets multiple times

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -577,6 +577,9 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 			}
 			if (!key && cachedChildren.length > 1) {
 				const errorMsg = 'It is recommended to provide a unique `key` property when using the same widget multiple times';
+				if (cachedChildren[0].child) {
+					console.warn(`${cachedChildren[0].child.constructor.name}:`);
+				}
 				console.warn(errorMsg);
 				this.emit({ type: 'error', target: this, error: new Error(errorMsg) });
 			}


### PR DESCRIPTION
As a widget author I'd like to know at least which widget caused the error
' It is recommended to provide a unique `key` property when using the same widget multiple times '

**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #???
