### PR TITLE
Bind functions passed to DNodes to the enclosing widget that they are declared

### DIFF
--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -994,9 +994,11 @@ registerSuite({
 			assert.strictEqual(result.children![1].properties.key, 'span');
 		},
 		'instance gets passed to VNodeProperties as bind to widget and all children'() {
+
+			class InnerWidget extends WidgetBase {}
 			class TestWidget extends WidgetBase<any> {
 				render() {
-					return v('div', [
+					return w(InnerWidget, {}, [
 						v('header', [
 							v('section')
 						])
@@ -1007,9 +1009,12 @@ registerSuite({
 			const widget: any = new TestWidget();
 			const result = <VNode> widget.__render__();
 			assert.lengthOf(result.children, 1);
-			assert.strictEqual(result.properties!.bind, widget);
+			assert.notStrictEqual(result.properties!.bind, widget);
+			assert.instanceOf(result.properties!.bind, InnerWidget);
 			assert.strictEqual(result.children![0].properties!.bind, widget);
+			assert.instanceOf(result.children![0].properties!.bind, TestWidget);
 			assert.strictEqual(result.children![0].children![0].properties!.bind, widget);
+			assert.instanceOf(result.children![0].children![0].properties!.bind, TestWidget);
 		},
 		'render with multiple text node children'() {
 			class TestWidget extends WidgetBase<any> {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that `bind` and `afterCreate`/`afterUpdate` properties are decorated on the return from `render` rather than when they are processed to `VNode` in `WidgetCore`. This ensures that the scope and hook functions are from the widget that they are declared.

Resolves #633 
