### PR TITLE
Add Hover meta manager

### DIFF
--- a/src/meta/Hover.ts
+++ b/src/meta/Hover.ts
@@ -1,0 +1,53 @@
+import WeakMap from '@dojo/shim/WeakMap';
+import { Base } from './Base';
+import { WidgetMetaProperties } from '../interfaces';
+
+interface HoverInfo {
+	hovering: boolean;
+}
+
+export default class Hover extends Base {
+	private _hoverInfo: WeakMap<HTMLElement, HoverInfo>;
+
+	constructor(properties: WidgetMetaProperties) {
+		super(properties);
+		this._hoverInfo = new WeakMap();
+	}
+
+	/**
+	 * Returns `true` if the mouse is hovering over the node, identified by `key`, otherwise returns `false`
+	 * @param key The key of the node that the hover information is required for
+	 */
+	public get(key: string): boolean {
+		this.requireNode(key);
+
+		const node = this.nodes.get(key);
+
+		if (!node) {
+			return false;
+		}
+
+		let hoverInfo = this._hoverInfo.get(node);
+
+		if (!hoverInfo) {
+			hoverInfo = { hovering: false };
+			this._hoverInfo.set(node, hoverInfo);
+			node.addEventListener('mouseenter', () => {
+				// Issue with CFA and function scope (see: Microsoft/TypeScript#17449), using non null assertion
+				if (!hoverInfo!.hovering) {
+					hoverInfo!.hovering = true;
+					this.invalidate();
+				}
+			});
+			node.addEventListener('mouseleave', () => {
+				// Issue with CFA and function scope (see: Microsoft/TypeScript#17449), using non null assertion
+				if (hoverInfo!.hovering) {
+					hoverInfo!.hovering = false;
+					this.invalidate();
+				}
+			});
+		}
+
+		return hoverInfo.hovering;
+	}
+}

--- a/tests/support/sendEvent.ts
+++ b/tests/support/sendEvent.ts
@@ -1,0 +1,153 @@
+import has, { add as hasAdd } from '@dojo/core/has';
+import { deepAssign } from '@dojo/core/lang';
+import global from '@dojo/shim/global';
+import { assign } from '@dojo/shim/object';
+
+hasAdd('customevent-constructor', () => {
+	try {
+		new global.window.CustomEvent('foo');
+		return true;
+	}
+	catch (e) {
+		return false;
+	}
+});
+
+export type EventClass =
+	'AnimationEvent' |
+	'AudioProcessingEvent' |
+	'BeforeInputEvent' |
+	'BeforeUnloadEvent' |
+	'BlobEvent' |
+	'ClipboardEvent' |
+	'CloseEvent' |
+	'CompositionEvent' |
+	'CSSFontFaceLoadEvent' |
+	'CustomEvent' |
+	'DeviceLightEvent' |
+	'DeviceMotionEvent' |
+	'DeviceOrientationEvent' |
+	'DeviceProximityEvent' |
+	'DOMTransactionEvent' |
+	'DragEvent' |
+	'EditingBeforeInputEvent' |
+	'ErrorEvent' |
+	'FetchEvent' |
+	'FocusEvent' |
+	'GamepadEvent' |
+	'HashChangeEvent' |
+	'IDBVersionChangeEvent' |
+	'InputEvent' |
+	'KeyboardEvent' |
+	'MediaStreamEvent' |
+	'MessageEvent' |
+	'MouseEvent' |
+	'MutationEvent' |
+	'OfflineAudioCompletionEvent' |
+	'PageTransitionEvent' |
+	'PointerEvent' |
+	'PopStateEvent' |
+	'ProgressEvent' |
+	'RelatedEvent' |
+	'RTCDataChannelEvent' |
+	'RTCIdentityErrorEvent' |
+	'RTCIdentityEvent' |
+	'RTCPeerConnectionIceEvent' |
+	'SensorEvent' |
+	'StorageEvent' |
+	'SVGEvent' |
+	'SVGZoomEvent' |
+	'TimeEvent' |
+	'TouchEvent' |
+	'TrackEvent' |
+	'TransitionEvent' |
+	'UIEvent' |
+	'UserProximityEvent' |
+	'WebGLContextEvent' |
+	'WheelEvent';
+
+export interface SendEventOptions<I extends EventInit> {
+	/**
+	 * The event class to use to create the event, defaults to `CustomEvent`
+	 */
+	eventClass?: EventClass;
+
+	/**
+	 * An object which is used to initialise the event
+	 */
+	eventInit?: I;
+
+	/**
+	 * A CSS selector string, used to query the target to identify the element to
+	 * dispatch the event to
+	 */
+	selector?: string;
+}
+
+export interface EventInitializer {
+	(type: string, bubbles: boolean, cancelable: boolean, detail: any): void;
+}
+
+/**
+ * Create and dispatch an event to an element
+ * @param type The event type to dispatch
+ * @param options A map of options to configure the event
+ */
+export default function sendEvent<I extends EventInit>(target: Element, type: string, options?: SendEventOptions<I>): void {
+
+	function dispatchEvent(target: Element, event: Event) {
+		let error: Error | undefined;
+
+		function catcher(e: ErrorEvent) {
+			e.preventDefault();
+			error = e.error;
+			return true;
+		}
+
+		window.addEventListener('error', catcher);
+		target.dispatchEvent(event);
+		window.removeEventListener('error', catcher);
+		if (error) {
+			throw error;
+		}
+	}
+
+	const {
+		eventClass = 'CustomEvent',
+		eventInit = {} as EventInit,
+		selector = ''
+	} = options || {};
+	let event: CustomEvent;
+	assign(eventInit, {
+		bubbles: 'bubbles' in eventInit ? eventInit.bubbles : true,
+		cancelable: 'cancelable' in eventInit ? eventInit.cancelable : true
+	});
+	const { bubbles, cancelable, ...initProps } = eventInit;
+	if (has('customevent-constructor')) {
+		const ctorName = eventClass in window ? eventClass : 'CustomEvent';
+		event = new ((<any> window)[ctorName] as typeof CustomEvent)(type, eventInit);
+	}
+	else {
+		/* because the arity varies too greatly to be able to properly call all the event types, we will
+		 * only support CustomEvent for those platforms that don't support event constructors, which is
+		 * essentially IE11 */
+		event = document.createEvent('CustomEvent');
+		(event as CustomEvent).initCustomEvent(type, bubbles!, cancelable!, {});
+	}
+	try {
+		deepAssign(event, initProps);
+	}
+	catch (e) { /* swallowing assignment errors when trying to overwrite native event properties */ }
+	if (selector) {
+		const selectorTarget = target.querySelector(selector);
+		if (selectorTarget) {
+			dispatchEvent(selectorTarget, event);
+		}
+		else {
+			throw new Error(`Cannot resolve to an element with selector "${selector}"`);
+		}
+	}
+	else {
+		dispatchEvent(target, event);
+	}
+}

--- a/tests/unit/meta/Hover.ts
+++ b/tests/unit/meta/Hover.ts
@@ -1,0 +1,144 @@
+import global from '@dojo/shim/global';
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { stub, SinonStub } from 'sinon';
+import sendEvent from '../../support/sendEvent';
+import { v } from '../../../src/d';
+import { ProjectorMixin } from '../../../src/main';
+import Hover from '../../../src/meta/Hover';
+import { WidgetBase } from '../../../src/WidgetBase';
+import { ThemeableMixin } from '../../../src/mixins/Themeable';
+
+let rAF: SinonStub;
+
+function resolveRAF() {
+	for (let i = 0; i < rAF.callCount; i++) {
+		rAF.getCall(i).args[0]();
+	}
+	rAF.reset();
+}
+
+registerSuite({
+	name: 'meta/Hover',
+
+	beforeEach() {
+		rAF = stub(global, 'requestAnimationFrame');
+	},
+
+	afterEach() {
+		rAF.restore();
+	},
+
+	'basic behaviour'() {
+		const hovering: boolean[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				hovering.push(this.meta(Hover).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root'
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		assert.deepEqual(hovering, [ false, false ], 'should have been called twice, both not hovering');
+
+		document.body.removeChild(div);
+	},
+
+	'hovering'() {
+		const hovering: boolean[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				hovering.push(this.meta(Hover).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root'
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		sendEvent(div as Element, 'mouseenter', { selector: ':first-child' });
+
+		resolveRAF();
+
+		assert.deepEqual(hovering, [ false, false, true ]);
+
+		sendEvent(div as Element, 'mouseleave', { selector: ':first-child' });
+
+		resolveRAF();
+
+		assert.deepEqual(hovering, [ false, false, true, false ]);
+
+		document.body.removeChild(div);
+	},
+
+	'only state changes should invalidate'() {
+		const hovering: boolean[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				hovering.push(this.meta(Hover).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root'
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		sendEvent(div as Element, 'mouseenter', { selector: ':first-child' });
+
+		resolveRAF();
+
+		assert.deepEqual(hovering, [ false, false, true ]);
+
+		sendEvent(div as Element, 'mouseenter', { selector: ':first-child' });
+
+		resolveRAF();
+
+		assert.deepEqual(hovering, [ false, false, true ]);
+
+		sendEvent(div as Element, 'mouseleave', { selector: ':first-child' });
+
+		resolveRAF();
+
+		assert.deepEqual(hovering, [ false, false, true, false ]);
+
+		sendEvent(div as Element, 'mouseleave', { selector: ':first-child' });
+
+		resolveRAF();
+
+		assert.deepEqual(hovering, [ false, false, true, false ]);
+
+		document.body.removeChild(div);
+	}
+});

--- a/tests/unit/meta/all.ts
+++ b/tests/unit/meta/all.ts
@@ -1,2 +1,3 @@
 import './meta';
 import './Dimensions';
+import './Hover';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR adds a hover meta manager.  In part is raised to discuss some features of meta to help flesh out some of the architecture as well as provide the ability to detect a hover state in the DOM without having to store that state in the widget.

Usage would be something like:

```ts
class SomeWidget extends ThemeableMixin(WidgetBase) {
  render() {
    return v('div', {
      classes: this.classes(this.meta(Hovering).get('root') && css.hovering),
            key: 'root'
        }, [ 'Hello World!' ]);
  }
}
```

Things to note about the PR, which I think would extend to other DOM meta managers is:

- Currently there is no easy/built-in way of managing some state information related to the actual DOM nodes, the Hover manager has to create that, but I know there is other state information relating it back to a key that is cached in the base class.  We might want to provide some easy mechanism to cache/set state related to the nodes.
- There is no way of managing event handlers.  It is logical that meta managers will want/need to hook event handlers, either at the node level or at some delegate level.  They are easy to create, but it raises lifecycle concerns in my mind and potentially memory leaks.  The Base doesn't inherit from Destroyable so, there is no way to own a destruction handle.  I am not entirely sure there is a concern, but it feels dirty adding things and not cleaning up after myself.

Refs #571
