### PR TITLE
Refector typings round to play nicely with ts-loader

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -6,11 +6,12 @@ import { defaultMappers, BaseInjector, Mappers } from './Injector';
 export function Container<W extends WidgetBaseInterface>(
 	component: Constructor<W> | RegistryLabel,
 	name: RegistryLabel,
-	{
+	mappers: Partial<Mappers> = defaultMappers
+): Constructor<WidgetBase<W['properties']>> {
+	const {
 		getProperties = defaultMappers.getProperties,
 		getChildren = defaultMappers.getChildren
-	}: Partial<Mappers> = defaultMappers
-): Constructor<WidgetBase<W['properties']>> {
+	} = mappers;
 
 	return class extends WidgetBase<any> {
 		protected render(): DNode {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The mapper typings were causing a failure when built via cli-build (uses webpack and ts-loader).

```
ERROR in /Users/Anthony/routing-component/node_modules/@dojo/widget-core/Container.d.ts
(4,131): error TS2459: Type 'Partial<Mappers> | undefined' has no property 'getProperties' and no string index signature.

ERROR in /Users/Anthony/routing-component/node_modules/@dojo/widget-core/Container.d.ts
(4,146): error TS2459: Type 'Partial<Mappers> | undefined' has no property 'getChildren' and no string index signature.
```

Refactor the typings to play nicely.