### PR TITLE
Enable Injector to work with Widgets the use local registries and meta

### DIFF
--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -12,6 +12,7 @@ import {
 	DNode,
 	WidgetProperties
 } from './interfaces';
+import RegistryHandler from './RegistryHandler';
 
 export interface GetProperties {
 	<C, P extends WidgetProperties>(inject: C, properties: P): any;
@@ -65,7 +66,7 @@ export class Context<T = any> extends Evented {
 }
 
 export interface InjectorProperties extends WidgetProperties {
-	scope: any;
+	scope: WidgetBase;
 	render(): DNode;
 	getProperties?: GetProperties;
 	properties: any;
@@ -130,6 +131,10 @@ export function Injector<C extends Evented, T extends Constructor<BaseInjector<C
 			}
 
 			return render();
+		}
+
+		public get registries(): RegistryHandler {
+			return this.properties.scope.registries;
 		}
 	}
 	return Injector;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -244,18 +244,10 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 				}
 			});
 			this._requiredNodes.clear();
-			return renderFunc();
+			const dNodes = renderFunc();
+			this._nodeMap.clear();
+			return dNodes;
 		};
-	}
-
-	/**
-	 * A render decorator that clears the node map used
-	 * by 'meta' calls in this render.
-	 */
-	@afterRender()
-	clearNodeMap(node: DNode | DNode[]): DNode | DNode[] {
-		this._nodeMap.clear();
-		return node;
 	}
 
 	/**
@@ -558,7 +550,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		});
 	}
 
-	protected get registries(): RegistryHandler {
+	public get registries(): RegistryHandler {
 		return this._registries;
 	}
 
@@ -622,7 +614,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			let child: WidgetBaseInterface<WidgetProperties>;
 
 			if (!isWidgetBaseConstructor(widgetConstructor)) {
-				const item = this._registries.get(widgetConstructor);
+				const item = this.registries.get(widgetConstructor);
 				if (item === null) {
 					return null;
 				}

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -11,9 +11,7 @@ class TestInjector extends BaseInjector {
 	}
 }
 
-const bind = {
-	foo: 'bar'
-};
+const bind = new WidgetBase();
 
 registerSuite({
 	name: 'Injector',
@@ -85,7 +83,7 @@ registerSuite({
 
 		const injector = new InjectorWidget();
 		injector.__setProperties__({
-			scope: context,
+			scope: bind,
 			render,
 			properties: testProperties,
 			children: testChildren

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1488,7 +1488,7 @@ registerSuite({
 		const testWidget = new TestWidget();
 		const testWidget2 = new TestWidget2();
 
-		assert.equal(testWidget.getAfterRenders().length, 4);
-		assert.equal(testWidget2.getAfterRenders().length, 5);
+		assert.equal(testWidget.getAfterRenders().length, 3);
+		assert.equal(testWidget2.getAfterRenders().length, 4);
 	}
 });

--- a/tests/unit/meta/Dimensions.ts
+++ b/tests/unit/meta/Dimensions.ts
@@ -6,6 +6,7 @@ import { v } from '../../../src/d';
 import { ProjectorMixin } from '../../../src/main';
 import Dimensions from '../../../src/meta/Dimensions';
 import { WidgetBase } from '../../../src/WidgetBase';
+import { ThemeableMixin } from './../../../src/mixins/Themeable';
 
 let rAF: any;
 
@@ -30,7 +31,7 @@ registerSuite({
 	'dimensions are correctly configured'(this: any) {
 		const dimensions: any[] = [];
 
-		class TestWidget extends ProjectorMixin(WidgetBase)<any> {
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase))<any> {
 			render() {
 				dimensions.push(this.meta(Dimensions).get('root'));
 				return v('div', {
@@ -77,7 +78,7 @@ registerSuite({
 	},
 
 	'dimensions has returns false for keys that dont exist'(this: any) {
-		class TestWidget extends ProjectorMixin(WidgetBase)<any> {
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase))<any> {
 			render() {
 				this.meta(Dimensions);
 
@@ -103,7 +104,7 @@ registerSuite({
 	},
 
 	'dimensions has returns true for keys that exist'(this: any) {
-		class TestWidget extends ProjectorMixin(WidgetBase)<any> {
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase))<any> {
 			render() {
 				this.meta(Dimensions);
 

--- a/tests/unit/meta/meta.ts
+++ b/tests/unit/meta/meta.ts
@@ -6,6 +6,9 @@ import { ProjectorMixin } from '../../../src/main';
 import { Base as MetaBase } from '../../../src/meta/Base';
 import { WidgetBase } from '../../../src/WidgetBase';
 import { stub } from 'sinon';
+import { ThemeableMixin } from './../../../src/mixins/Themeable';
+
+class TestWidgetBase<P = any> extends ThemeableMixin(WidgetBase)<P> {}
 
 let rAF: any;
 
@@ -28,7 +31,7 @@ registerSuite({
 		class TestMeta extends MetaBase {
 		}
 
-		class TestWidget extends ProjectorMixin(WidgetBase)<any> {
+		class TestWidget extends ProjectorMixin(TestWidgetBase)<any> {
 			render() {
 				return v('div', {
 					innerHTML: 'hello world',
@@ -52,7 +55,7 @@ registerSuite({
 		class TestMeta extends MetaBase {
 		}
 
-		class TestWidget extends ProjectorMixin(WidgetBase) {
+		class TestWidget extends ProjectorMixin(TestWidgetBase) {
 			render() {
 				return v('div', {
 					innerHTML: 'hello world',
@@ -79,7 +82,7 @@ registerSuite({
 
 		let renders = 0;
 
-		class TestWidget extends ProjectorMixin(WidgetBase) {
+		class TestWidget extends ProjectorMixin(TestWidgetBase) {
 			nodes: any;
 
 			render() {
@@ -115,7 +118,7 @@ registerSuite({
 
 		let renders = 0;
 
-		class TestWidget extends ProjectorMixin(WidgetBase) {
+		class TestWidget extends ProjectorMixin(TestWidgetBase) {
 			nodes: any;
 
 			render() {
@@ -133,7 +136,7 @@ registerSuite({
 					}, [
 						test.has('name') ? v('div', {
 							innerHTML: '!',
-							key: 'exclmation'
+							key: 'exclamation'
 						}) : null
 					]) : null
 				]);
@@ -155,7 +158,7 @@ registerSuite({
 
 		let renders = 0;
 
-		class TestWidget extends ProjectorMixin(WidgetBase) {
+		class TestWidget extends ProjectorMixin(TestWidgetBase) {
 			nodes: any;
 
 			render() {

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -6,8 +6,9 @@ import { RegistryMixin, RegistryMixinProperties } from '../../../src/mixins/Regi
 import { WidgetBase } from '../../../src/WidgetBase';
 import WidgetRegistry from '../../../src/WidgetRegistry';
 import { spy } from 'sinon';
+import { ThemeableMixin } from './../../../src/mixins/Themeable';
 
-class TestWithRegistry extends RegistryMixin(WidgetBase)<RegistryMixinProperties> {
+class TestWithRegistry extends RegistryMixin(ThemeableMixin(WidgetBase))<RegistryMixinProperties> {
 	private _changedKeys: string[];
 	constructor() {
 		super();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Attempt to enable use of Injectors to be used in a `@beforeRender()` with `meta` and local registries.

Resolves #595 
