### PR TITLE
Container should assume the widgets Properties as a Partial

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -1,5 +1,5 @@
 import { WidgetBase } from './WidgetBase';
-import { Constructor, DNode, WidgetBaseInterface, RegistryLabel } from './interfaces';
+import { Constructor, DNode, WidgetBaseInterface, RegistryLabel, WidgetProperties } from './interfaces';
 import { w } from './d';
 import { defaultMappers, BaseInjector, Mappers } from './Injector';
 
@@ -7,7 +7,7 @@ export function Container<W extends WidgetBaseInterface>(
 	component: Constructor<W> | RegistryLabel,
 	name: RegistryLabel,
 	mappers: Partial<Mappers> = defaultMappers
-): Constructor<WidgetBase<W['properties']>> {
+): Constructor<WidgetBase<Partial<W['properties']> & WidgetProperties>> {
 	const {
 		getProperties = defaultMappers.getProperties,
 		getChildren = defaultMappers.getChildren

--- a/tests/unit/Container.ts
+++ b/tests/unit/Container.ts
@@ -4,7 +4,12 @@ import { v, registry } from '../../src/d';
 import { WidgetBase } from '../../src/WidgetBase';
 import { Container } from './../../src/Container';
 
-class TestWidget extends WidgetBase<any> {
+interface TestWidgetProperties {
+	foo: string;
+	boo: number;
+}
+
+class TestWidget extends WidgetBase<TestWidgetProperties> {
 	render() {
 		return v('test', this.properties);
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Change the `Container` to assume a `Partial` of the widget's properties that it is containing

Resolves #539 
