### PR TITLE
Support setting async mode

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -109,6 +109,11 @@ export interface ProjectorMixin<P> {
 	toHtml(): string;
 
 	/**
+	 * Indicates if the projectors is n async mode, configured to `true` by defaults.
+	 */
+	async: boolean;
+
+	/**
 	 * Root element to attach the projector
 	 */
 	root: Element;
@@ -230,6 +235,17 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 		public get root(): Element {
 			return this._root;
+		}
+
+		public get async(): boolean {
+			return this._async;
+		}
+
+		public set async(async: boolean) {
+			if (this.projectorState === ProjectorAttachState.Attached) {
+				throw new Error('Projector already attached, cannot change async mode');
+			}
+			this._async = async;
 		}
 
 		public sandbox(doc: Document = document): Handle {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -109,7 +109,7 @@ export interface ProjectorMixin<P> {
 	toHtml(): string;
 
 	/**
-	 * Indicates if the projectors is n async mode, configured to `true` by defaults.
+	 * Indicates if the projectors is in async mode, configured to `true` by defaults.
 	 */
 	async: boolean;
 

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -663,6 +663,21 @@ registerSuite({
 		projector.destroy();
 		assert.equal(projector.projectorState, ProjectorAttachState.Detached);
 	},
+	'async': {
+		'can set async mode on projector'() {
+			const projector = new BaseTestWidget();
+			assert.isTrue(projector.async);
+			projector.async = false;
+			assert.isFalse(projector.async);
+		},
+		'cannot set async mode on projector that is already attached'() {
+			const projector = new BaseTestWidget();
+			projector.append();
+			assert.throws(() => {
+				projector.async = false;
+			}, Error, 'Projector already attached, cannot change async mode');
+		}
+	},
 	'toHtml()': {
 		'appended'() {
 			const projector = new BaseTestWidget();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Allow the `async` mode to be set from outside the projector instance before it has been attached.

Resolves #645 
