### PR TITLE
Support an array of `DNode`s from `render`

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -411,9 +411,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 			afterRenders.forEach((afterRenderFunction: Function) => {
 				dNode = afterRenderFunction.call(this, dNode);
 			});
-
 			const widget = this.dNodeToVNode(dNode);
-
 			this.manageDetachedChildren();
 			if (widget) {
 				this._cachedVNode = widget;
@@ -551,6 +549,8 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 	 * @param dNode the dnode to process
 	 * @returns a VNode, string or null
 	 */
+	private dNodeToVNode(dNode: DNode): VNode | string | null;
+	private dNodeToVNode(dNode: DNode[]): (VNode | string | null)[];
 	private dNodeToVNode(dNode: DNode | DNode[]): (VNode | string | null)[] | VNode | string | null {
 
 		if (typeof dNode === 'string' || dNode === null) {
@@ -558,9 +558,7 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 		}
 
 		if (Array.isArray(dNode)) {
-			return dNode.map((node) => {
-				return this.dNodeToVNode(node) as VNode | string | null;
-			});
+			return dNode.map((node) => this.dNodeToVNode(node));
 		}
 
 		if (isWNode(dNode)) {

--- a/src/d.ts
+++ b/src/d.ts
@@ -48,6 +48,7 @@ export function isHNode(child: DNode): child is HNode {
  */
 export function decorate(dNodes: DNode, modifier: (dNode: DNode) => void, predicate?: (dNode: DNode) => boolean): DNode;
 export function decorate(dNodes: DNode[], modifier: (dNode: DNode) => void, predicate?: (dNode: DNode) => boolean): DNode[];
+export function decorate(dNodes: DNode | DNode[], modifier: (dNode: DNode) => void, predicate?: (dNode: DNode) => boolean): DNode | DNode[];
 export function decorate(dNodes: DNode | DNode[], modifier: (dNode: DNode) => void, predicate?: (dNode: DNode) => boolean): DNode | DNode[] {
 	let nodes = Array.isArray(dNodes) ? [ ...dNodes ] : [ dNodes ];
 	while (nodes.length) {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -232,7 +232,7 @@ export interface HNode {
 	/**
 	 * Array of processed VNode children.
 	 */
-	vNodes?: (string | VNode | null)[];
+	vNodes?: ((string | VNode | null)[] |string | VNode | null)[];
 	/**
 	 * Specified children
 	 */
@@ -367,7 +367,7 @@ export interface WidgetBaseInterface<
 	/**
 	 * Main internal function for dealing with widget rendering
 	 */
-	__render__(): VNode | string | null;
+	__render__(): (VNode | string)[] | VNode | string | null;
 
 	/**
 	 * invalidate the widget

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -367,7 +367,7 @@ export interface WidgetBaseInterface<
 	/**
 	 * Main internal function for dealing with widget rendering
 	 */
-	__render__(): (VNode | string)[] | VNode | string | null;
+	__render__(): (VNode | string | null)[] | VNode | string | null;
 
 	/**
 	 * invalidate the widget

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -305,25 +305,12 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			}
 			let result = super.__render__();
 
-			if (Array.isArray(result)) {
+			if (Array.isArray(result) || typeof result === 'string' || result === null) {
 				if (!this._rootTagName) {
 					this._rootTagName = 'span';
 				}
 
-				return h(this._rootTagName, {}, result);
-			}
-			else if (typeof result === 'string' || result === null) {
-				if (!this._rootTagName) {
-					this._rootTagName = 'span';
-				}
-
-				result = {
-					domNode: null,
-					vnodeSelector: this._rootTagName,
-					properties: {},
-					children: undefined,
-					text: result === null ? undefined : result
-				};
+				result = h(this._rootTagName, {}, result);
 			}
 			else if (!this._rootTagName) {
 				this._rootTagName = result.vnodeSelector;
@@ -334,13 +321,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 					assign(result, { vnodeSelector: this._rootTagName });
 				}
 				else {
-					result = {
-						domNode: null,
-						vnodeSelector: this._rootTagName,
-						properties: {},
-						children: [ result ],
-						text: undefined
-					};
+					result = h(this._rootTagName, {}, result);
 				}
 			}
 			return result;

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -296,6 +296,27 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			return this._projection.domNode.outerHTML;
 		}
 
+		private parseArrayResult(nodes: (string | VNode | null)[]): VNode[] {
+			return nodes.reduce((parsedNodes, node) => {
+				if (node === null) {
+					return parsedNodes;
+				}
+				if (typeof node === 'string') {
+					parsedNodes.push({
+						domNode: null,
+						vnodeSelector: '',
+						properties: {},
+						children: undefined,
+						text: node
+					});
+				}
+				else {
+					parsedNodes.push(node);
+				}
+				return parsedNodes;
+			}, [] as VNode[]);
+		}
+
 		public __render__(): VNode {
 			if (this._projectorChildren) {
 				this.setChildren(this._projectorChildren);
@@ -304,7 +325,21 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 				this.setProperties(this._projectorProperties);
 			}
 			let result = super.__render__();
-			if (typeof result === 'string' || result === null) {
+
+			if (Array.isArray(result)) {
+				if (!this._rootTagName) {
+					this._rootTagName = 'span';
+				}
+
+				return {
+					domNode: null,
+					vnodeSelector: this._rootTagName,
+					properties: {},
+					children: this.parseArrayResult(result),
+					text: undefined
+				};
+			}
+			else if (typeof result === 'string' || result === null) {
 				if (!this._rootTagName) {
 					this._rootTagName = 'span';
 				}

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -3,7 +3,7 @@ import global from '@dojo/core/global';
 import { createHandle } from '@dojo/core/lang';
 import { Handle } from '@dojo/interfaces/core';
 import { VNode } from '@dojo/interfaces/vdom';
-import { dom, Projection, ProjectionOptions, VNodeProperties } from 'maquette';
+import { h, dom, Projection, ProjectionOptions, VNodeProperties } from 'maquette';
 import 'pepjs';
 import cssTransitions from '../animations/cssTransitions';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';
@@ -296,27 +296,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			return this._projection.domNode.outerHTML;
 		}
 
-		private parseArrayResult(nodes: (string | VNode | null)[]): VNode[] {
-			return nodes.reduce((parsedNodes, node) => {
-				if (node === null) {
-					return parsedNodes;
-				}
-				if (typeof node === 'string') {
-					parsedNodes.push({
-						domNode: null,
-						vnodeSelector: '',
-						properties: {},
-						children: undefined,
-						text: node
-					});
-				}
-				else {
-					parsedNodes.push(node);
-				}
-				return parsedNodes;
-			}, [] as VNode[]);
-		}
-
 		public __render__(): VNode {
 			if (this._projectorChildren) {
 				this.setChildren(this._projectorChildren);
@@ -331,13 +310,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 					this._rootTagName = 'span';
 				}
 
-				return {
-					domNode: null,
-					vnodeSelector: this._rootTagName,
-					properties: {},
-					children: this.parseArrayResult(result),
-					text: undefined
-				};
+				return h(this._rootTagName, {}, result);
 			}
 			else if (typeof result === 'string' || result === null) {
 				if (!this._rootTagName) {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -975,6 +975,31 @@ widget.__setProperties__({
 			assert.isUndefined(result.children);
 			assert.equal(result.text, 'I am a text node');
 		},
+		'render returns array'() {
+			class TestChildWidget extends WidgetBase {
+				render() {
+					return [
+						v('div', [ 'text' ]),
+						v('span', { key: 'span' })
+					];
+				}
+			}
+
+			class TestWidget extends WidgetBase {
+				render() {
+					return v('div', [ w(TestChildWidget, {}) ]);
+				}
+			}
+
+			const widget = new TestWidget();
+			const result: any = widget.__render__();
+			assert.strictEqual(result.vnodeSelector, 'div');
+			assert.lengthOf(result.children, 2);
+			assert.strictEqual(result.children![0].vnodeSelector, 'div');
+			assert.strictEqual(result.children![0].text, 'text');
+			assert.strictEqual(result.children![1].vnodeSelector, 'span');
+			assert.strictEqual(result.children![1].properties.key, 'span');
+		},
 		'instance gets passed to VNodeProperties as bind to widget and all children'() {
 			class TestWidget extends WidgetBase<any> {
 				render() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -149,6 +149,17 @@ registerSuite({
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
 				assert.lengthOf(vnode.children, 0);
+			},
+			'array root node'() {
+				result = [ v('h2', [ 'my string' ]) ];
+				projector = new MyWidget();
+
+				projector.append();
+				let vnode: any = projector.__render__() as VNode;
+				assert.equal(vnode.vnodeSelector, 'span');
+				assert.lengthOf(vnode.children, 1);
+				assert.strictEqual(vnode.children[0].vnodeSelector, 'h2');
+				assert.strictEqual(vnode.children[0].text, 'my string');
 			}
 		},
 		'sandbox': {
@@ -293,6 +304,19 @@ registerSuite({
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
 				assert.lengthOf(vnode.children, 0);
+			},
+			'array root node'() {
+				const root = document.createElement('my-app');
+				document.body.appendChild(root);
+				result = [ v('h2', [ 'my string' ]) ];
+				projector = new MyWidget();
+
+				projector.replace(root);
+				let vnode: any = projector.__render__() as VNode;
+				assert.equal(vnode.vnodeSelector, 'span');
+				assert.lengthOf(vnode.children, 1);
+				assert.strictEqual(vnode.children[0].vnodeSelector, 'h2');
+				assert.strictEqual(vnode.children[0].text, 'my string');
 			}
 		},
 		'merge': {
@@ -385,6 +409,19 @@ registerSuite({
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.isUndefined(vnode.text);
 				assert.lengthOf(vnode.children, 0);
+			},
+			'array root node'() {
+				const root = document.createElement('my-app');
+				document.body.appendChild(root);
+				result = [ v('h2', [ 'my string' ]) ];
+				projector = new MyWidget();
+
+				projector.merge(root);
+				let vnode: any = projector.__render__() as VNode;
+				assert.equal(vnode.vnodeSelector, 'my-app');
+				assert.lengthOf(vnode.children, 1);
+				assert.strictEqual(vnode.children[0].vnodeSelector, 'h2');
+				assert.strictEqual(vnode.children[0].text, 'my string');
 			},
 			'pre rendered DOM used'() {
 				const iframe = document.createElement('iframe');

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -121,7 +121,7 @@ registerSuite({
 				let vnode: VNode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
-				assert.isUndefined(vnode.children);
+				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
 				projector.invalidate();
@@ -148,7 +148,7 @@ registerSuite({
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
-				assert.isUndefined(vnode.children);
+				assert.lengthOf(vnode.children, 0);
 			}
 		},
 		'sandbox': {
@@ -263,7 +263,7 @@ registerSuite({
 				let vnode: VNode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
-				assert.isUndefined(vnode.children);
+				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
 				projector.invalidate();
@@ -292,7 +292,7 @@ registerSuite({
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
-				assert.isUndefined(vnode.children);
+				assert.lengthOf(vnode.children, 0);
 			}
 		},
 		'merge': {
@@ -358,7 +358,7 @@ registerSuite({
 				let vnode: VNode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.isUndefined(vnode.text);
-				assert.isUndefined(vnode.children);
+				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
 				projector.invalidate();
@@ -384,7 +384,7 @@ registerSuite({
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.isUndefined(vnode.text);
-				assert.isUndefined(vnode.children);
+				assert.lengthOf(vnode.children, 0);
 			},
 			'pre rendered DOM used'() {
 				const iframe = document.createElement('iframe');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support to return an array of `DNode`s from a widget `render`, widgets used as a projector that return an array of nodes from the render will be automatically wrapped in a `span` (append and replace) or the tag name of the root DOM Element (merge).

Example Usage:

```ts
class MyListWidget extends WidgetBase {
    protected render(): DNode[] {
        return [
            v('li', { key: '1' }, [ 'Item One' ]),
            v('li', { key: '2' }, [ 'Item Two' ]),
            v('li', { key: '3' }, [ 'Item Three' ]),
            v('li', { key: '4' }, [ 'Item Four' ]),
            v('li', { key: '5' }, [ 'Item Five' ]),
            v('li', { key: '6' }, [ 'Item Six' ]),
            v('li', { key: '7' }, [ 'Item Seven' ])
        ];
    }
}
```
Resolves #533 
