### PR TITLE
Add reaction callback to custom `diffProperty`

### DIFF
--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -6,7 +6,7 @@ import {
 	WidgetBase
 } from './WidgetBase';
 import { decorate, isHNode, isWNode } from './d';
-import { DiffType } from './diff';
+import { always } from './diff';
 import {
 	Constructor,
 	DNode,
@@ -96,7 +96,7 @@ export class BaseInjector<C extends Evented = Context> extends WidgetBase<Inject
  */
 export function Injector<C extends Evented, T extends Constructor<BaseInjector<C>>>(Base: T, context: C): T {
 
-	@diffProperty('render', DiffType.ALWAYS)
+	@diffProperty('render', always)
 	class Injector extends Base {
 
 		constructor(...args: any[]) {

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -7,13 +7,14 @@ import Promise from '@dojo/shim/Promise';
 import Set from '@dojo/shim/Set';
 import WeakMap from '@dojo/shim/WeakMap';
 import { decorate, isHNode, isWNode, registry, v } from './d';
-import diff, { DiffType } from './diff';
+import { auto, reference } from './diff';
 import {
 	AfterRender,
 	BeforeRender,
+	DiffPropertyFunction,
+	DiffPropertyReaction,
 	DNode,
 	HNode,
-	PropertyChangeRecord,
 	PropertiesChangeEvent,
 	RegistryLabel,
 	Render,
@@ -26,8 +27,6 @@ import {
 import MetaBase from './meta/Base';
 import RegistryHandler from './RegistryHandler';
 import { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './WidgetRegistry';
-
-export { DiffType };
 
 /**
  * Widget cache wrapper for instance management
@@ -44,13 +43,15 @@ enum WidgetRenderState {
 	RENDER
 }
 
-/**
- * Diff property configuration
- */
-interface DiffPropertyConfig {
+interface ReactionFunctionArguments {
+	previousProperties: any;
+	newProperties: any;
+	changed: boolean;
+}
+
+interface ReactionFunctionConfig {
 	propertyName: string;
-	diffType: DiffType;
-	diffFunction?<P>(previousProperty: P, newProperty: P): PropertyChangeRecord;
+	reaction: DiffPropertyReaction;
 }
 
 export interface WidgetBaseEvents<P extends WidgetProperties> extends BaseEventedEvents {
@@ -88,24 +89,15 @@ export function beforeRender(method?: Function) {
  * @param diffType      The diff type, default is DiffType.AUTO.
  * @param diffFunction  A diff function to run if diffType if DiffType.CUSTOM
  */
-export function diffProperty(propertyName: string, diffType = DiffType.AUTO, diffFunction?: Function) {
+export function diffProperty(propertyName: string, diffFunction: DiffPropertyFunction = auto, reactionFunction?: Function) {
 	return handleDecorator((target, propertyKey) => {
-		target.addDecorator('diffProperty', {
-			propertyName,
-			diffType: propertyKey ? DiffType.CUSTOM : diffType,
-			diffFunction: propertyKey ? target[propertyKey] : diffFunction
-		});
-	});
-}
-
-/**
- * Decorator used to register listeners to the `properties:changed` event.
- */
-export function onPropertiesChanged(method: Function): (target: any) => void;
-export function onPropertiesChanged(): (target: any, propertyKey: any) => void;
-export function onPropertiesChanged(method?: Function) {
-	return handleDecorator((target, propertyKey) => {
-		target.addDecorator('onPropertiesChanged', propertyKey ? target[propertyKey] : method);
+		target.addDecorator(`diffProperty:${propertyName}`, diffFunction);
+		if (reactionFunction || propertyKey) {
+			target.addDecorator('diffReaction', {
+				propertyName,
+				reaction: propertyKey ? target[propertyKey] : reactionFunction
+			});
+		}
 	});
 }
 
@@ -136,7 +128,7 @@ function isHNodeWithKey(node: DNode): node is HNode {
 /**
  * Main widget base for all widgets to extend
  */
-@diffProperty('bind', DiffType.REFERENCE)
+@diffProperty('bind', reference)
 export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends Evented implements WidgetBaseInterface<P, C> {
 
 	/**
@@ -167,12 +159,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	/**
 	 * internal widget properties
 	 */
-	private  _properties: P & WidgetProperties;
-
-	/**
-	 * properties from the previous render
-	 */
-	private _previousProperties: P & { [index: string]: any };
+	private _properties: P & WidgetProperties & { [index: string]: any };
 
 	/**
 	 * cached chldren map for instance management
@@ -218,7 +205,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		this._children = [];
 		this._decoratorCache = new Map<string, any[]>();
 		this._properties = <P> {};
-		this._previousProperties = <P> {};
 		this._cachedChildrenMap = new Map<string | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>();
 		this._diffPropertyFunctionMap = new Map<string, string>();
 		this._renderDecorators = new Set<string>();
@@ -228,16 +214,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		this.own(this._registries);
 
 		this.own(this._registries.on('invalidate', this.invalidate.bind(this)));
-
-		this.own(this.on('properties:changed', (evt) => {
-			this._dirty = true;
-
-			const propertiesChangedListeners = this.getDecorator('onPropertiesChanged');
-			propertiesChangedListeners.forEach((propertiesChangedFunction) => {
-				propertiesChangedFunction.call(this, evt);
-			});
-		}));
-
 		this._checkOnElementUsage();
 	}
 
@@ -369,78 +345,66 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	}
 
 	public __setProperties__(originalProperties: P): void {
-		const { bind, ...properties } = <any> originalProperties;
-		this._renderState = WidgetRenderState.PROPERTIES;
-		const diffPropertyResults: { [index: string]: any } = {};
-		const diffPropertyChangedKeys: string[] = [];
+		const { bind, ...properties } = originalProperties as any;
+		const changedPropertyKeys: string[] = [];
 
+		this._renderState = WidgetRenderState.PROPERTIES;
 		this._bindFunctionProperties(properties, bind);
 
-		const registeredDiffPropertyConfigs: DiffPropertyConfig[] = this.getDecorator('diffProperty');
+		const diffPropertyResults = Object.keys(properties).reduce((diffPropertyResults, propertyName) => {
+			const previousProperty = this._properties[propertyName];
+			const newProperty = properties[propertyName];
+			const diffFunctions: DiffPropertyFunction[] = this.getDecorator(`diffProperty:${propertyName}`);
 
-		const allProperties = [...Object.keys(this._previousProperties), ...Object.keys(properties)].filter((value, index, self) => {
-			return self.indexOf(value) === index;
-		});
+			if (diffFunctions.length === 0) {
+				diffFunctions.push(auto);
+			}
 
-		const propertyDiffHandlers = allProperties.reduce((diffFunctions: any, propertyName) => {
-			diffFunctions[propertyName] = [
-				...registeredDiffPropertyConfigs.filter(value => {
-					return value.propertyName === propertyName;
-				})
-			];
-
-			return diffFunctions;
-		}, {});
-
-		allProperties.forEach(propertyName => {
-			const previousValue = this._previousProperties[propertyName];
-			const newValue = (<any> properties)[propertyName];
-			const diffHandlers = propertyDiffHandlers[propertyName];
-			let result: PropertyChangeRecord = {
-				changed: false,
-				value: newValue
-			};
-
-			if (diffHandlers.length) {
-				for (let i = 0; i < diffHandlers.length; i++) {
-					const { diffFunction, diffType } = diffHandlers[i];
-
-					const meta = {
-						diffFunction: diffFunction,
-						scope: this
-					};
-
-					result = diff(propertyName, diffType, previousValue, newValue, meta);
-
-					if (result.changed) {
-						break;
-					}
+			diffFunctions.forEach((diffFunction) => {
+				const result = diffFunction(previousProperty, newProperty);
+				if (result.changed && changedPropertyKeys.indexOf(propertyName) === -1) {
+					changedPropertyKeys.push(propertyName);
 				}
-			}
-			else {
-				result = diff(propertyName, DiffType.AUTO, previousValue, newValue);
-			}
-
-			if (propertyName in properties) {
 				diffPropertyResults[propertyName] = result.value;
-			}
+			});
+			return diffPropertyResults;
+		}, {} as any);
 
-			if (result.changed) {
-				diffPropertyChangedKeys.push(propertyName);
+		const reactionFunctions: ReactionFunctionConfig[] = this.getDecorator('diffReaction');
+
+		const reactionPropertyMap = reactionFunctions.reduce((reactionPropertyMap, { reaction, propertyName }) => {
+			let reactionArguments = reactionPropertyMap.get(reaction);
+			if (reactionArguments === undefined) {
+				reactionArguments = {
+					previousProperties: {},
+					newProperties: {},
+					changed: false
+				};
+			}
+			reactionArguments.previousProperties[propertyName] = this._properties[propertyName];
+			reactionArguments.newProperties[propertyName] = properties[propertyName];
+			if (changedPropertyKeys.indexOf(propertyName) !== -1) {
+				reactionArguments.changed = true;
+			}
+			reactionPropertyMap.set(reaction, reactionArguments);
+			return reactionPropertyMap;
+		}, new Map<Function, ReactionFunctionArguments>());
+
+		reactionPropertyMap.forEach((args, reaction) => {
+			if (args.changed) {
+				reaction.call(this, args.previousProperties, args.newProperties);
 			}
 		});
 
-		this._properties = <P> diffPropertyResults;
+		this._properties = diffPropertyResults;
 
-		if (diffPropertyChangedKeys.length) {
+		if (changedPropertyKeys.length) {
+			this._dirty = true;
 			this.emit({
 				type: 'properties:changed',
-				target: this,
-				properties: this.properties,
-				changedPropertyKeys: diffPropertyChangedKeys
+				target: this
 			});
 		}
-		this._previousProperties = this.properties;
 	}
 
 	public get children(): (C | null)[] {
@@ -564,6 +528,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		}
 
 		allDecorators = this._buildDecoratorList(decoratorKey);
+
 		this._decoratorCache.set(decoratorKey, allDecorators);
 		return allDecorators;
 	}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -351,7 +351,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		this._renderState = WidgetRenderState.PROPERTIES;
 		this._bindFunctionProperties(properties, bind);
 
-		const diffPropertyResults = Object.keys(properties).reduce((diffPropertyResults, propertyName) => {
+		const allProperties = new Set([...Object.keys(properties), ...Object.keys(this._properties)]);
+		const diffPropertyResults: any = {};
+		allProperties.forEach((propertyName) => {
 			const previousProperty = this._properties[propertyName];
 			const newProperty = properties[propertyName];
 			const diffFunctions: DiffPropertyFunction[] = this.getDecorator(`diffProperty:${propertyName}`);
@@ -365,10 +367,11 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 				if (result.changed && changedPropertyKeys.indexOf(propertyName) === -1) {
 					changedPropertyKeys.push(propertyName);
 				}
-				diffPropertyResults[propertyName] = result.value;
+				if (propertyName in properties) {
+					diffPropertyResults[propertyName] = result.value;
+				}
 			});
-			return diffPropertyResults;
-		}, {} as any);
+		});
 
 		const reactionFunctions: ReactionFunctionConfig[] = this.getDecorator('diffReaction');
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -363,7 +363,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			}
 
 			diffFunctions.forEach((diffFunction) => {
-				const result = diffFunction(previousProperty, newProperty);
+				const result = diffFunction.call(null, previousProperty, newProperty);
 				if (result.changed && changedPropertyKeys.indexOf(propertyName) === -1) {
 					changedPropertyKeys.push(propertyName);
 				}

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,52 +1,32 @@
 import { PropertyChangeRecord } from './interfaces';
 import { WIDGET_BASE_TYPE } from './WidgetRegistry';
 
-export const enum DiffType {
-	CUSTOM = 1,
-	ALWAYS,
-	IGNORE,
-	REFERENCE,
-	SHALLOW,
-	AUTO
-}
-
 function isObjectOrArray(value: any): boolean {
 	return Object.prototype.toString.call(value) === '[object Object]' || Array.isArray(value);
 }
 
-function always(previousProperty: any, newProperty: any): PropertyChangeRecord {
+export function always(previousProperty: any, newProperty: any): PropertyChangeRecord {
 	return {
 		changed: true,
 		value: newProperty
 	};
 }
 
-function ignore(previousProperty: any, newProperty: any): PropertyChangeRecord {
+export function ignore(previousProperty: any, newProperty: any): PropertyChangeRecord {
 	return {
 		changed: false,
 		value: newProperty
 	};
 }
 
-function custom(previousProperty: any, newProperty: any, meta: any): PropertyChangeRecord {
-	const { diffFunction, scope } = meta;
-	if (!diffFunction) {
-		return {
-			changed: false,
-			value: newProperty
-		};
-	}
-	return diffFunction.call(scope, previousProperty, newProperty);
-}
-
-function reference(previousProperty: any, newProperty: any): PropertyChangeRecord {
+export function reference(previousProperty: any, newProperty: any): PropertyChangeRecord {
 	return {
 		changed: previousProperty !== newProperty,
 		value: newProperty
 	};
 }
 
-function shallow(previousProperty: any, newProperty: any): PropertyChangeRecord {
+export function shallow(previousProperty: any, newProperty: any): PropertyChangeRecord {
 	let changed = false;
 
 	const validOldProperty = previousProperty && isObjectOrArray(previousProperty);
@@ -76,43 +56,21 @@ function shallow(previousProperty: any, newProperty: any): PropertyChangeRecord 
 	};
 }
 
-export default function diff(propertyName: string, diffDiffType: DiffType, previousProperty: any, newProperty: any, meta?: any) {
+export function auto(previousProperty: any, newProperty: any): PropertyChangeRecord {
 	let result;
-	switch (diffDiffType) {
-		case DiffType.CUSTOM:
-			result = custom(previousProperty, newProperty, meta);
-		break;
-		case DiffType.ALWAYS:
-			result = always(previousProperty, newProperty);
-		break;
-		case DiffType.IGNORE:
-			result = ignore(previousProperty, newProperty);
-		break;
-		case DiffType.REFERENCE:
+	if (typeof newProperty === 'function') {
+		if (newProperty._type === WIDGET_BASE_TYPE) {
 			result = reference(previousProperty, newProperty);
-		break;
-		case DiffType.SHALLOW:
-			result = shallow(previousProperty, newProperty);
-		break;
-		case DiffType.AUTO:
-			if (typeof newProperty === 'function') {
-				if (newProperty._type === WIDGET_BASE_TYPE) {
-					result = reference(previousProperty, newProperty);
-				}
-				else {
-					result = ignore(previousProperty, newProperty);
-				}
-			}
-			else if (isObjectOrArray(newProperty)) {
-				result = shallow(previousProperty, newProperty);
-			}
-			else {
-				result = reference(previousProperty, newProperty);
-			}
-		break;
-		default:
-			console.warn(`no valid DiffType provided, will mark property '${propertyName}' as changed`);
-			result = always(previousProperty, newProperty);
+		}
+		else {
+			result = ignore(previousProperty, newProperty);
+		}
+	}
+	else if (isObjectOrArray(newProperty)) {
+		result = shallow(previousProperty, newProperty);
+	}
+	else {
+		result = reference(previousProperty, newProperty);
 	}
 	return result;
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -321,14 +321,6 @@ export interface PropertyChangeRecord {
 	value: any;
 }
 
-/**
- * Properties changed record, return for diffProperties
- */
-export interface PropertiesChangeRecord<P extends WidgetProperties> {
-	changedKeys: string[];
-	properties: P;
-}
-
 export interface DiffPropertyFunction {
 	<T>(previousProperty: T, newProperty: any): PropertyChangeRecord;
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -329,6 +329,14 @@ export interface PropertiesChangeRecord<P extends WidgetProperties> {
 	properties: P;
 }
 
+export interface DiffPropertyFunction {
+	<T>(previousProperty: T, newProperty: any): PropertyChangeRecord;
+}
+
+export interface DiffPropertyReaction {
+	(previousProperties: any, newProperties: any): void;
+}
+
 /**
  * WidgetBase constructor type
  */

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -1,6 +1,7 @@
 import { Constructor } from '../interfaces';
 import { diffProperty, WidgetBase } from './../WidgetBase';
 import WidgetRegistry from '../WidgetRegistry';
+import { reference } from './../diff';
 
 export interface RegistryMixinProperties {
 	registry?: WidgetRegistry;
@@ -13,7 +14,7 @@ export interface RegistryMixin {
 export function RegistryMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & Constructor<RegistryMixin> {
 	class Registry extends Base {
 
-		@diffProperty('registry')
+		@diffProperty('registry', reference)
 		protected diffPropertyRegistry(previousProperties: any, newProperties: any): void {
 			const result = this.registries.replace(previousProperties.registry, newProperties.registry);
 			if (!result) {

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -1,4 +1,4 @@
-import { Constructor, PropertyChangeRecord } from '../interfaces';
+import { Constructor } from '../interfaces';
 import { diffProperty, WidgetBase } from './../WidgetBase';
 import WidgetRegistry from '../WidgetRegistry';
 
@@ -14,20 +14,11 @@ export function RegistryMixin<T extends Constructor<WidgetBase<any>>>(Base: T): 
 	class Registry extends Base {
 
 		@diffProperty('registry')
-		protected diffPropertyRegistry(previousValue: WidgetRegistry, value: WidgetRegistry): PropertyChangeRecord {
-			let changed = false;
-			if (!previousValue) {
-				this.registries.add(value);
-				changed = true;
+		protected diffPropertyRegistry(previousProperties: any, newProperties: any): void {
+			const result = this.registries.replace(previousProperties.registry, newProperties.registry);
+			if (!result) {
+				this.registries.add(newProperties.registry);
 			}
-			else if (previousValue !== value) {
-				this.registries.replace(previousValue, value);
-				changed = true;
-			}
-			return {
-				changed,
-				value: value
-			};
 		}
 	}
 	return Registry;

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -6,6 +6,7 @@ import { w, registry } from './../d';
 import { WidgetRegistry } from './../WidgetRegistry';
 import { BaseInjector, Context, Injector } from './../Injector';
 import { beforeRender, diffProperty, WidgetBase, handleDecorator } from './../WidgetBase';
+import { shallow } from './../diff';
 
 /**
  * A representation of the css class names to be applied and
@@ -251,8 +252,8 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<any>>>(Base: T):
 		/**
 		 * Function fired when `theme` or `extraClasses` are changed.
 		 */
-		@diffProperty('theme')
-		@diffProperty('extraClasses')
+		@diffProperty('theme', shallow)
+		@diffProperty('extraClasses', shallow)
 		protected onPropertiesChanged() {
 			this._recalculateClasses = true;
 		}

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -1,11 +1,11 @@
 import { assign } from '@dojo/core/lang';
-import { includes, find } from '@dojo/shim/array';
+import { find } from '@dojo/shim/array';
 import Map from '@dojo/shim/Map';
-import { ClassesFunction, Constructor, DNode, WidgetProperties, PropertiesChangeEvent } from './../interfaces';
+import { ClassesFunction, Constructor, DNode, WidgetProperties } from './../interfaces';
 import { w, registry } from './../d';
 import { WidgetRegistry } from './../WidgetRegistry';
 import { BaseInjector, Context, Injector } from './../Injector';
-import { beforeRender, WidgetBase, onPropertiesChanged, handleDecorator } from './../WidgetBase';
+import { beforeRender, diffProperty, WidgetBase, handleDecorator } from './../WidgetBase';
 
 /**
  * A representation of the css class names to be applied and
@@ -249,18 +249,12 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<any>>>(Base: T):
 		}
 
 		/**
-		 * Function fired when properties are changed on the widget.
-		 *
-		 * @param changedPropertyKeys Array of properties that have changed
+		 * Function fired when `theme` or `extraClasses` are changed.
 		 */
-		@onPropertiesChanged()
-		protected onPropertiesChanged({ changedPropertyKeys }: PropertiesChangeEvent<this, ThemeableProperties>) {
-			const themeChanged = includes(changedPropertyKeys, 'theme');
-			const extraClassesChanged = includes(changedPropertyKeys, 'extraClasses');
-
-			if (themeChanged || extraClassesChanged) {
-				this._recalculateClasses = true;
-			}
+		@diffProperty('theme')
+		@diffProperty('extraClasses')
+		protected onPropertiesChanged() {
+			this._recalculateClasses = true;
 		}
 
 		/**

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -11,7 +11,7 @@ import {
 	afterRender,
 	beforeRender
 } from '../../src/WidgetBase';
-import { ignore, always } from '../../src/diff';
+import { ignore, always, auto } from '../../src/diff';
 import WidgetRegistry, { WIDGET_BASE_TYPE } from './../../src/WidgetRegistry';
 
 interface TestProperties {
@@ -101,7 +101,7 @@ registerSuite({
 			let invalidateCalled = false;
 			let renderCount = 0;
 			class Foo extends WidgetBase<{ bar: string }> {
-				@diffProperty('bar')
+				@diffProperty('bar', auto)
 				barDiff() {
 					this.invalidate();
 					return {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -4,19 +4,18 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { stub, spy, SinonStub } from 'sinon';
 import { v, w, registry } from '../../src/d';
-import { Constructor, DNode, Render } from '../../src/interfaces';
+import { Constructor, DNode, PropertyChangeRecord, Render } from '../../src/interfaces';
 import {
 	WidgetBase,
 	diffProperty,
-	DiffType,
 	afterRender,
-	beforeRender,
-	onPropertiesChanged
+	beforeRender
 } from '../../src/WidgetBase';
+import { ignore, always } from '../../src/diff';
 import WidgetRegistry, { WIDGET_BASE_TYPE } from './../../src/WidgetRegistry';
 
 interface TestProperties {
-	id: string;
+	id?: string;
 	foo: string;
 	bar?: null | string;
 	baz?: number;
@@ -155,45 +154,52 @@ registerSuite({
 	},
 	diffProperties: {
 		'no updated properties'() {
+			let propertiesChanged = false;
 			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
-				assert.lengthOf(result.changedPropertyKeys, 0);
+				propertiesChanged = true;
 			});
 
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
+			assert.isFalse(propertiesChanged);
 		},
 		'updated properties'() {
+			let propertiesChanged = false;
 			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
-				assert.lengthOf(result.changedPropertyKeys, 1);
+				propertiesChanged = true;
 			});
 
 			widgetBase.__setProperties__({ id: 'id', foo: 'baz' });
+			assert.isTrue(propertiesChanged);
 		},
 		'new properties'() {
+			let propertiesChanged = false;
 			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
-				assert.lengthOf(result.changedPropertyKeys, 1);
+				propertiesChanged = true;
 			});
 
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar', bar: 'baz' });
+			assert.isTrue(propertiesChanged);
 		},
 		'updated / new properties with falsy values'() {
+			let propertiesChanged = false;
 			const widgetBase = new TestWidget();
 			widgetBase.__setProperties__({ id: 'id', foo: 'bar' });
 
 			widgetBase.on('properties:changed', result => {
-				assert.lengthOf(result.changedPropertyKeys, 4);
-				assert.deepEqual(result.changedPropertyKeys, ['foo', 'bar', 'baz', 'qux']);
+				propertiesChanged = true;
 			});
 
 			widgetBase.__setProperties__({ id: 'id', foo: '', bar: null, baz: 0, qux: false });
+			assert.isTrue(propertiesChanged);
 		}
 	},
 	diffProperty: {
@@ -201,7 +207,7 @@ registerSuite({
 				let callCount = 0;
 				let value;
 
-				@diffProperty('foo', DiffType.CUSTOM, (previousProperty: any, newProperty: any) => {
+				@diffProperty('foo', (previousProperty: any, newProperty: any) => {
 					callCount++;
 					return {
 						changed: true,
@@ -224,18 +230,17 @@ registerSuite({
 		decorator() {
 			let callCount = 0;
 
-			class TestWidget extends WidgetBase<any> {
-
-				@diffProperty('foo')
-				diffPropertyFoo(this: any, previousProperty: any, newProperty: any): any {
+			function diffFunction(previousProperty: any, newProperty: any) {
 					callCount++;
 					assert.equal(newProperty, 'bar');
 					return {
 						changed: false,
 						value: newProperty
 					};
-				}
 			}
+
+			@diffProperty('foo', diffFunction)
+			class TestWidget extends WidgetBase<any> { }
 
 			const testWidget = new TestWidget();
 			testWidget.__setProperties__({ foo: 'bar' });
@@ -245,20 +250,20 @@ registerSuite({
 		'non decorator'() {
 			let callCount = 0;
 
-			class TestWidget extends WidgetBase<any> {
-
-				constructor() {
-					super();
-					diffProperty('foo', DiffType.CUSTOM, this.diffPropertyFoo)(this);
-				}
-
-				diffPropertyFoo(this: any, previousProperty: any, newProperty: any): any {
+			function diffFunction(previousProperty: any, newProperty: any) {
 					callCount++;
 					assert.equal(newProperty, 'bar');
 					return {
 						changed: false,
 						value: newProperty
 					};
+			}
+
+			class TestWidget extends WidgetBase<any> {
+
+				constructor() {
+					super();
+					diffProperty('foo', diffFunction)(this);
 				}
 			}
 
@@ -291,60 +296,80 @@ registerSuite({
 
 			assert.equal(renderCallCount, 1);
 		},
-		'multiple decorators on the same method cause the first matching decorator to win'() {
+		'multiple default decorators on the same method cause the first matching decorator to win'() {
+			let propertiesChanged = false;
+
+			@diffProperty('foo', ignore)
+			class TestWidget extends WidgetBase<TestProperties> { }
+
+			@diffProperty('foo', always)
+			class SubWidget extends TestWidget { }
+
+			const widget = new SubWidget();
+			widget.on('properties:changed', () => {
+				propertiesChanged = true;
+			});
+			widget.__setProperties__({
+				foo: 'bar'
+			});
+
+			assert.isTrue(propertiesChanged);
+		},
+		'multiple custom decorators on the same method cause the first matching decorator to win'() {
 			const calls: string[] = [];
 
-			class TestWidget extends WidgetBase<any> {
-				@diffProperty('prop')
-				ignoreProp(previousValue: any, newValue: any) {
-					calls.push('ignore');
-
-					return {
-						changed: false,
-						value: newValue
-					};
-				}
+			function diff1(prevProp: any, newProp: any): PropertyChangeRecord {
+				calls.push('diff1');
+				return {
+					changed: false,
+					value: newProp
+				};
 			}
 
-			class SubWidget extends TestWidget {
-				@diffProperty('prop')
-				alwaysProp(previousValue: any, newValue: any) {
-					calls.push('always');
-
-					return {
-						changed: true,
-						value: newValue
-					};
-				}
+			function diff2(prevProp: any, newProp: any): PropertyChangeRecord {
+				calls.push('diff2');
+				return {
+					changed: false,
+					value: newProp
+				};
 			}
+
+			@diffProperty('foo', diff1)
+			class TestWidget extends WidgetBase<TestProperties> { }
+
+			@diffProperty('foo', diff2)
+			class SubWidget extends TestWidget { }
 
 			const widget = new SubWidget();
 			widget.__setProperties__({
-				prop: true
+				id: '',
+				foo: 'bar'
 			});
 
-			assert.deepEqual(calls, ['ignore', 'always']);
+			assert.deepEqual(calls, ['diff1', 'diff2']);
+			assert.strictEqual(calls[0], 'diff1');
+			assert.strictEqual(calls[1], 'diff2');
 		},
 
 		'diffProperty properties are excluded from catch-all'() {
-			class TestWidget extends WidgetBase<any> {
-				@diffProperty('prop')
-				ignoreProp(previousValue: any, newValue: any) {
-					return {
-						changed: false,
-						value: newValue
-					};
-				}
+			function customDiff() {
+				return {
+					changed: false,
+					value: ''
+				};
 			}
+			@diffProperty('foo', customDiff)
+			@diffProperty('id', customDiff)
+			class TestWidget extends WidgetBase<TestProperties> { }
 
 			const widget = new TestWidget();
 			widget.on('properties:changed', result => {
-				assert.deepEqual(result.changedPropertyKeys, ['anotherProp']);
+				assert.fail('property should not be considered changed');
 			});
 
 			widget.__setProperties__({
-				prop: true,
-				anotherProp: true
+				foo: '',
+				id: ''
 			});
 		},
 
@@ -367,36 +392,6 @@ registerSuite({
 		}
 	},
 	setProperties: {
-		'result from diff property override diff and assign'() {
-			class TestWidget extends WidgetBase<any> {
-
-				@diffProperty('foo')
-				diffPropertyFoo(this: any, previousProperty: any, newProperty: any): any {
-					return {
-						changed: true,
-						value: newProperty
-					};
-				}
-
-				@diffProperty('baz')
-				diffPropertyBaz(this: any, previousProperty: any, newProperty: any): any {
-					return {
-						changed: false,
-						value: newProperty
-					};
-				}
-			}
-
-			const widget = new TestWidget();
-			widget.__setProperties__({ foo: 'bar', baz: 'qux' });
-
-			widget.on('properties:changed', (event: any) => {
-				assert.include(event.changedPropertyKeys, 'foo');
-				assert.notInclude(event.changedPropertyKeys, 'baz');
-			});
-
-			widget.__setProperties__({ foo: 'bar', baz: 'bar' });
-		},
 		'widgets function properties are bound to the parent by default'() {
 			class TestChildWidget extends WidgetBase<any> {
 				render() {
@@ -706,100 +701,24 @@ registerSuite({
 			assert.isTrue(consoleStub.calledWith('DNodes not returned from afterRender, using existing dNodes'));
 		}
 	},
-	'properties:changed event': {
-		decorator() {
-			let onPropertiesChangedCount = 1;
-			class TestWidget extends WidgetBase<any> {
-				@onPropertiesChanged()
-				firstOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 1);
-				}
+	'extendable'() {
+		let called = false;
 
-				@onPropertiesChanged()
-				secondOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 2);
-				}
-			}
-
-			class ExtendedTestWidget extends TestWidget {
-				@onPropertiesChanged()
-				thirdOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount, 3);
-				}
-			}
-
-			const widget = new ExtendedTestWidget();
-			widget.emit({ type: 'properties:changed' });
-			assert.strictEqual(onPropertiesChangedCount, 3);
-		},
-		'non decorator'() {
-
-			let onPropertiesChangedCount = 1;
-			class TestWidget extends WidgetBase<any> {
-				constructor() {
-					super();
-					onPropertiesChanged(this.firstOnPropertiesChanged)(this);
-					onPropertiesChanged(this.secondOnPropertiesChanged)(this);
-				}
-				firstOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 1);
-				}
-				secondOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount++, 2);
-				}
-			}
-
-			class ExtendedTestWidget extends TestWidget {
-				constructor() {
-					super();
-					onPropertiesChanged(this.thirdOnPropertiesChanged)(this);
-				}
-				thirdOnPropertiesChanged() {
-					assert.strictEqual(onPropertiesChangedCount, 3);
-				}
-			}
-
-			const widget = new ExtendedTestWidget();
-			widget.emit({ type: 'properties:changed' });
-			assert.strictEqual(onPropertiesChangedCount, 3);
-		},
-
-		'class level decorator'() {
-			let called = 0;
-
-			@onPropertiesChanged(function () {
-				called++;
-			})
-			class TestWidget extends WidgetBase<any> {
-			}
-
-			const widget = new TestWidget();
-			widget.__setProperties__({
-				test: true
+		function PropertyLogger() {
+			return afterRender(function(dNode: any) {
+				called = true;
+				return dNode;
 			});
-			assert.strictEqual(called, 1);
-		},
-
-		'extendable'() {
-			let called = false;
-
-function PropertyLogger() {
-	return onPropertiesChanged(function() {
-		called = true;
-	});
-}
-
-@PropertyLogger()
-class TestWidget extends WidgetBase<any> {
-}
-
-const widget = new TestWidget();
-widget.__setProperties__({
-	test: true
-});
-
-			assert.strictEqual(called, true);
 		}
+
+		@PropertyLogger()
+		class TestWidget extends WidgetBase {
+		}
+
+		const widget = new TestWidget();
+		widget.__render__();
+
+		assert.strictEqual(called, true);
 	},
 	render: {
 		'render with non widget children'() {

--- a/tests/unit/diff.ts
+++ b/tests/unit/diff.ts
@@ -1,61 +1,33 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import diff, { DiffType } from '../../src/diff';
+import * as diff from '../../src/diff';
 import WidgetBase from '../../src/WidgetBase';
-import { stub } from 'sinon';
 
 registerSuite({
 	name: 'diff',
-	'DiffType.ALWAYS'() {
+	'always'() {
 		const foo = {};
-		const result = diff('myProperty', DiffType.ALWAYS, foo, foo);
+		const result = diff.always(foo, foo);
 		assert.equal(result.value, foo);
 		assert.isTrue(result.changed);
 	},
-	'DiffType.IGNORE'() {
-		const result = diff('myProperty', DiffType.IGNORE, 'foo', 'bar');
+	'ignore'() {
+		const result = diff.ignore('foo', 'bar');
 		assert.equal(result.value, 'bar');
 		assert.isFalse(result.changed);
 	},
-	'DiffType.CUSTOM': {
-		'diff function'() {
-			const foo = 1;
-			const bar = 2;
-			const meta: any = {};
-			let scope;
-			meta.diffFunction = function (this: any) {
-				scope = this;
-				return {
-					changed: true,
-					value: 'anything'
-				};
-			};
-			meta.scope = meta;
-			const result = diff('myProperty', DiffType.CUSTOM, foo, bar, meta);
-			assert.isTrue(result.changed);
-			assert.equal(result.value, 'anything');
-			assert.equal(scope, meta);
-		},
-		'no diff function'() {
-			const foo = 1;
-			const bar = 2;
-			const result = diff('myProperty', DiffType.CUSTOM, foo, bar, {});
-			assert.isFalse(result.changed);
-			assert.equal(result.value, 2);
-		}
-	},
-	'DiffType.REFERENCE'() {
+	'reference'() {
 		const foo = {
 			bar: 'bar'
 		};
 		const bar = {
 			bar: 'bar'
 		};
-		const result = diff('myProperty', DiffType.REFERENCE, foo, bar);
+		const result = diff.reference(foo, bar);
 		assert.equal(result.value, bar);
 		assert.isTrue(result.changed);
 	},
-	'DiffType.SHALLOW': {
+	'shallow': {
 		'object'() {
 			const foo = {
 				bar: 'bar'
@@ -63,12 +35,12 @@ registerSuite({
 			const bar = {
 				bar: 'bar'
 			};
-			let result = diff('myProperty', DiffType.SHALLOW, foo, bar);
+			let result = diff.shallow(foo, bar);
 			assert.equal(result.value, bar);
 			assert.isFalse(result.changed);
 
 			bar.bar = 'qux';
-			result = diff('myProperty', DiffType.SHALLOW, foo, bar);
+			result = diff.shallow(foo, bar);
 			assert.equal(result.value, bar);
 			assert.isTrue(result.changed);
 
@@ -76,39 +48,39 @@ registerSuite({
 				bar: 'bar',
 				baz: 'baz'
 			};
-			result = diff('myProperty', DiffType.SHALLOW, foo, baz);
+			result = diff.shallow(foo, baz);
 			assert.equal(result.value, baz);
 			assert.isTrue(result.changed);
 
-			result = diff('myProperty', DiffType.SHALLOW, 'foo', baz);
+			result = diff.shallow('foo', baz);
 			assert.equal(result.value, baz);
 			assert.isTrue(result.changed);
 		},
 		'array'() {
 			const foo = [ 1, 2, 3 ];
 			const bar = [ 1, 2, 3 ];
-			let result = diff('myProperty', DiffType.SHALLOW, foo, bar);
+			let result = diff.shallow(foo, bar);
 			assert.equal(result.value, bar);
 			assert.isFalse(result.changed);
 
 			const qux = [ 1, 3, 2];
-			result = diff('myProperty', DiffType.SHALLOW, foo, qux);
+			result = diff.shallow(foo, qux);
 			assert.equal(result.value, qux);
 			assert.isTrue(result.changed);
 		}
 	},
-	'DiffType.AUTO': {
+	'auto': {
 		'widget constructor'() {
 			class Foo extends WidgetBase {}
 			class Bar extends WidgetBase {}
-			let result = diff('myProperty', DiffType.AUTO, Foo, Bar);
+			let result = diff.auto(Foo, Bar);
 			assert.equal(result.value, Bar);
 			assert.isTrue(result.changed);
 		},
 		'function'() {
 			const foo = () => {};
 			const bar = () => {};
-			let result = diff('myProperty', DiffType.AUTO, foo, bar);
+			let result = diff.auto(foo, bar);
 			assert.equal(result.value, bar);
 			assert.isFalse(result.changed);
 		},
@@ -119,35 +91,25 @@ registerSuite({
 			const bar = {
 				bar: 'bar'
 			};
-			let result = diff('myProperty', DiffType.AUTO, foo, bar);
+			let result = diff.auto(foo, bar);
 			assert.equal(result.value, bar);
 			assert.isFalse(result.changed);
 
 			bar.bar = 'qux';
-			result = diff('myProperty', DiffType.AUTO, foo, bar);
+			result = diff.auto(foo, bar);
 			assert.equal(result.value, bar);
 			assert.isTrue(result.changed);
 		},
 		'other'() {
 			const foo = new Date();
-			let result = diff('myProperty', DiffType.AUTO, foo, foo);
+			let result = diff.auto(foo, foo);
 			assert.equal(result.value, foo);
 			assert.isFalse(result.changed);
 
 			const bar = new Date();
-			result = diff('myProperty', DiffType.AUTO, foo, bar);
+			result = diff.auto(foo, bar);
 			assert.equal(result.value, bar);
 			assert.isTrue(result.changed);
 		}
-	},
-	'fall-thru'() {
-		const warn = stub(console, 'warn');
-		const NONTYPE = 20;
-		const foo = {};
-		const result = diff('myProperty', NONTYPE, foo, foo);
-		warn.restore();
-		assert.equal(result.value, foo);
-		assert.isTrue(result.changed);
-		assert.isTrue(warn.calledWith(`no valid DiffType provided, will mark property 'myProperty' as changed`));
 	}
 });

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -11,16 +11,10 @@ class TestWithRegistry extends RegistryMixin(WidgetBase)<RegistryMixinProperties
 	private _changedKeys: string[];
 	constructor() {
 		super();
-		this.on('properties:changed', (evt) => {
-			this._changedKeys = evt.changedPropertyKeys;
-		});
 	}
 	__setProperties__(properties: any) {
 		this._changedKeys = [];
 		super.__setProperties__(properties);
-	}
-	getChangedKeys() {
-		return this._changedKeys;
 	}
 	getRegistries() {
 		return this.registries;
@@ -36,7 +30,6 @@ registerSuite({
 			const add = spy(widget.getRegistries(), 'add');
 			widget.__setProperties__({ registry });
 			assert.isTrue(add.calledWith(registry));
-			assert.deepEqual(widget.getChangedKeys(), [ 'registry' ]);
 		},
 		'replaces registry and marks as changed when different to previous registry'() {
 			const widget = new TestWithRegistry();
@@ -49,7 +42,6 @@ registerSuite({
 
 			widget.__setProperties__({ registry: newRegistry });
 			assert.isTrue(replace.calledWith(registry, newRegistry));
-			assert.deepEqual(widget.getChangedKeys(), [ 'registry' ]);
 		}
 	},
 	integration: {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR changes the `diffProperty` decorator to add the concept of a reaction callback that is registered by using the decorator at a class method level. 

Diff functions are now passed via the second argument of the decorator and are required to **pure functions** with no side affects.

```ts
@diffProperty('foo', diffFunction)
class MyWidget extends WidgetBase {}
```

When the decorator is used at a method level it will register the function as the reaction callback that is called when one or more of the defined properties are considered changed. The function receives the previous and new properties for the registered keys.

```ts
class MyWidget extends WidgetBase {
    @diffProperty('foo', diffFunction)
    protected onFooChanged(previousProperties: any, newProperties: any): void {
        // do something when foo is considered changed by the function passed i.e. `diffFunction`
        // the previous and new foo value is available on the function arguments.
    }
}
```

This is the function that should be used to apply custom logic based on property changes and replaced the existing `onPropertiesChanged` catch all decorator.

**Note:** `onPropertiesChanged` decorator has been removed as part of these changes.

Resolves #579
