### PR TITLE
Add deprecation warning for onElementCreated and onElementUpdated usage

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -237,6 +237,8 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 				propertiesChangedFunction.call(this, evt);
 			});
 		}));
+
+		this._checkOnElementUsage();
 	}
 
 	/**
@@ -636,6 +638,16 @@ export class WidgetBase<P extends WidgetProperties = WidgetProperties, C extends
 			});
 			this._cachedChildrenMap.set(key, filterCachedChildren);
 		});
+	}
+
+	private _checkOnElementUsage() {
+		const name = (<any> this).constructor.name || 'unknown';
+		if (this.onElementCreated !== WidgetBase.prototype.onElementCreated) {
+			console.warn(`Usage of 'onElementedCreated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`);
+		}
+		if (this.onElementUpdated !== WidgetBase.prototype.onElementUpdated) {
+			console.warn(`Usage of 'onElementUpdated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`);
+		}
 	}
 }
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -34,6 +34,24 @@ registerSuite({
 		assert.isFunction(widgetBase.__render__);
 		assert.isFunction(widgetBase.invalidate);
 	},
+	'deprecated api warning'() {
+		class TestWidgetOne extends WidgetBase<any> {
+			onElementUpdated(element: Element, key: string) {
+
+			}
+			onElementCreated(element: Element, key: string) {
+
+			}
+		}
+		class TestWidgetTwo extends WidgetBase<any> {}
+
+		const name = (<any> TestWidgetOne).name || 'unknown';
+		new TestWidgetOne();
+		new TestWidgetTwo();
+		assert.isTrue(consoleStub.calledTwice);
+		assert.isTrue(consoleStub.firstCall.calledWith(`Usage of 'onElementedCreated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`));
+		assert.isTrue(consoleStub.secondCall.calledWith(`Usage of 'onElementUpdated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`));
+	},
 	children() {
 		let childrenEventEmitted = false;
 		const expectedChild = v('div');


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

In preparation for removing DOM access for nodes created and managed through the Dojo 2 widget system have added deprecation warnings for `onElementUpdated` and `onElementCreated` usage.

Part of #559

Resolves #557 
