### PR TITLE
Support default properties

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -187,6 +187,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 
 	private _requiredNodes = new Set<string>();
 
+	public readonly defaultProperties = {};
+
 	/**
 	 * @constructor
 	 */
@@ -323,7 +325,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		this._nodeMap.set(String(properties.key), <HTMLElement> element);
 	}
 
-	public get properties(): Readonly<P> & Readonly<WidgetProperties> {
+	public get properties(): Readonly<P> & Readonly<WidgetProperties> & this['defaultProperties'] {
 		return this._properties;
 	}
 
@@ -362,7 +364,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			}
 		});
 
-		this._properties = diffPropertyResults;
+		this._properties = { ...this.defaultProperties, ...diffPropertyResults };
 
 		if (changedPropertyKeys.length) {
 			this.invalidate();

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -327,10 +327,12 @@ export interface WidgetBaseInterface<
 	P = WidgetProperties,
 	C extends DNode = DNode<DefaultWidgetBaseInterface>> extends Evented {
 
+	readonly defaultProperties: {};
+
 	/**
 	 * Widget properties
 	 */
-	readonly properties: P & WidgetProperties;
+	readonly properties: P & WidgetProperties & this['defaultProperties'];
 
 	/**
 	 * Returns the widget's children


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add support for specifying defaults for optional properties. Once defaulted, the properties will not be considered optional in usage within the widget. I was not able to restrict the default properties to the properties interface, which means "extra" properties can be added and would be available within the widget's use of `this.properties`.

Example usage:

```ts
interface TestProps {
	a: string;
	b?: string;
	c: string;
	d?: string;
}

function num(a: string) {}

class TestOne extends WidgetBase<TestProps> {

	defaultProperties = { b: '1' };

	myFuncOne() {
		num(this.properties.b); // uses the defaulted value and doesn't error for `strictNullChecks`
	}

	myFuncTwo() {
		num(this.properties.d); // no default, so fails the `strictNullChecks`
	}
}

class TestTwo extends WidgetBase<TestProps> {

	defaultProperties = { d: '1' };

	myFuncOne() {
		num(this.properties.b); // no default, so fails the `strictNullChecks`
	}

	myFuncTwo() {
		num(this.properties.d); // uses the defaulted value and doesn't error for `strictNullChecks`
	}
}
```

Resolves #466 
