### PR TITLE
Add prototype and name to Constructor

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -7,7 +7,11 @@ import Set from '@dojo/shim/Set';
 /**
  * Generic constructor type
  */
-export type Constructor<T> = new (...args: any[]) => T;
+export interface Constructor<T> {
+	new (...args: any[]): T;
+	name?: string;
+	prototype: T;
+}
 
 /**
  * Typed target event


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Provides `prototype` and `name` on the `Constructor` interface which makes it easier for downstream code to work with a widget class/constructor function.

Resolves #437 
