### PR TITLE
Add invalidation when context is set

### DIFF
--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -69,7 +69,7 @@ export interface InjectorProperties extends WidgetProperties {
 	children: DNode[];
 }
 
-export class BaseInjector<C extends Context = Context> extends WidgetBase<InjectorProperties> {
+export class BaseInjector<C extends Evented = Context> extends WidgetBase<InjectorProperties> {
 
 	protected context: C = <C> {};
 
@@ -90,7 +90,7 @@ export class BaseInjector<C extends Context = Context> extends WidgetBase<Inject
  * Mixin that extends the supplied Injector class with the proxy `render` and passing the provided to `context` to the Injector
  * class via the constructor.
  */
-export function Injector<C extends Context, T extends Constructor<BaseInjector<C>>>(Base: T, context: C): T {
+export function Injector<C extends Evented, T extends Constructor<BaseInjector<C>>>(Base: T, context: C): T {
 
 	@diffProperty('render', DiffType.ALWAYS)
 	class Injector extends Base {

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -1,4 +1,5 @@
 import { assign } from '@dojo/core/lang';
+import { Evented } from '@dojo/core/Evented';
 import { diffProperty, afterRender, WidgetBase, InternalWNode, InternalHNode } from './WidgetBase';
 import { decorate, isHNode, isWNode } from './d';
 import { DiffType } from './diff';
@@ -36,6 +37,29 @@ export const defaultMappers: Mappers = {
 	}
 };
 
+/**
+ * Base context class that extends Evented and
+ * returns the context using `.get()`.
+ */
+export class Context<T = any> extends Evented {
+
+	private _context: T;
+
+	constructor(context: T = <T> {}) {
+		super({});
+		this._context = context;
+	}
+
+	public get(): T {
+		return this._context;
+	}
+
+	public set(context: T): void {
+		this._context = context;
+		this.emit({ type: 'invalidate' });
+	}
+}
+
 export interface InjectorProperties extends WidgetProperties {
 	bind: any;
 	render(): DNode;
@@ -45,17 +69,20 @@ export interface InjectorProperties extends WidgetProperties {
 	children: DNode[];
 }
 
-export class BaseInjector<C> extends WidgetBase<InjectorProperties> {
+export class BaseInjector<C extends Context = Context> extends WidgetBase<InjectorProperties> {
 
-	private _context: C;
+	protected context: C = <C> {};
 
-	constructor(context: C = <C> {}) {
+	constructor(context?: C) {
 		super();
-		this._context = context;
+		if (context) {
+			this.context = context;
+			this.context.on('invalidate', this.invalidate.bind(this));
+		}
 	}
 
 	public toInject(): C {
-		return this._context;
+		return this.context;
 	}
 }
 
@@ -63,7 +90,7 @@ export class BaseInjector<C> extends WidgetBase<InjectorProperties> {
  * Mixin that extends the supplied Injector class with the proxy `render` and passing the provided to `context` to the Injector
  * class via the constructor.
  */
-export function Injector<C, T extends Constructor<BaseInjector<C>>>(Base: T, context: C): T {
+export function Injector<C extends Context, T extends Constructor<BaseInjector<C>>>(Base: T, context: C): T {
 
 	@diffProperty('render', DiffType.ALWAYS)
 	class Injector extends Base {

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -6,11 +6,9 @@ import {
 	theme,
 	ThemeableProperties,
 	INJECTED_THEME_KEY,
-	ThemeInjector,
-	ThemeInjectorContext,
 	registerThemeInjector
 } from '../../../src/mixins/Themeable';
-import { Injector } from './../../../src/Injector';
+import { BaseInjector, Context, Injector } from './../../../src/Injector';
 import { WidgetBase } from '../../../src/WidgetBase';
 import { WidgetRegistry } from '../../../src/WidgetRegistry';
 import { WidgetProperties } from '../../../src/interfaces';
@@ -401,8 +399,8 @@ registerSuite({
 	},
 	'injecting a theme': {
 		'theme can be injected by defining a ThemeInjector with registry'() {
-			const themeInjectorContext = new ThemeInjectorContext(testTheme1);
-			const InjectorBase = Injector(ThemeInjector, themeInjectorContext);
+			const themeInjectorContext = new Context(testTheme1);
+			const InjectorBase = Injector(BaseInjector, themeInjectorContext);
 			testRegistry.define(INJECTED_THEME_KEY, InjectorBase);
 			class InjectedTheme extends TestWidget {
 				render() {
@@ -415,8 +413,8 @@ registerSuite({
 			assert.deepEqual(vNode.properties.classes, { theme1Class1: true });
 		},
 		'theme will not be injected if a theme has been passed via a property'() {
-			const themeInjectorContext = new ThemeInjectorContext(testTheme1);
-			const InjectorBase = Injector(ThemeInjector, themeInjectorContext);
+			const themeInjectorContext = new Context(testTheme1);
+			const InjectorBase = Injector(BaseInjector, themeInjectorContext);
 			testRegistry.define(INJECTED_THEME_KEY, InjectorBase);
 			class InjectedTheme extends TestWidget {
 				render() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds invalidation for injectors when the context is set using the `.set()` API.

Resolves #527
