### PR TITLE
Add guards for beforeRender and afterRender for undefined return values

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -386,3 +386,21 @@ export interface WidgetMetaProperties {
 	requiredNodes: Set<string>;
 	invalidate: () => void;
 }
+
+export interface Render {
+	(): DNode | DNode[];
+}
+
+/**
+ * Interface for beforeRender function
+ */
+export interface BeforeRender {
+	(renderFunc: Render, properties: WidgetProperties, children: DNode[]): Render | undefined;
+}
+
+/**
+ * Interface for afterRender function
+ */
+export interface AfterRender {
+	(dNode: DNode | DNode []): DNode | DNode[];
+}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a guard for the `beforeRender` decorator if a function does not return a render method then the original render function is re-used.

Adds a guard for the `afterRender` decorator if a function does not return dNodes then the original dNodes function is re-used.

Resolves #522
