### PR TITLE
Switch mixins to not require widgets to extend their properties interface

### DIFF
--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -62,10 +62,14 @@ export interface I18nMixin {
 	 * The localized messages, along with a `format` method for formatting ICU-formatted templates.
 	 */
 	localizeBundle<T extends Messages>(bundle: Bundle<T>): LocalizedMessages<T>;
+
+	properties: I18nProperties;
 }
 
-export function I18nMixin<T extends Constructor<WidgetBase<I18nProperties>>>(base: T): T & Constructor<I18nMixin> {
+export function I18nMixin<T extends Constructor<WidgetBase<any>>>(base: T): T & Constructor<I18nMixin> {
 	class I18n extends base {
+
+		public properties: I18nProperties;
 
 		constructor(...args: any[]) {
 			super(...args);

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -159,8 +159,8 @@ function setDomNodes(vnode: VNode, domNode: Element | null = null) {
 	}
 }
 
-export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T): T & Constructor<ProjectorMixin<P>> {
-	class Projector extends base {
+export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T): T & Constructor<ProjectorMixin<P>> {
+	class Projector extends Base {
 
 		public projectorState: ProjectorAttachState;
 

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -1,16 +1,16 @@
 import WidgetRegistry from '../WidgetRegistry';
 import { WidgetBase, diffProperty } from './../WidgetBase';
-import {
-	PropertyChangeRecord,
-	Constructor,
-	WidgetProperties
-} from '../interfaces';
+import { PropertyChangeRecord, Constructor } from '../interfaces';
 
-export interface RegistryMixinProperties extends WidgetProperties {
-	registry: WidgetRegistry;
+export interface RegistryMixinProperties {
+	registry?: WidgetRegistry;
 }
 
-export function RegistryMixin<T extends Constructor<WidgetBase<RegistryMixinProperties>>>(base: T): T {
+export interface RegistryMixin {
+	properties: RegistryMixinProperties;
+}
+
+export function RegistryMixin<T extends Constructor<WidgetBase<any>>>(base: T): T & Constructor<RegistryMixin> {
 	class Registry extends base {
 
 		@diffProperty('registry')

--- a/src/mixins/Stateful.ts
+++ b/src/mixins/Stateful.ts
@@ -1,5 +1,5 @@
 import { deepAssign } from '@dojo/core/lang';
-import { Constructor, WidgetProperties } from './../interfaces';
+import { Constructor } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
 
 /**
@@ -33,7 +33,7 @@ export interface StatefulMixin {
  */
 const stateChangedEventType = 'state:changed';
 
-export function StatefulMixin<T extends Constructor<WidgetBase<WidgetProperties>>>(base: T): T & Constructor<StatefulMixin> {
+export function StatefulMixin<T extends Constructor<WidgetBase<any>>>(base: T): T & Constructor<StatefulMixin> {
 	return class extends base {
 
 		private _state: State;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -74,6 +74,8 @@ export interface ThemeableMixin {
 	 * @returns a function chain to `get` or process more classes using `fixed`
 	 */
 	classes(...classNames: (string | null)[]): ClassesFunctionChain;
+
+	properties: ThemeableProperties;
 }
 
 /**
@@ -153,8 +155,10 @@ export function registerThemeInjector(theme: any, themeRegistry: WidgetRegistry 
 /**
  * Function that returns a class decorated with with Themeable functionality
  */
-export function ThemeableMixin<T extends Constructor<WidgetBase<ThemeableProperties>>>(base: T): T & Constructor<ThemeableMixin> {
+export function ThemeableMixin<T extends Constructor<WidgetBase<any>>>(base: T): T & Constructor<ThemeableMixin> {
 	class Themeable extends base {
+
+		public properties: ThemeableProperties;
 
 		/**
 		 * The Themeable baseClasses

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -53,7 +53,7 @@ class NonDecoratorDuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<T
 	}
 }
 
-let themeableInstance: TestWidget;
+let themeableInstance: any;
 let consoleStub: SinonStub;
 
 registerSuite({


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Currently it isn't possible add mixin capabilities unless an author has explicitly extended the relevant property interfaces at design time.

```ts
interface MyWidgetProperties extends WidgetProperties { }

class MyWidget extends WidgetBase<MyWidgetProperties> { }
```

As the widget's `MyWidgetProperties` doesn't extend the properties required for any mixin capabilities it means that the mixins cannot be used.

```ts
// errors as `MyWidgetProperties` does not extend `ThemeableProperties`
const MyThemeableWidget = ThemeableMixin(MyWidget); 
```

This change loosens the typings for mixins to accept `any` properties and adds an intersection to the return type to ensure that the extended widget has the correct property shape.

```ts
// An interface that defines the mixins properties
interface MyMixin {
    properties: MyMixinProperties;
}
// mixin return type
function MyMixin<T extends Constructor<WidgetBase<any>>>(Base: T):T & Constructor<MyMixin> {
    return class extends Base { }
}
```
If the `properties` need to be referenced within the mixin then the attribute will need to be added within the class typed to the mixins property interface. 

```ts
function MyMixin<T extends Constructor<WidgetBase<any>>>(Base: T):T & Constructor<MyMixin> {
    return class extends Base { 
        public readonly properties: MyMixinProperties;
        
        public myFunction() {
            const { myMixinProperty } = this.properties;
            // do other things
        }
    }
}
```
Resolves #524 