### PR TITLE
Revert to use safari 9.1 and skip functional tests for safari

### DIFF
--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -2,24 +2,30 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import pollUntil = require('intern/dojo/node!leadfoot/helpers/pollUntil');
 
+let skip: boolean;
+
 registerSuite({
 	name: 'registerCustomElement',
-
-	'custom elements are registered'(this: any) {
-		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
-			this.skip('not compatible with iOS 9.1');
+	beforeEach(this: any) {
+		const { browserName, browser, version } = this.remote.session.capabilities;
+		skip = false;
+		if ((browser === 'iPhone' && version === '9.1') || (browserName === 'safari' && version === '9.1.3')) {
+			skip = true;
 		}
-
+	},
+	'custom elements are registered'(this: any) {
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
+		}
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
 			.findByCssSelector('test-button > button');
 	},
 	'custom element initial properties are set correctly'(this: any) {
-		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
-			this.skip('not compatible with iOS 9.1');
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
 		}
-
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
@@ -32,10 +38,9 @@ registerSuite({
 			});
 	},
 	'custom element event handlers are registered'(this: any) {
-		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
-			this.skip('not compatible with iOS 9.1');
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
 		}
-
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
@@ -48,10 +53,9 @@ registerSuite({
 			});
 	},
 	'setting custom element attribute updates properties'(this: any) {
-		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
-			this.skip('not compatible with iOS 9.1');
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
 		}
-
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
@@ -63,10 +67,9 @@ registerSuite({
 			}, undefined, 1000), undefined);
 	},
 	'setting custom element properties updates widget'(this: any) {
-		if (this.remote.session.capabilities.browser === 'iPhone' && this.remote.session.capabilities.version === '9.1') {
-			this.skip('not compatible with iOS 9.1');
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
 		}
-
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -23,7 +23,7 @@ export const environments = [
 	{ browserName: 'edge' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
 	{ browserName: 'chrome', platform: 'WINDOWS' },
-	{ browserName: 'safari', version: '10', platform: 'MAC' },
+	{ browserName: 'safari', version: '9.1', platform: 'MAC' },
 	{ browserName: 'iPhone', version: '9.1' }
 ];
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

MAC Safari 10 is failing for a driver issue, so bumping down to 9.1 and adding skips for the custom element functional tests (as not supported)