### PR TITLE
Clean up meta instances

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -211,6 +211,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 				invalidate: this._boundInvalidate
 			});
 			this._metaMap.set(MetaType, cached);
+			this.own(cached);
 		}
 
 		return cached as T;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -195,6 +195,12 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		this._registries = new RegistryHandler();
 		this._registries.add(registry);
 		this.own(this._registries);
+		this.own({
+			destroy: () => {
+				this._nodeMap.clear();
+				this._requiredNodes.clear();
+			}
+		});
 		this._boundRenderFunc = this.render.bind(this);
 		this._boundInvalidate = this.invalidate.bind(this);
 

--- a/src/meta/Base.ts
+++ b/src/meta/Base.ts
@@ -1,15 +1,18 @@
+import { Destroyable } from '@dojo/core/Destroyable';
 import global from '@dojo/shim/global';
 import Map from '@dojo/shim/Map';
 import Set from '@dojo/shim/Set';
 import { WidgetMetaProperties } from '../interfaces';
 
-export class Base {
+export class Base extends Destroyable {
 	private _invalidate: () => void;
 	private _invalidating: number;
 	private _requiredNodes: Set<string>;
 	protected nodes: Map<string, HTMLElement>;
 
 	constructor(properties: WidgetMetaProperties) {
+		super();
+
 		this._invalidate = properties.invalidate;
 		this._requiredNodes = properties.requiredNodes;
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

meta/Base extends Destroyable. Meta instances are set to owned by the widget instance.

Resolves #635 
