### PR TITLE
Check children before setting widget as dirty

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -365,12 +365,14 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 	}
 
 	public __setChildren__(children: (C | null)[]): void {
-		this._dirty = true;
-		this._children = children;
-		this.emit({
-			type: 'widget:children',
-			target: this
-		});
+		if (this._children.length || children.length) {
+			this._dirty = true;
+			this._children = children;
+			this.emit({
+				type: 'widget:children',
+				target: this
+			});
+		}
 	}
 
 	public __render__(): VNode | string | null {
@@ -581,9 +583,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 				this.emit({ type: 'error', target: this, error: new Error(errorMsg) });
 			}
 
-			if (Array.isArray(children)) {
-				child.__setChildren__(children);
-			}
+			child.__setChildren__(children);
 			return child.__render__();
 		}
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1419,6 +1419,28 @@ widget.__setProperties__({
 		widget.__render__();
 		assert.equal(foo, 2);
 	},
+	'widget should not be marked as dirty if previous and current children are empty'() {
+		let foo = 0;
+		class FooWidget extends WidgetBase<any> {
+			render() {
+				foo++;
+				return v('div');
+			}
+		}
+
+		class TestWidget extends WidgetBase<any> {
+			render() {
+				return w(FooWidget, { key: '1' });
+			}
+		}
+
+		const widget: any = new TestWidget();
+		widget.__render__();
+		assert.equal(foo, 1);
+		widget.invalidate();
+		widget.__render__();
+		assert.equal(foo, 1);
+	},
 	'properties:changed should mark as dirty but not invalidate'() {
 		let foo = 0;
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Check that either previous children or current children exist before marking a widget as `dirty`.

Resolves #509 
