### PR TITLE
remove 'bind' from public consumer properties

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -20,7 +20,7 @@ export function Container<W extends WidgetBaseInterface>(
 			const { properties, children } = this;
 
 			return w<BaseInjector<any>>(name, {
-				bind: this,
+				scope: this,
 				render: () => w(component, properties, children),
 				getProperties,
 				properties,

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -61,7 +61,7 @@ export class Context<T = any> extends Evented {
 }
 
 export interface InjectorProperties extends WidgetProperties {
-	bind: any;
+	scope: any;
 	render(): DNode;
 	getProperties?: GetProperties;
 	properties: WidgetProperties;
@@ -101,10 +101,10 @@ export function Injector<C extends Evented, T extends Constructor<BaseInjector<C
 
 		@afterRender()
 		protected decoratateBind(node: DNode) {
-			const { bind } = this.properties;
+			const { scope } = this.properties;
 			decorate(node, (node: InternalHNode | InternalWNode) => {
 				const { properties } = node;
-				properties.bind = bind;
+				properties.bind = scope;
 			}, (node: DNode) => { return isHNode(node) || isWNode(node); });
 
 			return node;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -309,12 +309,13 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 		return this._properties;
 	}
 
-	public __setProperties__(properties: P): void {
+	public __setProperties__(originalProperties: P): void {
+		const { bind, ...properties } = <any> originalProperties;
 		this._renderState = WidgetRenderState.PROPERTIES;
 		const diffPropertyResults: { [index: string]: any } = {};
 		const diffPropertyChangedKeys: string[] = [];
 
-		this.bindFunctionProperties(properties);
+		this.bindFunctionProperties(properties, bind);
 
 		const registeredDiffPropertyConfigs: DiffPropertyConfig[] = this.getDecorator('diffProperty');
 
@@ -521,10 +522,9 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 	 *
 	 * @param properties properties to check for functions
 	 */
-	private bindFunctionProperties(properties: P & { [index: string]: any }): void {
+	private bindFunctionProperties(properties: any, bind: any): void {
 		Object.keys(properties).forEach((propertyKey) => {
 			const property = properties[propertyKey];
-			const bind = properties.bind;
 
 			if (typeof property === 'function' && !isWidgetBaseConstructor(property)) {
 				const bindInfo = this._bindFunctionPropertyMap.get(property) || {};

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -232,7 +232,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<any>>>(base: T):
 				const hasInjectedTheme = this.registries.has(INJECTED_THEME_KEY);
 				if (hasInjectedTheme) {
 					return w<BaseInjector>(INJECTED_THEME_KEY, {
-						bind: this,
+						scope: this,
 						render: renderFunc,
 						getProperties: (inject: Context, properties: ThemeableProperties): ThemeableProperties => {
 							if (!properties.theme && this._theme !== properties.injectedTheme) {

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -26,7 +26,6 @@ export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): D
 
 		protected render() {
 			const properties = { ...this.properties, key: 'root' };
-			delete properties.bind;
 			return v(domNode.tagName, properties);
 		}
 	};

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -48,7 +48,7 @@ registerSuite({
 		const injector = new InjectorWidget();
 		injector.__setProperties__({
 			render,
-			bind,
+			scope: bind,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
 				assert.deepEqual(inject, context);
@@ -85,7 +85,7 @@ registerSuite({
 
 		const injector = new InjectorWidget();
 		injector.__setProperties__({
-			bind: context,
+			scope: context,
 			render,
 			properties: testProperties,
 			children: testChildren
@@ -110,7 +110,7 @@ registerSuite({
 
 		const injector = new InjectorWidget();
 		injector.__setProperties__({
-			bind,
+			scope: bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
@@ -145,7 +145,7 @@ registerSuite({
 
 		const injector = new InjectorWidget();
 		injector.__setProperties__({
-			bind,
+			scope: bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
@@ -183,7 +183,7 @@ registerSuite({
 
 		const injector = new InjectorWidget();
 		injector.__setProperties__({
-			bind,
+			scope: bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
@@ -214,7 +214,7 @@ registerSuite({
 
 		const injector = new InjectorWidget();
 		injector.__setProperties__({
-			bind,
+			scope: bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: any, properties: any): any => {
@@ -247,7 +247,7 @@ registerSuite({
 		};
 		const InjectorWidget = Injector(TestInjector, new Context());
 		const properties = {
-			bind,
+			scope: bind,
 			render,
 			properties: testProperties,
 			getProperties: (inject: Context, properties: any): any => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

`bind` is a special internal property that gets decorated onto nodes return from `render`, this should not be available for consumers from `this.properties` - `bind` is not on the API but if the properties are spread then `bind` will get passed on without the consumer knowing.

`bind` is now removed from widget properties as part of the `__setProperties__` process and only used to bind functions that are passed in the `properties` object.

Renamed the `Injector` property `bind` to `scope` as this is public so we do want all the standard `__setProperties__` processing.

Resolves #544
