### PR TITLE
Support null and string render result from a projector

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -175,6 +175,8 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 		private _boundRender: Function;
 		private _projectorChildren: DNode[];
 		private _projectorProperties: P;
+		private _rootTagName: string;
+		private _attachType: AttachType;
 
 		constructor(...args: any[]) {
 			super(...args);
@@ -294,18 +296,45 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 			return this._projection.domNode.outerHTML;
 		}
 
-		public __render__() {
+		public __render__(): VNode {
 			if (this._projectorChildren) {
 				this.setChildren(this._projectorChildren);
 			}
 			if (this._projectorProperties) {
 				this.setProperties(this._projectorProperties);
 			}
-			const result = super.__render__();
+			let result = super.__render__();
 			if (typeof result === 'string' || result === null) {
-				throw new Error('Must provide a VNode at the root of a projector');
+				if (!this._rootTagName) {
+					this._rootTagName = 'span';
+				}
+
+				result = {
+					domNode: null,
+					vnodeSelector: this._rootTagName,
+					properties: {},
+					children: undefined,
+					text: result === null ? undefined : result
+				};
+			}
+			else if (!this._rootTagName) {
+				this._rootTagName = this._attachType === AttachType.Merge ? this._root.tagName.toLowerCase() : result.vnodeSelector;
 			}
 
+			if (this._rootTagName !== result.vnodeSelector) {
+				if (this._attachType === AttachType.Merge) {
+					assign(result, { vnodeSelector: this._rootTagName });
+				}
+				else {
+					result = {
+						domNode: null,
+						vnodeSelector: this._rootTagName,
+						properties: {},
+						children: [ result ],
+						text: undefined
+					};
+				}
+			}
 			return result;
 		}
 
@@ -333,6 +362,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 		}
 
 		private attach({ type, root }: AttachOptions): Handle {
+			this._attachType = type;
 			if (root) {
 				this.root = root;
 			}
@@ -359,6 +389,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 					this._projection = dom.append(this.root, this._boundRender(), this._projectionOptions);
 				break;
 				case AttachType.Merge:
+					this._rootTagName = this._root.tagName.toLowerCase();
 					const vnode: VNode = this._boundRender();
 					setDomNodes(vnode, this.root);
 					this._projection = dom.merge(this.root, vnode, this._projectionOptions);

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -318,7 +318,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(base: T)
 				};
 			}
 			else if (!this._rootTagName) {
-				this._rootTagName = this._attachType === AttachType.Merge ? this._root.tagName.toLowerCase() : result.vnodeSelector;
+				this._rootTagName = result.vnodeSelector;
 			}
 
 			if (this._rootTagName !== result.vnodeSelector) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for all attach types to return either `null` or `string` from a top level projector. Maquette doesn't support changing the `vnodeSelector` of the root `VNode`, so need to ensure that they remain consistent when the top level node switches between a `VNode` and `null` or `string`.

##### Merge

For `merge`, if `null` or `string` is returned from `__render__` then a `VNode` is created using the `tagName` from the `root` node, with the `vnode.text` set for `string`s. When a `VNode`s is returned as the top level node, the `vnodeSelector` is set to the `root`s `tagName`.

Assuming a `root` node of `my-app`:

* Returning `null` will render `<my-app></my-app>`
* Returning `string` will render `<my-app>string</my-app>`
* Returning `VNode` will render `<my-app>...</my-app>`

##### Append & Replace

For `append` and `replace` it is not possible to know the correct `tagName` therefore a wrapper `VNode` is created with a `vnodeSelector` of `span`. If the `VNode` is returned for the first `render` then the actual `tagName` is stored and used if subsequent `__render__`s return `string` or `null`.

Assuming a `root` node of `my-app` & first render being `null` or `string`:

* Returning `null` will render `<span></span>`
* Returning `string` will render `<span>string</span>`
* Returning `VNode` (div) will render `<span><div>...</div></span>`

Assuming a `root` node of `my-app` & first render being `VNode` with a `vnodeSelector` of `div`:

* Returning `null` will render `<div></div>`
* Returning `string` will render `<div>string</div>`
* Returning `VNode` will render `<div>...</div>`

Resolves #532