### PR TITLE
Cannot warn or use the previous DNodes when a supported DNode type of `undefined` is returned.

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -587,12 +587,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		const afterRenders = this.getDecorator('afterRender');
 
 		return afterRenders.reduce((dNode: DNode | DNode[], afterRenderFunction: AfterRender) => {
-			const updatedDNode = afterRenderFunction.call(this, dNode);
-			if (!updatedDNode) {
-				console.warn('DNodes not returned from afterRender, using existing dNodes');
-				return dNode;
-			}
-			return updatedDNode;
+			return  afterRenderFunction.call(this, dNode);
 		}, dNode);
 	}
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -777,23 +777,6 @@ registerSuite({
 			const widget = new TestWidget();
 			widget.__render__();
 			assert.strictEqual(afterRenderCount, 1);
-		},
-		'Use previous DNodes when an afterRender does not return DNodes'() {
-			class TestWidget extends WidgetBase {
-				@afterRender()
-				protected firstBeforeRender(dNode: DNode | DNode[]) {
-					return 'first render';
-				}
-
-				@afterRender()
-				protected secondBeforeRender(dNode: DNode | DNode[]) { }
-			}
-
-			const widget = new TestWidget();
-			const vNode = <VNode> widget.__render__();
-			assert.strictEqual(vNode, 'first render');
-			assert.isTrue(consoleStub.calledOnce);
-			assert.isTrue(consoleStub.calledWith('DNodes not returned from afterRender, using existing dNodes'));
 		}
 	},
 	'extendable'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

It was fine to warn when `undefined` was not a supported `DNode` value but now that `undefined` is a supported type, we cannot warn or automatically replace with the previous value.

Resolves #585 
