### PR TITLE
Remove bind when spreading properties in DomWrapper

### DIFF
--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -22,7 +22,8 @@ export function DomWrapper(domNode: Element): Constructor<WidgetBase<VirtualDomP
 		}
 
 		protected render() {
-			const properties = this._firstRender ? {} : this.properties;
+			const properties = this._firstRender ? {} as any : this.properties;
+			properties.bind && delete properties.bind;
 			return v(domNode.tagName, { ...properties, key: 'root' });
 		}
 	};

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import { WidgetBase } from './../../../src/WidgetBase';
-import { w } from './../../../src/d';
+import { v, w } from './../../../src/d';
 import { DomWrapper } from '../../../src/util/DomWrapper';
 import global from '@dojo/core/global';
 import { stub } from 'sinon';
@@ -35,7 +35,9 @@ registerSuite({
 		const DomNode = DomWrapper(domNode);
 		class Foo extends WidgetBase {
 			render() {
-				return w(DomNode, { id: 'foo', extra: { foo: 'bar' } });
+				return v('div', [
+					w(DomNode, { id: 'foo', extra: { foo: 'bar' } })
+				]);
 			}
 		}
 		const Projector = ProjectorMixin(Foo);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Because `bind` is automagically passed via props (see: https://github.com/dojo/widget-core/issues/544), and i'm returning an empty object on the first render, this can cause maquette to not track the children correctly. To be safe always delete `bind` if it exists when passing to `v`.
