### PR TITLE
Type theme property

### DIFF
--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -24,11 +24,18 @@ export type ClassNames = {
 };
 
 /**
+ * A lookup object for available widget classes names
+ */
+export interface Theme {
+	[key: string]: ClassNames;
+}
+
+/**
  * Properties required for the themeable mixin
  */
 export interface ThemeableProperties extends WidgetProperties {
 	injectedTheme?: any;
-	theme?: any;
+	theme?: Theme;
 	extraClasses?: any;
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The `theme` property is typed as `any` when it could be typed as an index.  This would prevent people from accidentally assigning themes that are not valid.  I tried to type `injectedTheme` but there appears to be, likely, a code logic issue in that `Themeable._theme` is typed as `ClassNames` but there is also a comparison of `theme !== injectedTheme` in the code, which means that we are likely mis-handling something somewhere, but we should try to type `injectedTheme` and `extraClasses` with something that is more narrow than `any` as it is just too prone to downstream errors.