### PR TITLE
Include widget name in multiple widget warn message.

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -576,7 +576,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 				this.own(child);
 			}
 			if (typeof childrenMapKey !== 'string' && cachedChildren.length > 1) {
-				const errorMsg = `It is recommended to provide a unique 'key' property when using the same widget (${childrenMapKey.name}) multiple times`;
+				const errorMsg = `It is recommended to provide a unique 'key' property when using the same widget (${(<any> childrenMapKey).name}) multiple times`;
 				console.warn(errorMsg);
 				this.emit({ type: 'error', target: this, error: new Error(errorMsg) });
 			}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -577,7 +577,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 			}
 			if (typeof childrenMapKey !== 'string' && cachedChildren.length > 1) {
 				const errorMsg = `It is recommended to provide a unique 'key' property when using the same widget (${childrenMapKey.name}) multiple times`;
-				console.warn(`${errorMsg}`);
+				console.warn(errorMsg);
 				this.emit({ type: 'error', target: this, error: new Error(errorMsg) });
 			}
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -576,7 +576,13 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 				this.own(child);
 			}
 			if (typeof childrenMapKey !== 'string' && cachedChildren.length > 1) {
-				const errorMsg = `It is recommended to provide a unique 'key' property when using the same widget (${(<any> childrenMapKey).name}) multiple times`;
+				const widgetName = (<any> childrenMapKey).name;
+				let errorMsg = 'It is recommended to provide a unique \'key\' property when using the same widget multiple times';
+
+				if (widgetName) {
+					errorMsg = `It is recommended to provide a unique 'key' property when using the same widget (${widgetName}) multiple times`;
+				}
+
 				console.warn(errorMsg);
 				this.emit({ type: 'error', target: this, error: new Error(errorMsg) });
 			}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -575,9 +575,9 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 				this._cachedChildrenMap.set(childrenMapKey, cachedChildren);
 				this.own(child);
 			}
-			if (!key && cachedChildren.length > 1) {
-				const errorMsg = 'It is recommended to provide a unique `key` property when using the same widget multiple times';
-				console.warn(errorMsg);
+			if (typeof childrenMapKey !== 'string' && cachedChildren.length > 1) {
+				const errorMsg = `It is recommended to provide a unique 'key' property when using the same widget (${childrenMapKey.name}) multiple times`;
+				console.warn(`${errorMsg}`);
 				this.emit({ type: 'error', target: this, error: new Error(errorMsg) });
 			}
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1220,9 +1220,14 @@ widget.__setProperties__({
 			assert.strictEqual(lastRenderChild.vnodeSelector, 'footer');
 		},
 		'render with multiple children of the same type without an id'() {
-			const warnMsg = 'It is recommended to provide a unique \'key\' property when using the same widget (TestWidgetTwo) multiple times';
 			class TestWidgetOne extends WidgetBase<any> {}
 			class TestWidgetTwo extends WidgetBase<any> {}
+			const widgetName = (<any> TestWidgetTwo).name;
+			let warnMsg = 'It is recommended to provide a unique \'key\' property when using the same widget multiple times';
+
+			if (widgetName) {
+				warnMsg = `It is recommended to provide a unique 'key' property when using the same widget (${widgetName}) multiple times`;
+			}
 
 			class TestWidget extends WidgetBase<any> {
 				render() {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -2,7 +2,7 @@ import { VNode } from '@dojo/interfaces/vdom';
 import Promise from '@dojo/shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { stub, spy } from 'sinon';
+import { stub, spy, SinonStub } from 'sinon';
 import { v, w, registry } from '../../src/d';
 import { DNode, WidgetProperties } from '../../src/interfaces';
 import { WidgetBase, diffProperty, DiffType, afterRender, beforeRender, onPropertiesChanged } from '../../src/WidgetBase';
@@ -18,8 +18,16 @@ interface TestProperties extends WidgetProperties {
 
 class TestWidget extends WidgetBase<TestProperties> {}
 
+let consoleStub: SinonStub;
+
 registerSuite({
 	name: 'WidgetBase',
+	beforeEach() {
+		consoleStub = stub(console, 'warn');
+	},
+	afterEach() {
+		consoleStub.restore();
+	},
 	api() {
 		const widgetBase = new WidgetBase();
 		assert(widgetBase);
@@ -1212,7 +1220,7 @@ widget.__setProperties__({
 			assert.strictEqual(lastRenderChild.vnodeSelector, 'footer');
 		},
 		'render with multiple children of the same type without an id'() {
-			const warnMsg = 'It is recommended to provide a unique `key` property when using the same widget multiple times';
+			const warnMsg = 'It is recommended to provide a unique \'key\' property when using the same widget (TestWidgetTwo) multiple times';
 			class TestWidgetOne extends WidgetBase<any> {}
 			class TestWidgetTwo extends WidgetBase<any> {}
 
@@ -1227,7 +1235,6 @@ widget.__setProperties__({
 			}
 
 			const widget: any = new TestWidget();
-			const consoleStub = stub(console, 'warn');
 			widget.__render__();
 			assert.isTrue(consoleStub.calledOnce);
 			assert.isTrue(consoleStub.calledWith(warnMsg));
@@ -1235,7 +1242,6 @@ widget.__setProperties__({
 			widget.__render__();
 			assert.isTrue(consoleStub.calledThrice);
 			assert.isTrue(consoleStub.calledWith(warnMsg));
-			consoleStub.restore();
 		},
 		'__render__ with updated array properties'() {
 			const properties = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"lib": [
 			"dom",
 			"es5",
+			"es2015.core",
 			"es2015.iterable",
 			"es2015.symbol",
 			"es2015.symbol.wellknown"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
 		"lib": [
 			"dom",
 			"es5",
-			"es2015.core",
 			"es2015.iterable",
 			"es2015.symbol",
 			"es2015.symbol.wellknown"


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds the `constructor.name` of the widget that has been used multiple times without a unique key warning.

Resolves #505 
