### PR TITLE
Adding deferred properties

### DIFF
--- a/tests/functional/support/deferredProperties.html
+++ b/tests/functional/support/deferredProperties.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../../../../node_modules/@dojo/loader/loader.js"></script>
+	<style type="text/css">
+		.accordion ul {
+			padding: 0;
+			margin: 0;
+			list-style-type: none;
+		}
+
+		.accordion ul li {
+			padding: 0;
+			margin: 0;
+			border: 1px solid black;
+			border-radius: 5px;
+		}
+
+		.accordion ul li .title {
+			padding: 7px 14px;
+			border-bottom: 1px solid black;
+			background-color: #dedede;
+			cursor: pointer;
+		}
+
+		.accordion ul li .content {
+			overflow: hidden;
+		}
+
+		.accordion ul li .content .padded {
+			padding: 13px;
+		}
+
+		.accordion ul li.selected .content {
+		}
+	</style>
+</head>
+<body>
+	<div id="content-area"></div>
+	<div>
+		<br/><br/><br/>
+		<button id="change-button">Update panels</button>
+	</div>
+
+<script>
+    require.config({
+        packages: [
+            { name: '@dojo', location: '../../../../../node_modules/@dojo' },
+            { name: 'maquette', location: '../../../../../node_modules/maquette/dist', main: 'maquette' },
+            { name: 'pepjs', location: '../../../../../node_modules/pepjs/dist', main: 'pep' }
+        ]
+    });
+
+    require(['./deferredProperties'], function() {
+    });
+</script>
+</body>
+</html>

--- a/tests/functional/support/deferredProperties.ts
+++ b/tests/functional/support/deferredProperties.ts
@@ -1,0 +1,183 @@
+import { v, w } from '../../../src/d';
+import { DNode, WidgetProperties } from '../../../src/interfaces';
+import { ProjectorMixin } from '../../../src/mixins/Projector';
+import { asyncProperty, diffProperty, WidgetBase } from '../../../src/WidgetBase';
+import { Base as MetaBase } from '../../../src/meta/Base';
+import { Dimensions } from '../../../src/meta/Dimensions';
+import { auto } from '../../../src/diff';
+
+interface AccordionProperties extends WidgetProperties {
+	panels: {
+		label: string;
+		node: DNode;
+	}[];
+}
+
+interface AccordionPanelProperties extends WidgetProperties {
+	title: string;
+	content: DNode;
+	index: number;
+	selected: boolean;
+	onClick: (index: number) => void;
+}
+
+class Animation extends MetaBase {
+	animate(key: string, animations: any[], duration = 500) {
+		this.requireNode(key);
+
+		const node = this.nodes.get(key);
+
+		if (node) {
+			(<any> node).animate(animations, {duration});
+		}
+	}
+}
+
+class AccordionPanel extends WidgetBase<AccordionPanelProperties> {
+	private _heightCache: number | undefined = undefined;
+
+	private _onClick() {
+		const {onClick, index} = this.properties;
+
+		onClick && onClick(index);
+	}
+
+	@diffProperty('selected', auto)
+	protected _selectedChanged(previousProperties: AccordionPanelProperties, newProperties: AccordionPanelProperties) {
+		const { selected: newSelected = false } = newProperties;
+		const { selected: oldSelected = false } = previousProperties;
+		const { index } = this.properties;
+		const contentKey = `content-${index}`;
+		const contentHeight = this._heightCache;
+
+		if (contentHeight !== undefined) {
+			if (!oldSelected && newSelected) {
+				this.meta(Animation).animate(contentKey, [
+					{height: 0},
+					{height: contentHeight + 'px'}
+				], 250);
+			} else if (oldSelected && !newSelected) {
+				this.meta(Animation).animate(contentKey, [
+					{height: contentHeight + 'px'},
+					{height: 0}
+				], 250);
+			}
+		}
+	}
+
+	render() {
+		const {selected, title, content, index} = this.properties;
+		const contentKey = `content-${index}`;
+
+		return v('li', {key: `panel-${index}`, 'classes': {selected: selected}}, [
+			v('div', {'class': 'title', onclick: this._onClick}, [title]),
+			v('div', {
+				'class': 'content',
+				key: contentKey,
+				styles: {
+					height: asyncProperty(() => {
+						let height = this._heightCache;
+
+						if (height === undefined) {
+							const dim = this.meta(Dimensions).get(contentKey);
+							height = dim.size.height;
+							this._heightCache = height;
+						}
+
+						return (selected ? height : 0) + 'px';
+					})
+				}
+			}, [v('div', { 'class': 'padded' }, [content])])
+		]);
+	}
+}
+
+class Accordion extends WidgetBase<AccordionProperties> {
+	private _selectedPanel = 0;
+	private _indexBase = 0;
+
+	private _onPanelTitleClick = (index: number) => {
+		this._selectedPanel = index - this._indexBase;
+		this.invalidate();
+	}
+
+	@diffProperty('panels', auto)
+	protected _onPanelsUpdated(previousProperties: AccordionProperties) {
+		this._indexBase += (previousProperties.panels || []).length;
+		this._selectedPanel = 0;
+	}
+
+	render() {
+		return v('div.accordion', [
+			v('ul', [
+					this.properties.panels.map((panel, index) => w(AccordionPanel, {
+						key: `panel-${this._indexBase + index}`,
+						selected: this._selectedPanel === index,
+						index: this._indexBase + index,
+						onClick: this._onPanelTitleClick,
+						title: panel.label,
+						content: panel.node
+					}))
+				]
+			)
+		]);
+	}
+}
+
+const projector = new (ProjectorMixin(Accordion))();
+projector.setProperties({
+	panels: [
+		{
+			label: 'Dummy text',
+			node: v('div', ['panel 1 is awesome! panel 1 is awesome! panel 1 is awesome! panel 1 is awesome! panel 1 is awesome! panel 1 is awesome! panel 1 is awesome!'])
+		},
+		{
+			label: 'I\'ve got a lovely bunch of coconuts',
+			node: v('div', [`Ive got a lovely bunch of coconuts
+There they are, all standing in a row
+Big ones, small ones, some as big as your head
+Give them a twist a flick of the wrist
+Thats what the showman said`])
+		},
+		{
+			label: 'Tip Toe Through the Tuplics',
+			node: v('div', [`Tiptoe through the window
+By the window, that is where I'll be
+Come tiptoe through the tulips with me
+Oh, tiptoe from the garden
+By the garden of the willow tree
+And tiptoe through the tulips with me`])
+		},
+		{
+			label: 'Panelception',
+			node: w(Accordion, {
+				panels: [
+					{
+						label: 'P1',
+						node: v('div', ['Panel 1'])
+					},
+					{
+						label: 'P2',
+						node: v('div', ['Panel 2'])
+					}
+				]
+			})
+		}
+	]
+});
+projector.append(document.getElementById('content-area')!);
+
+document.getElementById('change-button')!.addEventListener('click', () => {
+	projector.setProperties({
+		panels: [
+			{
+				label: 'Herpy Derpy',
+				node: v('div', ['Such pannels, much wow!'])
+			},
+			{
+				label: 'I\'ve got a lovely bunch of coconts',
+				node: v('div', [`fruit loops and butter cups!`])
+			}
+		]
+	});
+});

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1377,7 +1377,7 @@ registerSuite({
 		const testWidget = new TestWidget();
 		const testWidget2 = new TestWidget2();
 
-		assert.equal(testWidget.getAfterRenders().length, 3);
-		assert.equal(testWidget2.getAfterRenders().length, 4);
+		assert.equal(testWidget.getAfterRenders().length, 4);
+		assert.equal(testWidget2.getAfterRenders().length, 5);
 	}
 });


### PR DESCRIPTION
**Type:** feature

**Description:**

Throwing this out here to get some feedback. Currently, deferred properties let you apply styles **after** a virtual node is rendered.

For example, this will create a `div` that is as wide as it is tall:

```typescript
render() {
    return v('div', {
        key: 'root',
        styles: {
            width: asyncProperty(() => {
                const dim = this.meta(Dimensions).get('root');
                return dim.size.height + 'px';
            })
        }
    }, ['some text']);
}
```

Note that the height is calculated on the height of the node _without a `width` style_. Also note that once the property has been applied, you've just fixed the width of the node and subsequent calls will return your first value.

Take a look at the `deferredProperties.html` example to see how it would work in the case of a panel component that animates to show the current panel.