### PR TITLE
Ensure _decoratorCache uses class-level decorators

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -441,7 +441,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			specificDecoratorList.push(...value);
 		}
 		else {
-			const decorators = this._decoratorCache.get(decoratorKey) || [];
+			const decorators = this.getDecorator(decoratorKey);
 			this._decoratorCache.set(decoratorKey, [ ...decorators, ...value ]);
 		}
 	}

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1379,5 +1379,24 @@ registerSuite({
 
 		assert.equal(testWidget.getAfterRenders().length, 3);
 		assert.equal(testWidget2.getAfterRenders().length, 4);
+	},
+	'decorator cache is populated when addDecorator is called after instantiation'() {
+		class TestWidget extends WidgetBase<any> {
+			constructor() {
+				super();
+
+				this.addDecorator('beforeRender', function() {});
+				this.addDecorator('afterRender', function() {});
+			}
+
+			getDecoratorCount(key: string): number {
+				return this.getDecorator(key).length;
+			}
+		}
+
+		const testWidget = new TestWidget();
+
+		assert.equal(testWidget.getDecoratorCount('beforeRender'), 2, '1 beforeRender added to existing 1');
+		assert.equal(testWidget.getDecoratorCount('afterRender'), 3, '1 afterRender added to existing 2');
 	}
 });

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1377,8 +1377,8 @@ registerSuite({
 		const testWidget = new TestWidget();
 		const testWidget2 = new TestWidget2();
 
-		assert.equal(testWidget.getAfterRenders().length, 3);
-		assert.equal(testWidget2.getAfterRenders().length, 4);
+		assert.equal(testWidget.getAfterRenders().length, 1);
+		assert.equal(testWidget2.getAfterRenders().length, 2);
 	},
 	'decorator cache is populated when addDecorator is called after instantiation'() {
 		class TestWidget extends WidgetBase<any> {
@@ -1396,7 +1396,7 @@ registerSuite({
 
 		const testWidget = new TestWidget();
 
-		assert.equal(testWidget.getDecoratorCount('beforeRender'), 2, '1 beforeRender added to existing 1');
-		assert.equal(testWidget.getDecoratorCount('afterRender'), 3, '1 afterRender added to existing 2');
+		assert.equal(testWidget.getDecoratorCount('beforeRender'), 2, 'beforeRender = 1 (existing) + 1');
+		assert.equal(testWidget.getDecoratorCount('afterRender'), 1, 'afterRender = 0 (existing) + 1');
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

addDecorator called at the method level does not use decoratorMap to add class-level decorators to the cache.

Resolves #622 