### PR TITLE
Always re-render an Injector

### DIFF
--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -1,6 +1,7 @@
 import { assign } from '@dojo/core/lang';
-import { afterRender, WidgetBase, InternalWNode, InternalHNode } from './WidgetBase';
+import { diffProperty, afterRender, WidgetBase, InternalWNode, InternalHNode } from './WidgetBase';
 import { decorate, isHNode, isWNode } from './d';
+import { DiffType } from './diff';
 import {
 	Constructor,
 	DNode,
@@ -64,6 +65,7 @@ export class BaseInjector<C> extends WidgetBase<InjectorProperties> {
  */
 export function Injector<C, T extends Constructor<BaseInjector<C>>>(Base: T, context: C): T {
 
+	@diffProperty('render', DiffType.ALWAYS)
 	class Injector extends Base {
 
 		constructor(...args: any[]) {

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -234,5 +234,41 @@ registerSuite({
 		assert.deepEqual(testProperties, { qux: 'baz' });
 		assert.deepEqual(testChildren, [ 'child' ]);
 		assert.strictEqual(renderedNode, 'Called Render');
+	},
+	'render property is always considered changed'() {
+		const testProperties = {
+			qux: 'baz'
+		};
+		let rendered = 0;
+		const testChildren: DNode[] = [ 'child' ];
+		const render = (): DNode => {
+			rendered++;
+			return 'Called Render';
+		};
+		const InjectorWidget = Injector(TestInjector, undefined);
+		const properties = {
+			bind,
+			render,
+			properties: testProperties,
+			getProperties: (inject: any, properties: any): any => {
+				assert.deepEqual(inject, {});
+				assert.deepEqual(properties, testProperties);
+				return {};
+			},
+			children: testChildren,
+			getChildren: (inject: any, children: DNode[]): DNode[] => {
+				assert.deepEqual(inject, {});
+				assert.deepEqual(children, testChildren);
+				return [];
+			}
+		};
+
+		const injector = new InjectorWidget<any>();
+		injector.__setProperties__(properties);
+		injector.__render__();
+		assert.strictEqual(rendered, 1);
+		injector.__setProperties__(properties);
+		injector.__render__();
+		assert.strictEqual(rendered, 2);
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Use custom diff for render to always consider the property as changed. This is to ensure the when a widget that an Injector proxies invalidates that it will be re-rendered and not stop at the injector because it has not been considered "dirty"

Resolves #514 
