### PR TITLE
Support original `afterRenders` when replacing render with an `Injector`

### DIFF
--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -1,7 +1,6 @@
 import { assign } from '@dojo/core/lang';
 import { Evented } from '@dojo/core/Evented';
 import {
-	afterRender,
 	diffProperty,
 	WidgetBase
 } from './WidgetBase';
@@ -67,7 +66,7 @@ export class Context<T = any> extends Evented {
 
 export interface InjectorProperties extends WidgetProperties {
 	scope: WidgetBase;
-	render(): DNode;
+	render(): DNode | DNode[];
 	getProperties?: GetProperties;
 	properties: any;
 	getChildren?: GetChildren;
@@ -104,8 +103,7 @@ export function Injector<C extends Evented, T extends Constructor<BaseInjector<C
 			super(context);
 		}
 
-		@afterRender()
-		protected decorateBind(node: DNode): DNode {
+		protected decorateBind(node: DNode | DNode[]): DNode | DNode[] {
 			const { scope } = this.properties;
 			decorate(node, (node: any) => {
 				const { properties } = node;
@@ -115,7 +113,7 @@ export function Injector<C extends Evented, T extends Constructor<BaseInjector<C
 			return node;
 		}
 
-		protected render(): DNode {
+		protected render(): DNode | DNode[] {
 			const {
 				render,
 				properties,
@@ -130,11 +128,15 @@ export function Injector<C extends Evented, T extends Constructor<BaseInjector<C
 				children.push(...injectedChildren);
 			}
 
-			return render();
+			return this.decorateBind(render());
 		}
 
-		public get registries(): RegistryHandler {
-			return this.properties.scope.registries;
+		protected getRegistries(): RegistryHandler {
+			return super.getRegistries.call(this.properties.scope);
+		}
+
+		protected runAfterRenders(dNode: DNode | DNode[]): DNode | DNode[] {
+			return super.runAfterRenders.call(this.properties.scope, dNode);
 		}
 	}
 	return Injector;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -385,7 +385,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			this._dirty = false;
 			const render = this._runBeforeRenders();
 			let dNode = render();
-			dNode = this._runAfterRenders(dNode);
+			dNode = this.runAfterRenders(dNode);
 			const widget = this._dNodeToVNode(dNode);
 			this._manageDetachedChildren();
 			if (widget) {
@@ -538,7 +538,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		});
 	}
 
-	public get registries(): RegistryHandler {
+	protected getRegistries(): RegistryHandler {
 		return this._registries;
 	}
 
@@ -563,11 +563,11 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	 *
 	 * @param dNode The DNodes to run through the after renders
 	 */
-	private _runAfterRenders(dNode: DNode | DNode[]): DNode | DNode[] {
+	protected runAfterRenders(dNode: DNode | DNode[]): DNode | DNode[] {
 		const afterRenders = this.getDecorator('afterRender');
 
 		return afterRenders.reduce((dNode: DNode | DNode[], afterRenderFunction: AfterRender) => {
-			return  afterRenderFunction.call(this, dNode);
+			return afterRenderFunction.call(this, dNode);
 		}, dNode);
 	}
 
@@ -597,7 +597,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			let child: WidgetBaseInterface<WidgetProperties>;
 
 			if (!isWidgetBaseConstructor(widgetConstructor)) {
-				const item = this.registries.get(widgetConstructor);
+				const item = this.getRegistries().get(widgetConstructor);
 				if (item === null) {
 					return null;
 				}

--- a/src/mixins/Registry.ts
+++ b/src/mixins/Registry.ts
@@ -16,9 +16,9 @@ export function RegistryMixin<T extends Constructor<WidgetBase<any>>>(Base: T): 
 
 		@diffProperty('registry', reference)
 		protected diffPropertyRegistry(previousProperties: any, newProperties: any): void {
-			const result = this.registries.replace(previousProperties.registry, newProperties.registry);
+			const result = this.getRegistries().replace(previousProperties.registry, newProperties.registry);
 			if (!result) {
-				this.registries.add(newProperties.registry);
+				this.getRegistries().add(newProperties.registry);
 			}
 		}
 	}

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -230,7 +230,7 @@ export function ThemeableMixin<T extends Constructor<WidgetBase<any>>>(Base: T):
 		@beforeRender()
 		protected injectTheme(renderFunc: () => DNode, properties: ThemeableProperties, children: DNode[]): () => DNode {
 			return () => {
-				const hasInjectedTheme = this.registries.has(INJECTED_THEME_KEY);
+				const hasInjectedTheme = this.getRegistries().has(INJECTED_THEME_KEY);
 				if (hasInjectedTheme) {
 					return w<BaseInjector>(INJECTED_THEME_KEY, {
 						scope: this,

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -796,7 +796,7 @@ registerSuite({
 			class TestWidget extends WidgetBase<any> {
 				constructor() {
 					super();
-					this.registries.add(localRegistry);
+					this.getRegistries().add(localRegistry);
 				}
 				render() {
 					return v('div', [
@@ -923,7 +923,7 @@ registerSuite({
 			class TestWidget extends WidgetBase<any> {
 				constructor() {
 					super();
-					this.registries.add(registry);
+					this.getRegistries().add(registry);
 				}
 
 				render() {

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -10,7 +10,7 @@ import { fetchCldrData } from '../../support/util';
 import { w } from './../../../src/d';
 import { ThemeableMixin } from './../../../src/mixins/Themeable';
 
-class Localized extends I18nMixin(ThemeableMixin(WidgetBase))<I18nProperties & { foo?: string }> { }
+class Localized extends I18nMixin(ThemeableMixin(WidgetBase))<I18nProperties> { }
 
 let localized: any;
 

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -8,8 +8,9 @@ import { WidgetBase } from '../../../src/WidgetBase';
 import bundle from '../../support/nls/greetings';
 import { fetchCldrData } from '../../support/util';
 import { w } from './../../../src/d';
+import { ThemeableMixin } from './../../../src/mixins/Themeable';
 
-class Localized extends I18nMixin(WidgetBase)<I18nProperties> {}
+class Localized extends I18nMixin(ThemeableMixin(WidgetBase))<I18nProperties & { foo?: string }> { }
 
 let localized: any;
 

--- a/tests/unit/mixins/Registry.ts
+++ b/tests/unit/mixins/Registry.ts
@@ -18,7 +18,7 @@ class TestWithRegistry extends RegistryMixin(ThemeableMixin(WidgetBase))<Registr
 		super.__setProperties__(properties);
 	}
 	getRegistries() {
-		return this.registries;
+		return super.getRegistries();
 	}
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Further support in `WidgetBase` and `Injector` to enable correct `afterRenders` to be executed when the original `DNode`s are returned from the `render` function passed to the `Injector`.

Breaking change as updated `this.registries` to `this.getRegistries()` so that `Injector` can override and call the `super.getRegistries()` with the original widgets scope passed as the properties.

Resolves #600
