### PR TITLE
Deffering custom element children until after the node is created

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -246,7 +246,9 @@ export function initializeElement(element: CustomElement) {
 	widgetInstance.__setChildren__(children);
 	element.setWidgetInstance(widgetInstance);
 
-	widgetInstance.append(element);
+	return function() {
+		widgetInstance.append(element);
+	};
 }
 
 /**

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -25,10 +25,20 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 	let widgetInstance: WidgetBase<any>;
 
 	customElements.define(descriptor.tagName, class extends HTMLElement {
+		private _isAppended = false;
+		private _appender: Function | null = null;
+
 		constructor() {
 			super();
 
-			initializeElement(this);
+			this._appender = initializeElement(this);
+		}
+
+		connectedCallback() {
+			if (!this._isAppended && this._appender) {
+				this._appender();
+				this._isAppended = true;
+			}
 		}
 
 		attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -26,7 +26,7 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 
 	customElements.define(descriptor.tagName, class extends HTMLElement {
 		private _isAppended = false;
-		private _appender: Function | null = null;
+		private _appender: Function;
 
 		constructor() {
 			super();
@@ -35,7 +35,7 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 		}
 
 		connectedCallback() {
-			if (!this._isAppended && this._appender) {
+			if (!this._isAppended) {
 				this._appender();
 				this._isAppended = true;
 			}

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -79,5 +79,18 @@ registerSuite({
 			.then(pollUntil<any>(function () {
 				return (<any> document).querySelector('no-attributes > button').innerHTML === 'greetings';
 			}, undefined, 1000), undefined);
+	},
+	'creating elements manually works'(this: any) {
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
+		}
+		return this.remote
+			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
+			.findByCssSelector('#manualButton > button')
+			.end()
+			.then(pollUntil<any>(function () {
+				return (<any> document).querySelector('#manualButton > button').innerHTML === 'manual';
+			}, undefined, 1000), undefined);
 	}
 });

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -92,5 +92,18 @@ registerSuite({
 			.then(pollUntil<any>(function () {
 				return (<any> document).querySelector('#manualButton > button').innerHTML === 'manual';
 			}, undefined, 1000), undefined);
+	},
+	'elements readded to the DOM are only initialized once'(this: any) {
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
+		}
+		return this.remote
+			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
+			.findByCssSelector('#reinitButton > button')
+			.end()
+			.then(pollUntil<any>(function () {
+				return (<any> document).querySelector('#reinitButton > button').innerHTML === 'test';
+			}, undefined, 1000), undefined);
 	}
 });

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -35,6 +35,13 @@
 		el.id = 'manualButton';
 		el.label = 'manual';
 		document.body.appendChild(el);
+
+		var reinitButton = document.createElement("test-button");
+		reinitButton.id = "reinitButton";
+		reinitButton.label = "test";
+		document.body.appendChild(reinitButton);
+		document.body.removeChild(reinitButton);
+		document.body.appendChild(reinitButton);
 	});
 </script>
 </body>

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -30,6 +30,11 @@
 		});
 
 		document.getElementById('noAttributes').buttonLabel = 'Test';
+
+		var el = document.createElement('test-button');
+		el.id = 'manualButton';
+		el.label = 'manual';
+		document.body.appendChild(el);
 	});
 </script>
 </body>

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -4,6 +4,9 @@ import { initializeElement, handleAttributeChanged, CustomElementDescriptor } fr
 import { WidgetBase } from '../../src/WidgetBase';
 import global from '@dojo/core/global';
 import { assign } from '@dojo/core/lang';
+import * as projector from '../../src/mixins/Projector';
+import * as sinon from 'sinon';
+import { v } from '../../src/d';
 
 function createFakeElement(attributes: any, descriptor: CustomElementDescriptor): any {
 	let widgetInstance: WidgetBase<any> | null;
@@ -316,5 +319,50 @@ registerSuite({
 
 			assert.strictEqual(element.getWidgetInstance().properties.prop1, 'test');
 		}
+	},
+
+	'appender': function () {
+		let sandbox: any;
+
+		return {
+			'beforeEach'() {
+				sandbox = sinon.sandbox.create();
+			},
+
+			afterEach() {
+				sandbox.restore();
+			},
+
+			'appender is returned as a function'(this: any) {
+				let rendered = false;
+
+				const appendStub = sandbox.stub();
+
+				sandbox.stub(projector, 'ProjectorMixin', function () {
+					return {
+						append: appendStub
+					};
+				});
+
+				let element = createFakeElement({}, {
+					tagName: 'test',
+					widgetConstructor: class extends WidgetBase<any> {
+						render() {
+							rendered = true;
+							return v('div');
+						}
+					}
+				});
+
+				const appender = initializeElement(element);
+
+				assert.isFalse(rendered);
+				assert.isFunction(appender);
+
+				appender();
+
+				assert.isTrue(appendStub.called);
+			}
+		};
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Creating a custom element manually (`document.createElement`) causes an error because elements are not supposed to be created with children (the projector). We're now deferring the appending of the projector until after the element is attached to the dom.

Resolves #517 
