### PR TITLE
Support property type guards for 'setProperties' on the ProjectorMixin

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -6,7 +6,7 @@ import { VNode } from '@dojo/interfaces/vdom';
 import { dom, h, Projection, ProjectionOptions } from 'maquette';
 import 'pepjs';
 import cssTransitions from '../animations/cssTransitions';
-import { Constructor, DNode, WidgetProperties } from './../interfaces';
+import { Constructor, DNode } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
 import eventHandlerInterceptor from '../util/eventHandlerInterceptor';
 

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -41,7 +41,9 @@ export interface AttachOptions {
 	root?: Element;
 }
 
-export interface ProjectorMixin<P extends WidgetProperties> {
+export interface ProjectorMixin<P> {
+
+	readonly properties: Readonly<P>;
 
 	/**
 	 * Append the projector to the root.
@@ -94,7 +96,7 @@ export interface ProjectorMixin<P extends WidgetProperties> {
 	 *
 	 * @param properties The new widget properties
 	 */
-	setProperties(properties: P & { [index: string]: any }): void;
+	setProperties(properties: this['properties']): void;
 
 	/**
 	 * Sets the widget's children
@@ -148,7 +150,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		private _boundDoRender: () => void;
 		private _boundRender: Function;
 		private _projectorChildren: DNode[];
-		private _projectorProperties: P;
+		private _projectorProperties: this['properties'];
 		private _rootTagName: string;
 		private _attachType: AttachType;
 
@@ -253,7 +255,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			super.__setChildren__(children);
 		}
 
-		public setProperties(properties: P & { [index: string]: any }): void {
+		public setProperties(properties: this['properties']): void {
 			this._projectorProperties = assign({}, properties);
 			super.__setProperties__(properties);
 		}

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -717,15 +717,28 @@ registerSuite({
 
 		assert.isTrue(maquetteProjectorStopSpy.calledOnce);
 	},
+	'setProperties guards against original property interface'() {
+		interface Props {
+			foo: string;
+		}
+
+		class TestClass extends WidgetBase<Props> {}
+		const ProjectorClass = ProjectorMixin(TestClass);
+		const projector = new ProjectorClass();
+		projector.setProperties({ foo: 'f' });
+		// Demonstrates the type guarding for widget properties
+
+		// projector.setProperties({ foo: true });
+	},
 	'scheduleRender on setting properties'() {
 		const projector = new BaseTestWidget();
 		const scheduleRender = spy(projector, 'scheduleRender');
-		projector.setProperties({ foo: 'hello' });
+		projector.setProperties({ key: 'hello' });
 		assert.isTrue(scheduleRender.called);
 	},
 	'properties are reset to original state on render'() {
 		const testProperties = {
-			foo: 'bar'
+			key: 'bar'
 		};
 		const testChildren = [ v('div') ];
 		class TestWidget extends BaseTestWidget {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support to type guarding of properties for the `ProjectorMixin` when using `setProperties`.

Resolves #613
