### PR TITLE
Simplify DomWrapper  

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "~2.3.2"
   },
   "dependencies": {
-    "maquette": "~2.5.0",
+    "maquette": "~2.5.1",
     "pepjs": "^0.4.2"
   }
 }

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -7,29 +7,26 @@ export interface DomWrapperOptions {
 	onAttached?(): void;
 }
 
-export type DomWrapper = Constructor<WidgetBase<VirtualDomProperties & WidgetProperties>>;
+export type DomWrapperProperties = VirtualDomProperties & WidgetProperties;
+
+export type DomWrapper = Constructor<WidgetBase<DomWrapperProperties>>;
 
 export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): DomWrapper {
-	return class extends WidgetBase<VirtualDomProperties & WidgetProperties> {
-		private _vNode: VNode;
-		private _firstRender = true;
+	return class extends WidgetBase<DomWrapperProperties> {
 
 		protected onElementCreated(element: Element, key: string) {
-			element.parentNode && element.parentNode.replaceChild(domNode, element);
-			this._vNode.domNode = domNode;
-			this._firstRender = false;
 			options.onAttached && options.onAttached();
-			this.invalidate();
 		}
 
 		public __render__() {
-			this._vNode = super.__render__() as VNode;
-			return this._vNode;
+			const vNode = super.__render__() as VNode;
+			vNode.domNode = domNode;
+			return vNode;
 		}
 
 		protected render() {
-			const properties = this._firstRender ? {} as any : this.properties;
-			properties.bind && delete properties.bind;
+			const properties: any = this.properties;
+			delete properties.bind;
 			return v(domNode.tagName, { ...properties, key: 'root' });
 		}
 	};

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -25,9 +25,9 @@ export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): D
 		}
 
 		protected render() {
-			const properties: any = this.properties;
+			const properties = { ...this.properties, key: 'root' };
 			delete properties.bind;
-			return v(domNode.tagName, { ...properties, key: 'root' });
+			return v(domNode.tagName, properties);
 		}
 	};
 }

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -89,7 +89,7 @@ registerSuite({
 			render() {
 				return w(DomNode, {
 					styles: {
-						background: 'red'
+						color: 'red'
 					},
 					classes: this.classes(myTheme.class1)
 				});
@@ -100,7 +100,7 @@ registerSuite({
 		projector.append(root);
 		resolveRAF();
 		assert.isTrue(domNode.classList.contains('classFoo'));
-		assert.equal(domNode.style.background, 'red');
+		assert.equal(domNode.style.color, 'red');
 	},
 	'onAttached'() {
 		let attached = false;

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -6,6 +6,7 @@ import global from '@dojo/core/global';
 import { stub } from 'sinon';
 import * as assert from 'intern/chai!assert';
 import ProjectorMixin from '../../../src/mixins/Projector';
+import { ThemeableMixin, theme } from '../../../src/mixins/Themeable';
 
 let rAF: any;
 let projector: any;
@@ -51,8 +52,56 @@ registerSuite({
 		assert.equal(domNode.getAttribute('original'), 'woop');
 		assert.equal(domNode.getAttribute('id'), 'foo');
 		assert.deepEqual(domNode.extra, { foo: 'bar' });
-	},
 
+	},
+	'supports events'() {
+		const domNode: any = document.createElement('custom-element');
+		const root = document.createElement('div');
+		let clicked = false;
+
+		const DomNode = DomWrapper(domNode);
+		class Foo extends WidgetBase {
+			_onClick() {
+				clicked = true;
+			}
+			render() {
+				return w(DomNode, { onclick: this._onClick });
+			}
+		}
+		const Projector = ProjectorMixin(Foo);
+		projector = new Projector();
+		projector.append(root);
+		resolveRAF();
+		domNode.click();
+		assert.isTrue(clicked);
+	},
+	'supports classes and styles'() {
+		const domNode: any = document.createElement('custom-element');
+		const root = document.createElement('div');
+
+		const DomNode = DomWrapper(domNode);
+		const myTheme = {
+			class1: 'classFoo'
+		};
+
+		@theme(myTheme)
+		class Foo extends ThemeableMixin(WidgetBase) {
+			render() {
+				return w(DomNode, {
+					styles: {
+						background: 'red'
+					},
+					classes: this.classes(myTheme.class1)
+				});
+			}
+		}
+		const Projector = ProjectorMixin(Foo);
+		projector = new Projector();
+		projector.append(root);
+		resolveRAF();
+		assert.isTrue(domNode.classList.contains('classFoo'));
+		assert.equal(domNode.style.background, 'red');
+	},
 	'onAttached'() {
 		let attached = false;
 		const domNode: any = document.createElement('custom-element');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Thanks to maquette (https://github.com/AFASSoftware/maquette/pull/103), we no longer need to do any dom replacement hacks in `DomWrapper`, this also has the nice side effect of resolving https://github.com/dojo/widget-core/issues/553. I have also added some supporting test cases. 

Resolves #553 
