### PR TITLE
Anchor did not match

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ widget-core is a library to create powerful, composable user interface widgets.
 	- [Advanced Properties](#advanced-properties)
 	- [Widget Registry](#widget-registry)
 	- [Render Lifecycle Hooks](#render-lifecycle-hooks)
-	- [DOM Wrapper](#dom-wrapper)
+	- [DOM Wrapper](#domwrapper)
 	- [Meta Configuration](#meta-configuration)
 	- [JSX Support](#jsx-support)
 	- [Web Components](#web-components)


### PR DESCRIPTION
**Type:** bug

The anchor `dom-wrapper` did not match the `DOMWrapper` section with the `domwrapper` anchor.