### PR TITLE
Ensure that custom elements get the correct instance

### DIFF
--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -26,7 +26,7 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 	customElements.define(descriptor.tagName, class extends HTMLElement {
 		private _isAppended = false;
 		private _appender: Function;
-		private widgetInstance: WidgetBase;
+		private _widgetInstance: WidgetBase;
 
 		constructor() {
 			super();
@@ -46,11 +46,11 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 		}
 
 		getWidgetInstance(): WidgetBase<any> {
-			return this.widgetInstance;
+			return this._widgetInstance;
 		}
 
 		setWidgetInstance(widget: WidgetBase<any>): void {
-			this.widgetInstance = widget;
+			this._widgetInstance = widget;
 		}
 
 		getWidgetConstructor(): Constructor<WidgetBase<WidgetProperties>> {

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -22,11 +22,11 @@ export interface CustomElementDescriptorFactory {
  */
 export function registerCustomElement(descriptorFactory: CustomElementDescriptorFactory) {
 	const descriptor = descriptorFactory();
-	let widgetInstance: WidgetBase<any>;
 
 	customElements.define(descriptor.tagName, class extends HTMLElement {
 		private _isAppended = false;
 		private _appender: Function;
+		private widgetInstance: WidgetBase;
 
 		constructor() {
 			super();
@@ -46,11 +46,11 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 		}
 
 		getWidgetInstance(): WidgetBase<any> {
-			return widgetInstance;
+			return this.widgetInstance;
 		}
 
 		setWidgetInstance(widget: WidgetBase<any>): void {
-			widgetInstance = widget;
+			this.widgetInstance = widget;
 		}
 
 		getWidgetConstructor(): Constructor<WidgetBase<WidgetProperties>> {

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -20,7 +20,7 @@ registerSuite({
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
-			.findByCssSelector('test-button > button');
+			.findById('testButton');
 	},
 	'custom element initial properties are set correctly'(this: any) {
 		if (skip) {
@@ -29,7 +29,7 @@ registerSuite({
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
-			.findByCssSelector('test-button > button')
+			.findById('testButton')
 			.then((element: any) => {
 				return element.getVisibleText();
 			})
@@ -44,12 +44,27 @@ registerSuite({
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
-			.findByCssSelector('test-button > button')
+			.findById('testButton')
 			.click()
 			.end()
 			.execute('return window.buttonClicked')
 			.then((buttonClicked: boolean) => {
 				assert.isTrue(buttonClicked);
+			});
+	},
+	'updates the correct instance when multiple or the same custom elements are used'(this: any) {
+		if (skip) {
+			this.skip('not compatible with iOS 9.1 or Safari 9.1');
+		}
+		return this.remote
+			.get((<any> require).toUrl('./support/registerCustomElement.html'))
+			.setFindTimeout(1000)
+			.findById('testButton-2')
+			.then((element: any) => {
+				return element.getVisibleText();
+			})
+			.then((text: string) => {
+				assert.strictEqual(text, 'Worlds hello');
 			});
 	},
 	'setting custom element attribute updates properties'(this: any) {
@@ -59,7 +74,7 @@ registerSuite({
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
-			.findByCssSelector('test-button > button')
+			.findById('testButton')
 			.end()
 			.execute('document.querySelector("test-button").setAttribute("label", "greetings")')
 			.then(pollUntil<any>(function () {

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -44,7 +44,7 @@ registerSuite({
 		return this.remote
 			.get((<any> require).toUrl('./support/registerCustomElement.html'))
 			.setFindTimeout(1000)
-			.findById('testButton')
+			.findByCssSelector('#testButton > button')
 			.click()
 			.end()
 			.execute('return window.buttonClicked')

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<script src="../../../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
-	<script src="../../../../../node_modules/@webcomponents/custom-elements/src/native-shim.js"></script>
-	<script src="../../../../../node_modules/@dojo/loader/loader.js"></script>
+	<script src="../../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+	<script src="../../../../node_modules/@webcomponents/custom-elements/src/native-shim.js"></script>
+	<script src="../../../../node_modules/@dojo/loader/loader.js"></script>
 </head>
 <body>
+<test-button id="testButton-2" label="world" label-suffix="hello"></test-button>
 <test-button id="testButton" label="hello" label-suffix="world"></test-button>
 
 <no-attributes id="noAttributes" label="hello" label-suffix="world"></no-attributes>
@@ -16,9 +17,9 @@
 
 	require.config({
 		packages: [
-			{ name: '@dojo', location: '../../../../../node_modules/@dojo' },
-			{ name: 'maquette', location: '../../../../../node_modules/maquette/dist', main: 'maquette' },
-			{ name: 'pepjs', location: '../../../../../node_modules/pepjs/dist', main: 'pep' }
+			{ name: '@dojo', location: '../../../../node_modules/@dojo' },
+			{ name: 'maquette', location: '../../../../node_modules/maquette/dist', main: 'maquette' },
+			{ name: 'pepjs', location: '../../../../node_modules/pepjs/dist', main: 'pep' }
 		]
 	});
 
@@ -30,6 +31,7 @@
 		});
 
 		document.getElementById('noAttributes').buttonLabel = 'Test';
+		document.getElementById('testButton-2').label = 'Worlds';
 
 		var el = document.createElement('test-button');
 		el.id = 'manualButton';


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensures that the correct instance is used when there is multiple custom elements of the same type.

Resolves #529
