### PR TITLE
Support generics on the registry

### DIFF
--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,5 +1,5 @@
 import { Evented } from '@dojo/core/Evented';
-import { WidgetBaseConstructor, RegistryLabel } from './interfaces';
+import { Constructor, RegistryLabel, WidgetBaseInterface } from './interfaces';
 import WidgetRegistry, { WidgetRegistryEventObject } from './WidgetRegistry';
 
 export default class RegistryHandler extends Evented {
@@ -37,10 +37,10 @@ export default class RegistryHandler extends Evented {
 		});
 	}
 
-	get(widgetLabel: RegistryLabel): WidgetBaseConstructor | null {
+	get<T extends WidgetBaseInterface = WidgetBaseInterface>(widgetLabel: RegistryLabel): Constructor<T> | null {
 		for (let i = 0; i < this._registries.length; i++) {
 			const registryWrapper = this._registries[i];
-			const item = registryWrapper.registry.get(widgetLabel);
+			const item = registryWrapper.registry.get<T>(widgetLabel);
 			if (item) {
 				return item;
 			}

--- a/src/WidgetRegistry.ts
+++ b/src/WidgetRegistry.ts
@@ -3,7 +3,7 @@ import Map from '@dojo/shim/Map';
 import Symbol from '@dojo/shim/Symbol';
 import { Handle } from '@dojo/interfaces/core';
 import Evented, { EventObject, BaseEventedEvents } from '@dojo/core/Evented';
-import { WidgetBaseConstructor, RegistryLabel } from './interfaces';
+import { WidgetBaseConstructor, WidgetBaseInterface, Constructor, RegistryLabel } from './interfaces';
 
 export type WidgetBaseConstructorFunction = () => Promise<WidgetBaseConstructor>;
 
@@ -45,7 +45,7 @@ export interface WidgetRegistry {
 	 * @param widgetLabel The label of the widget to return
 	 * @returns The WidgetRegistryItem for the widgetLabel, `null` if no entry exists
 	 */
-	get(widgetLabel: RegistryLabel): WidgetBaseConstructor | null;
+	get<T extends WidgetBaseInterface = WidgetBaseInterface>(widgetLabel: RegistryLabel): Constructor<T> | null;
 
 	/**
 	 * Returns a boolean if an entry for the label exists
@@ -62,7 +62,7 @@ export interface WidgetRegistry {
  * @param item the item to check
  * @returns true/false indicating if the item is a WidgetBaseConstructor
  */
-export function isWidgetBaseConstructor(item: any): item is WidgetBaseConstructor {
+export function isWidgetBaseConstructor<T extends WidgetBaseInterface>(item: any): item is Constructor<T> {
 	return Boolean(item && item._type === WIDGET_BASE_TYPE);
 }
 
@@ -113,14 +113,14 @@ export class WidgetRegistry extends Evented implements WidgetRegistry {
 		}
 	}
 
-	get(widgetLabel: RegistryLabel): WidgetBaseConstructor | null {
+	get<T extends WidgetBaseInterface = WidgetBaseInterface>(widgetLabel: RegistryLabel): Constructor<T> | null {
 		if (!this.has(widgetLabel)) {
 			return null;
 		}
 
 		const item = this.registry.get(widgetLabel);
 
-		if (isWidgetBaseConstructor(item)) {
+		if (isWidgetBaseConstructor<T>(item)) {
 			return item;
 		}
 

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -90,6 +90,25 @@ registerSuite({
 			assert.equal(registryHandler.get(baz), WidgetBase);
 		});
 	},
+	'get passing generic to specify widget type'() {
+		class TestWidget extends WidgetBase<{foo: string}> {}
+		const promise = new Promise((resolve) => {
+			setTimeout(() => {
+				resolve(TestWidget);
+			}, 1);
+		});
+		const registryHandler = new RegistryHandler();
+		registryHandler.add(registry);
+		registry.define('baz-1', promise);
+		return promise.then(() => {
+			const RegistryWidget = registryHandler.get<TestWidget>('baz-1');
+			assert.equal(RegistryWidget, TestWidget);
+			const widget = new RegistryWidget!();
+
+			// demonstrate registry widget is typed as TestWidget
+			widget.__setProperties__({ foo: 'baz' });
+		});
+	},
 	'invalidates once registry emits loaded event'() {
 		const baz = Symbol();
 		let promise: Promise<any> = Promise.resolve();

--- a/tests/unit/WidgetRegistry.ts
+++ b/tests/unit/WidgetRegistry.ts
@@ -74,6 +74,16 @@ registerSuite({
 			const factory = factoryRegistry.get(symbolLabel);
 			assert.strictEqual(factory, WidgetBase);
 		},
+		'get allows a generic to passed that defines the type of registry item'() {
+			class TestWidget extends WidgetBase<{foo: string}> {}
+			const factoryRegistry = new WidgetRegistry();
+			factoryRegistry.define('test-widget', TestWidget);
+			const RegistryTestWidget = factoryRegistry.get<TestWidget>('test-widget');
+			assert.isNotNull(RegistryTestWidget);
+			const widget = new RegistryTestWidget!();
+			// demontrates the design time typing
+			widget.__setProperties__({ foo: 'bar' });
+		},
 		'throws an error if factory has not been registered.'() {
 			const factoryRegistry = new WidgetRegistry();
 			const item = factoryRegistry.get('my-widget');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support generics for registry and registry handler `get`.

Resolves #565
