### PR TITLE
Remove events for properties and children changes

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -296,24 +296,6 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 export type DNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterface> = HNode | WNode<W> | string | null | undefined;
 
 /**
- * the event emitted on properties:changed
- */
-export interface PropertiesChangeEvent<T, P extends WidgetProperties> extends EventTypedObject<'properties:changed'> {
-	/**
-	 * the full set of properties
-	 */
-	properties: P;
-	/**
-	 * the changed properties between setProperty calls
-	 */
-	changedPropertyKeys: string[];
-	/**
-	 * the target (this)
-	 */
-	target: T;
-}
-
-/**
  * Property Change record for specific property diff functions
  */
 export interface PropertyChangeRecord {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -162,11 +162,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this._boundDoRender = this._doRender.bind(this);
 			this._boundRender = this.__render__.bind(this);
-
-			this.own(this.on('widget:children', this.invalidate));
-			this.own(this.on('properties:changed', () => {
-				this.scheduleRender();
-			}));
 			this.own(this.on('invalidated', this.scheduleRender));
 
 			this.root = document.body;
@@ -299,6 +294,11 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 				}
 			}
 			return result;
+		}
+
+		protected invalidate(): void {
+			super.invalidate();
+			this.scheduleRender();
 		}
 
 		private _doRender() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -717,7 +717,7 @@ registerSuite({
 
 		assert.isTrue(maquetteProjectorStopSpy.calledOnce);
 	},
-	'scheduleRender on properties:changed'() {
+	'scheduleRender on setting properties'() {
 		const projector = new BaseTestWidget();
 		const scheduleRender = spy(projector, 'scheduleRender');
 		projector.setProperties({ foo: 'hello' });
@@ -748,15 +748,10 @@ registerSuite({
 	},
 	'invalidate on setting children'() {
 		const projector = new BaseTestWidget();
-		let called = false;
-
-		projector.on('invalidated', () => {
-			called = true;
-		});
+		const scheduleRender = spy(projector, 'scheduleRender');
 
 		projector.setChildren([ v('div') ]);
-
-		assert.isTrue(called);
+		assert.isTrue(scheduleRender.called);
 	},
 	'invalidate before attached'() {
 		const projector: any = new BaseTestWidget();

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -272,24 +272,6 @@ registerSuite({
 				[ testTheme2.testPath1.class1 ]: true,
 				[ baseThemeClasses1.class2 ]: true
 			});
-		},
-		'will not regenerate theme classes if theme changed property is not set'() {
-			themeableInstance = new TestWidget();
-			themeableInstance.__setProperties__({ theme: testTheme1 });
-			themeableInstance.emit({
-				type: 'properties:changed',
-				properties: {
-					theme: testTheme2
-				},
-				changedPropertyKeys: [ 'id' ]
-			});
-
-			const { class1, class2 } = baseThemeClasses1;
-			const flaggedClasses = themeableInstance.classes(class1, class2).get();
-			assert.deepEqual(flaggedClasses, {
-				[ testTheme1.testPath1.class1 ]: true,
-				[ baseThemeClasses1.class2 ]: true
-			}, 'theme2 classes should not be present');
 		}
 	},
 	'setting override classes': {
@@ -439,15 +421,9 @@ registerSuite({
 		},
 		'setting the theme invalidates all "Themeable" widgets and the new theme is used'() {
 			const themeInjectorContext = registerThemeInjector(testTheme1, testRegistry);
-			let invalidateCallCount = 0;
 			class InjectedTheme extends TestWidget {
 				render() {
 					return v('div', { classes: this.classes(baseThemeClasses1.class1) });
-				}
-
-				invalidate() {
-					invalidateCallCount++;
-					super.invalidate();
 				}
 			}
 
@@ -466,19 +442,16 @@ registerSuite({
 			assert.lengthOf(vNode.children, 2);
 			assert.deepEqual(vNode.children[0].properties.classes, { theme1Class1: true });
 			assert.deepEqual(vNode.children[1].properties.classes, { theme1Class1: true });
-			assert.strictEqual(invalidateCallCount, 0);
 			themeInjectorContext.set(testTheme2);
 			vNode = testWidget.__render__();
 			assert.lengthOf(vNode.children, 2);
 			assert.deepEqual(vNode.children[0].properties.classes, { theme1Class1: false, theme2Class1: true });
 			assert.deepEqual(vNode.children[1].properties.classes, { theme1Class1: false, theme2Class1: true });
-			assert.strictEqual(invalidateCallCount, 2);
 			themeInjectorContext.set(testTheme1);
 			vNode = testWidget.__render__();
 			assert.lengthOf(vNode.children, 2);
 			assert.deepEqual(vNode.children[0].properties.classes, { theme2Class1: false, theme1Class1: true });
 			assert.deepEqual(vNode.children[1].properties.classes, { theme2Class1: false, theme1Class1: true });
-			assert.strictEqual(invalidateCallCount, 4);
 		},
 		'registerThemeInjector defaults to the global registry'() {
 			assert.isNull(registry.get(INJECTED_THEME_KEY));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Eventing for properties and children changes are not required. Replacing the listeners on these events by calling `scheduleRender` on invalidate and calling invalidate within the `__setProperties__` and `__setChlildren__` calls.

Resolves #589 
