### PR TITLE
Meta dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,39 @@ class TestWidget extends WidgetBase<WidgetProperties> {
 
 If an HTML node is required to calculate the meta information, a sensible default will be returned and your widget will be automatically re-rendered to provide more accurate information.
 
+###### Dimensions
+
+The `Dimensions` meta provides size/position information about a node.
+
+```
+const dimensions = this.meta(Dimensions).get('root');
+```
+
+In this simple snippet, `dimensions` would be an object with the following fields:
+
+| Property       | Source                                |
+| -------------- | ------------------------------------- |
+| `bottom`       | `node.getBoundingClientRect().bottom` |
+| `height`       | `node.getBoundingClientRect().height` |
+| `left`         | `node.getBoundingClientRect().left`   |
+| `right`        | `node.getBoundingClientRect().right`  |
+| `top`          | `node.getBoundingClientRect().top`    |
+| `width`        | `node.getBoundingClientRect().width`  |
+| `scrollLeft`   | `node.scrollLeft`                     |
+| `scrollTop`    | `node.scrollTop`                      |
+| `scrollHeight` | `node.scrollHeight`                   |
+| `scrollWidth`  | `node.scrollWidth`                    |
+| `offsetLeft`   | `node.offsetLeft`                     |
+| `offsetTop`    | `node.offsetTop`                      |
+| `offsetWidth`  | `node.offsetWidth`                    |
+| `offsetHeight` | `node.offsetHeight`                   |
+
+If the node has not yet been rendered, all values will contain `0`. If you need more information about whether or not the node has been rendered you can use the `has` method:
+
+```
+const hasRootBeenRendered = this.meta(Dimensions).has('root');
+```
+
 ##### Implementing Custom Meta
 
 You can create your own meta if you need access to DOM nodes.

--- a/README.md
+++ b/README.md
@@ -1097,24 +1097,26 @@ The `Dimensions` meta provides size/position information about a node.
 const dimensions = this.meta(Dimensions).get('root');
 ```
 
-In this simple snippet, `dimensions` would be an object with the following fields:
+In this simple snippet, `dimensions` would be an object containing `offset`, `position`, `scroll`, and `size` objects.
 
-| Property       | Source                                |
-| -------------- | ------------------------------------- |
-| `bottom`       | `node.getBoundingClientRect().bottom` |
-| `height`       | `node.getBoundingClientRect().height` |
-| `left`         | `node.getBoundingClientRect().left`   |
-| `right`        | `node.getBoundingClientRect().right`  |
-| `top`          | `node.getBoundingClientRect().top`    |
-| `width`        | `node.getBoundingClientRect().width`  |
-| `scrollLeft`   | `node.scrollLeft`                     |
-| `scrollTop`    | `node.scrollTop`                      |
-| `scrollHeight` | `node.scrollHeight`                   |
-| `scrollWidth`  | `node.scrollWidth`                    |
-| `offsetLeft`   | `node.offsetLeft`                     |
-| `offsetTop`    | `node.offsetTop`                      |
-| `offsetWidth`  | `node.offsetWidth`                    |
-| `offsetHeight` | `node.offsetHeight`                   |
+The following fields are provided:
+
+| Property         | Source                                |
+| -----------------| ------------------------------------- |
+| `position.bottom`| `node.getBoundingClientRect().bottom` |
+| `position.left`  | `node.getBoundingClientRect().left`   |
+| `position.right` | `node.getBoundingClientRect().right`  |
+| `position.top`   | `node.getBoundingClientRect().top`    |
+| `size.width`     | `node.getBoundingClientRect().width`  |
+| `size.height`    | `node.getBoundingClientRect().height` |
+| `scroll.left`    | `node.scrollLeft`                     |
+| `scroll.top`     | `node.scrollTop`                      |
+| `scroll.height`  | `node.scrollHeight`                   |
+| `scroll.width`   | `node.scrollWidth`                    |
+| `offset.left`    | `node.offsetLeft`                     |
+| `offset.top`     | `node.offsetTop`                      |
+| `offset.width`   | `node.offsetWidth`                    |
+| `offset.height`  | `node.offsetHeight`                   |
 
 If the node has not yet been rendered, all values will contain `0`. If you need more information about whether or not the node has been rendered you can use the `has` method:
 

--- a/src/meta/Dimensions.ts
+++ b/src/meta/Dimensions.ts
@@ -1,61 +1,87 @@
 import { Base } from './Base';
+import { deepAssign } from '@dojo/core/lang';
 
-export interface DimensionResults {
-	bottom: number;
-	height: number;
+export interface TopLeft {
 	left: number;
-	offsetHeight: number;
-	offsetLeft: number;
-	offsetTop: number;
-	offsetWidth: number;
-	right: number ;
-	scrollHeight: number;
-	scrollLeft: number;
-	scrollTop: number;
-	scrollWidth: number;
 	top: number;
+}
+
+export interface BottomRight {
+	bottom: number;
+	right: number ;
+}
+
+export interface Size {
+	height: number;
 	width: number;
 }
+
+export interface DimensionResults {
+	position: TopLeft & BottomRight;
+	offset: TopLeft & Size;
+	size: Size;
+	scroll: TopLeft & Size;
+}
+
+const defaultDimensions = {
+	offset: {
+		height: 0,
+		left: 0,
+		top: 0,
+		width: 0
+	},
+	position: {
+		bottom: 0,
+		left: 0,
+		right: 0,
+		top: 0
+	},
+	scroll: {
+		height: 0,
+		left: 0,
+		top: 0,
+		width: 0
+	},
+	size: {
+		width: 0,
+		height: 0
+	}
+};
 
 export class Dimensions extends Base {
 	public get(key: string): Readonly<DimensionResults> {
 		this.requireNode(key);
 
 		const node = this.nodes.get(key);
-		const {
-			bottom = 0,
-			height = 0,
-			left = 0,
-			right = 0,
-			top = 0,
-			width = 0
-		} = (node ? node.getBoundingClientRect() : {});
-		const {
-			scrollLeft = 0,
-			scrollTop = 0,
-			scrollHeight = 0,
-			scrollWidth = 0,
-			offsetLeft = 0,
-			offsetTop = 0,
-			offsetWidth = 0,
-			offsetHeight = 0
-		} = (node || {});
+		if (!node) {
+			return deepAssign({}, defaultDimensions);
+		}
+
+		const boundingDimensions = node.getBoundingClientRect();
 
 		return {
-			bottom,
-			height,
-			left,
-			right,
-			top,
-			width,
-			scrollLeft,
-			scrollTop,
-			scrollHeight,
-			scrollWidth,
-			offsetLeft,
-			offsetTop,
-			offsetWidth,
-			offsetHeight
+			offset: {
+				height: node.offsetHeight,
+				left: node.offsetLeft,
+				top: node.offsetTop,
+				width: node.offsetWidth
+			},
+			position: {
+				bottom: boundingDimensions.bottom,
+				left: boundingDimensions.left,
+				right: boundingDimensions.right,
+				top: boundingDimensions.top
+			},
+			scroll: {
+				height: node.scrollHeight,
+				left: node.scrollLeft,
+				top: node.scrollTop,
+				width: node.scrollWidth
+			},
+			size: {
+				width: boundingDimensions.width,
+				height: boundingDimensions.height
+			}
 		};
 	}
 }

--- a/src/meta/Dimensions.ts
+++ b/src/meta/Dimensions.ts
@@ -18,7 +18,7 @@ export interface DimensionResults {
 }
 
 export class Dimensions extends Base {
-	get(key: string): Readonly<DimensionResults> {
+	public get(key: string): Readonly<DimensionResults> {
 		this.requireNode(key);
 
 		const node = this.nodes.get(key);

--- a/src/meta/Dimensions.ts
+++ b/src/meta/Dimensions.ts
@@ -1,0 +1,63 @@
+import { Base } from './Base';
+
+export interface DimensionResults {
+	bottom: number;
+	height: number;
+	left: number;
+	offsetHeight: number;
+	offsetLeft: number;
+	offsetTop: number;
+	offsetWidth: number;
+	right: number ;
+	scrollHeight: number;
+	scrollLeft: number;
+	scrollTop: number;
+	scrollWidth: number;
+	top: number;
+	width: number;
+}
+
+export class Dimensions extends Base {
+	get(key: string): Readonly<DimensionResults> {
+		this.requireNode(key);
+
+		const node = this.nodes.get(key);
+		const {
+			bottom = 0,
+			height = 0,
+			left = 0,
+			right = 0,
+			top = 0,
+			width = 0
+		} = (node ? node.getBoundingClientRect() : {});
+		const {
+			scrollLeft = 0,
+			scrollTop = 0,
+			scrollHeight = 0,
+			scrollWidth = 0,
+			offsetLeft = 0,
+			offsetTop = 0,
+			offsetWidth = 0,
+			offsetHeight = 0
+		} = (node || {});
+
+		return {
+			bottom,
+			height,
+			left,
+			right,
+			top,
+			width,
+			scrollLeft,
+			scrollTop,
+			scrollHeight,
+			scrollWidth,
+			offsetLeft,
+			offsetTop,
+			offsetWidth,
+			offsetHeight
+		};
+	}
+}
+
+export default Dimensions;

--- a/tests/unit/meta/Dimensions.ts
+++ b/tests/unit/meta/Dimensions.ts
@@ -1,0 +1,123 @@
+import global from '@dojo/core/global';
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { stub } from 'sinon';
+import { v } from '../../../src/d';
+import { ProjectorMixin } from '../../../src/main';
+import Dimensions from '../../../src/meta/Dimensions';
+import { WidgetBase } from '../../../src/WidgetBase';
+
+let rAF: any;
+
+function resolveRAF() {
+	for (let i = 0; i < rAF.callCount; i++) {
+		rAF.getCall(i).args[0]();
+	}
+	rAF.reset();
+}
+
+registerSuite({
+	name: 'meta - Dimensions',
+
+	beforeEach() {
+		rAF = stub(global, 'requestAnimationFrame');
+	},
+
+	afterEach() {
+		rAF.restore();
+	},
+
+	'dimensions are correctly configured'(this: any) {
+		const dimensions: any[] = [];
+
+		class TestWidget extends ProjectorMixin(WidgetBase)<any> {
+			render() {
+				dimensions.push(this.meta(Dimensions).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root'
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		assert.strictEqual(dimensions.length, 2);
+		assert.deepEqual(dimensions[0], {
+			bottom: 0,
+			height: 0,
+			left: 0,
+			right: 0,
+			scrollHeight: 0,
+			scrollLeft: 0,
+			scrollTop: 0,
+			scrollWidth: 0,
+			top: 0,
+			width: 0,
+			offsetLeft: 0,
+			offsetTop: 0,
+			offsetWidth: 0,
+			offsetHeight: 0
+		});
+	},
+
+	'dimensions has returns false for keys that dont exist'(this: any) {
+		class TestWidget extends ProjectorMixin(WidgetBase)<any> {
+			render() {
+				this.meta(Dimensions);
+
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root'
+				});
+			}
+
+			getDimensions() {
+				return this.meta(Dimensions).has('test');
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+		resolveRAF();
+		assert.isFalse(widget.getDimensions());
+	},
+
+	'dimensions has returns true for keys that exist'(this: any) {
+		class TestWidget extends ProjectorMixin(WidgetBase)<any> {
+			render() {
+				this.meta(Dimensions);
+
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root'
+				});
+			}
+
+			getDimensions() {
+				return this.meta(Dimensions).has('root');
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+		resolveRAF();
+
+		assert.isTrue(widget.getDimensions());
+	}
+});

--- a/tests/unit/meta/Dimensions.ts
+++ b/tests/unit/meta/Dimensions.ts
@@ -51,20 +51,28 @@ registerSuite({
 
 		assert.strictEqual(dimensions.length, 2);
 		assert.deepEqual(dimensions[0], {
-			bottom: 0,
-			height: 0,
-			left: 0,
-			right: 0,
-			scrollHeight: 0,
-			scrollLeft: 0,
-			scrollTop: 0,
-			scrollWidth: 0,
-			top: 0,
-			width: 0,
-			offsetLeft: 0,
-			offsetTop: 0,
-			offsetWidth: 0,
-			offsetHeight: 0
+			offset: {
+				height: 0,
+				left: 0,
+				top: 0,
+				width: 0
+			},
+			position: {
+				bottom: 0,
+				left: 0,
+				right: 0,
+				top: 0
+			},
+			scroll: {
+				height: 0,
+				left: 0,
+				top: 0,
+				width: 0
+			},
+			size: {
+				height: 0,
+				width: 0
+			}
 		});
 	},
 

--- a/tests/unit/meta/all.ts
+++ b/tests/unit/meta/all.ts
@@ -1,1 +1,2 @@
 import './meta';
+import './Dimensions';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds dimensional meta using the new meta system. We can use this to get exciting things like node position and size!

```typescript
render() {
    const dimensions = this.meta(Dimensions).get('someNode');

    console.log('node width: ', dimensions.width);
    // ...
}
```
