### PR TITLE
Breakout eventHandlerInterceptor and don't pass through touch events.

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -3,11 +3,12 @@ import global from '@dojo/core/global';
 import { createHandle } from '@dojo/core/lang';
 import { Handle } from '@dojo/interfaces/core';
 import { VNode } from '@dojo/interfaces/vdom';
-import { h, dom, Projection, ProjectionOptions, VNodeProperties } from 'maquette';
+import { h, dom, Projection, ProjectionOptions } from 'maquette';
 import 'pepjs';
 import cssTransitions from '../animations/cssTransitions';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
+import eventHandlerInterceptor from '../util/eventHandlerInterceptor';
 
 /**
  * Represents the attach state of the projector
@@ -116,33 +117,6 @@ export interface ProjectorMixin<P extends WidgetProperties> {
 	readonly projectorState: ProjectorAttachState;
 }
 
-const eventHandlers = [
-	'ontouchcancel',
-	'ontouchend',
-	'ontouchmove',
-	'ontouchstart',
-	'onblur',
-	'onchange',
-	'onclick',
-	'ondblclick',
-	'onfocus',
-	'oninput',
-	'onkeydown',
-	'onkeypress',
-	'onkeyup',
-	'onload',
-	'onmousedown',
-	'onmouseenter',
-	'onmouseleave',
-	'onmousemove',
-	'onmouseout',
-	'onmouseover',
-	'onmouseup',
-	'onmousewheel',
-	'onscroll',
-	'onsubmit'
-];
-
 /**
  * Internal function that maps existing DOM Elements to virtual DOM nodes.
  *
@@ -183,7 +157,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this._projectionOptions = {
 				transitions: cssTransitions,
-				eventHandlerInterceptor: this.eventHandlerInterceptor.bind(this)
+				eventHandlerInterceptor: eventHandlerInterceptor.bind(this)
 			};
 
 			this._boundDoRender = this.doRender.bind(this);
@@ -325,21 +299,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 				}
 			}
 			return result;
-		}
-
-		private eventHandlerInterceptor(propertyName: string, eventHandler: Function, domNode: Element, properties: VNodeProperties) {
-			if (eventHandlers.indexOf(propertyName) > -1) {
-				return function(this: Node, ...args: any[]) {
-					return eventHandler.apply(properties.bind || this, args);
-				};
-			}
-			else {
-				// remove "on" from event name
-				const eventName = propertyName.substr(2);
-				domNode.addEventListener(eventName, (...args: any[]) => {
-					eventHandler.apply(properties.bind || this, args);
-				});
-			}
 		}
 
 		private doRender() {

--- a/src/util/eventHandlerInterceptor.ts
+++ b/src/util/eventHandlerInterceptor.ts
@@ -1,0 +1,41 @@
+import { includes } from '@dojo/shim/array';
+import { VNodeProperties } from 'maquette';
+import Projector from '../mixins/Projector';
+
+export const eventHandlers = [
+	'onblur',
+	'onchange',
+	'onclick',
+	'ondblclick',
+	'onfocus',
+	'oninput',
+	'onkeydown',
+	'onkeypress',
+	'onkeyup',
+	'onload',
+	'onmousedown',
+	'onmouseenter',
+	'onmouseleave',
+	'onmousemove',
+	'onmouseout',
+	'onmouseover',
+	'onmouseup',
+	'onmousewheel',
+	'onscroll',
+	'onsubmit'
+];
+
+export default function eventHandlerInterceptor(this: Projector<any>, propertyName: string, eventHandler: Function, domNode: Element, properties: VNodeProperties) {
+	if (includes(eventHandlers, propertyName)) {
+		return function(this: Node, ...args: any[]) {
+			return eventHandler.apply(properties.bind || this, args);
+		};
+	}
+	else {
+		// remove "on" from event name
+		const eventName = propertyName.substr(2);
+		domNode.addEventListener(eventName, (...args: any[]) => {
+			eventHandler.apply(properties.bind || this, args);
+		});
+	}
+}

--- a/tests/unit/util/all.ts
+++ b/tests/unit/util/all.ts
@@ -1,1 +1,2 @@
 import './DomWrapper';
+import './eventHandlerInterceptor';

--- a/tests/unit/util/eventHandlerInterceptor.ts
+++ b/tests/unit/util/eventHandlerInterceptor.ts
@@ -1,0 +1,115 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { stub } from 'sinon';
+import eventHandlerInterceptor from '../../../src/util/eventHandlerInterceptor';
+
+registerSuite({
+	name: 'util/eventHandlerInterceptor',
+
+	'event is passed through with bind'() {
+		const addEventListener = stub();
+		const mockDomNode: Element = {
+			addEventListener
+		} as any;
+		const listener = stub();
+		const context = {};
+		const bind = {};
+		const result = eventHandlerInterceptor.call(context, 'onscroll', listener, mockDomNode, { bind });
+		assert.isFunction(result);
+		assert.isTrue(addEventListener.notCalled, 'addEventListener should not have been called');
+		assert.isTrue(listener.notCalled, 'listener should not have been called');
+		result('foo');
+		assert.isTrue(listener.calledOnce);
+		assert.deepEqual(listener.lastCall.args, [ 'foo' ], 'should have been called with proper arguments');
+		assert.strictEqual(listener.lastCall.thisValue, bind, 'should have been called with proper bind');
+	},
+
+	'event is passed through without bind'() {
+		const addEventListener = stub();
+		const mockDomNode: Element = {
+			addEventListener
+		} as any;
+		const listener = stub();
+		const context = {};
+		const result = eventHandlerInterceptor.call(undefined, 'onscroll', listener, mockDomNode, { });
+		assert.isFunction(result);
+		assert.isTrue(addEventListener.notCalled, 'addEventListener should not have been called');
+		assert.isTrue(listener.notCalled, 'listener should not have been called');
+		result.call(context, 'foo');
+		assert.isTrue(listener.calledOnce);
+		assert.deepEqual(listener.lastCall.args, [ 'foo' ], 'should have been called with proper arguments');
+		assert.strictEqual(listener.lastCall.thisValue, context, 'should have been called with proper context');
+	},
+
+	'event is installed with bind'() {
+		const addEventListener = stub();
+		const mockDomNode: Element = {
+			addEventListener
+		} as any;
+		const listener = stub();
+		const context = {};
+		const bind = {};
+		const result = eventHandlerInterceptor.call(context, 'ontouchstart', listener, mockDomNode, { bind });
+		assert.isUndefined(result);
+		assert.isTrue(listener.notCalled, 'listener should not have been called');
+		assert.isTrue(addEventListener.calledOnce, 'addEventListener should not have been called once');
+		assert.strictEqual(addEventListener.lastCall.args[0], 'touchstart', 'should have called with proper event type');
+		assert.isFunction(addEventListener.lastCall.args[1], 'should have passed a handler');
+		const handler: (...args: any[]) => void = addEventListener.lastCall.args[1];
+		handler('foo');
+		assert.isTrue(listener.calledOnce);
+		assert.deepEqual(listener.lastCall.args, [ 'foo' ], 'should have been called with proper arguments');
+		assert.strictEqual(listener.lastCall.thisValue, bind, 'should have been called with proper context');
+	},
+
+	'event is installed without bind'() {
+		const addEventListener = stub();
+		const mockDomNode: Element = {
+			addEventListener
+		} as any;
+		const listener = stub();
+		const context = {};
+		const result = eventHandlerInterceptor.call(context, 'ontouchstart', listener, mockDomNode, { });
+		assert.isUndefined(result);
+		assert.isTrue(listener.notCalled, 'listener should not have been called');
+		assert.isTrue(addEventListener.calledOnce, 'addEventListener should not have been called once');
+		assert.strictEqual(addEventListener.lastCall.args[0], 'touchstart', 'should have called with proper event type');
+		assert.isFunction(addEventListener.lastCall.args[1], 'should have passed a handler');
+		const handler: (...args: any[]) => void = addEventListener.lastCall.args[1];
+		handler('foo');
+		assert.isTrue(listener.calledOnce);
+		assert.deepEqual(listener.lastCall.args, [ 'foo' ], 'should have been called with proper arguments');
+		assert.strictEqual(listener.lastCall.thisValue, context, 'should have been called with proper context');
+	},
+
+	'passed through events'() {
+		const eventHandlers = [
+			'onblur',
+			'onchange',
+			'onclick',
+			'ondblclick',
+			'onfocus',
+			'oninput',
+			'onkeydown',
+			'onkeypress',
+			'onkeyup',
+			'onload',
+			'onmousedown',
+			'onmouseenter',
+			'onmouseleave',
+			'onmousemove',
+			'onmouseout',
+			'onmouseover',
+			'onmouseup',
+			'onmousewheel',
+			'onscroll',
+			'onsubmit'
+		];
+		eventHandlers.forEach((eventType) => {
+			const mockDomNode: Element = { } as any;
+			const listener = () => { };
+			const context = {};
+			assert.isFunction(eventHandlerInterceptor.call(context, 'onscroll', listener, mockDomNode, { }), 'should pass through handler');
+		});
+	}
+});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR breaks out `eventHandlerInterceptor` (see #445) and removes the touch events from the list of events that are passed through to maquette, and instead installs the listeners/handlers via the `.addEventListener` on the target DOM element directly.

Resolves #445
Resolves #563 
