### PR TITLE
Adds support for a decorator that defines widgets in the default widget registry

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -355,7 +355,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		const { defaultRegistry } = this._registries;
 		for (let i = 0; i < registryItems.length; i++) {
 			const { label, item } = registryItems[i];
-			if (defaultRegistry && defaultRegistry.has(label) === false) {
+			if (defaultRegistry && !defaultRegistry.has(label)) {
 				defaultRegistry.define(label, item);
 			}
 		}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -23,7 +23,8 @@ import {
 	WidgetMetaRequiredNodeCallback
 } from './interfaces';
 import RegistryHandler from './RegistryHandler';
-import { isWidgetBaseConstructor, WIDGET_BASE_TYPE, WidgetRegistry, WidgetRegistryItem } from './WidgetRegistry';
+import { isWidgetBaseConstructor, WIDGET_BASE_TYPE, WidgetRegistry } from './WidgetRegistry';
+import { DefineDecoratorConfig } from './decorators/registry';
 
 /**
  * Widget cache wrapper for instance management
@@ -50,11 +51,6 @@ interface ReactionFunctionArguments {
 interface ReactionFunctionConfig {
 	propertyName: string;
 	reaction: DiffPropertyReaction;
-}
-
-interface RegisterConfig {
-	label: RegistryLabel;
-	item: WidgetRegistryItem;
 }
 
 export type BoundFunctionData = { boundFunc: (...args: any[]) => any, scope: any };
@@ -100,12 +96,6 @@ export function diffProperty(propertyName: string, diffFunction: DiffPropertyFun
 				reaction: propertyKey ? target[propertyKey] : reactionFunction
 			});
 		}
-	});
-}
-
-export function registryItem(label: RegistryLabel, item: WidgetRegistryItem) {
-	return handleDecorator((target) => {
-		target.addDecorator('registryItem', { label, item });
 	});
 }
 
@@ -361,7 +351,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	}
 
 	private _defineRegistryItems(): void {
-		const registryItems: RegisterConfig[] = this.getDecorator('registryItem');
+		const registryItems: DefineDecoratorConfig[] = this.getDecorator('registryItem');
 		const { defaultRegistry } = this._registries;
 		for (let i = 0; i < registryItems.length; i++) {
 			const { label, item } = registryItems[i];

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -372,8 +372,13 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		}
 		if (this._coreProperties.defaultRegistry !== defaultRegistry) {
 			this.setDefaultRegistry(this._coreProperties.defaultRegistry, defaultRegistry);
+			this._initializeDefaultRegistryItems = true;
 			this.invalidate();
 		}
+		if (this._initializeDefaultRegistryItems) {
+			this._defineRegistryItems();
+		}
+
 		this._coreProperties = coreProperties;
 	}
 
@@ -449,9 +454,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	public __render__(): VirtualDomNode | VirtualDomNode[] {
 		this._renderState = WidgetRenderState.RENDER;
 		if (this._dirty === true || this._cachedVNode === undefined) {
-			if (this._initializeDefaultRegistryItems) {
-				this._defineRegistryItems();
-			}
 			this._dirty = false;
 			const render = this._runBeforeRenders();
 			let dNode = render();

--- a/src/decorators/registry.ts
+++ b/src/decorators/registry.ts
@@ -1,0 +1,26 @@
+import { RegistryLabel } from './../interfaces';
+import { WidgetRegistryItem } from './../WidgetRegistry';
+import { handleDecorator } from './../WidgetBase';
+
+/**
+ * The shape of the decorator configuration.
+ */
+export interface DefineDecoratorConfig {
+	label: RegistryLabel;
+	item: WidgetRegistryItem;
+}
+
+/**
+ * Decorator function to registry items that will be defined against
+ * the default registry of a widget.
+ *
+ * @param label The label of the registry item
+ * @param item The registry item to define
+ */
+export function define(label: RegistryLabel, item: WidgetRegistryItem) {
+	return handleDecorator((target) => {
+		target.addDecorator('registryItem', { label, item });
+	});
+}
+
+export default define;

--- a/tests/support/createTestWidget.ts
+++ b/tests/support/createTestWidget.ts
@@ -12,11 +12,11 @@ interface TestWidget<W extends WidgetBase> extends WidgetBaseInterface {
 
 function createTestWidget<W extends WidgetBase>(
 	component: Constructor<W>,
-	properties: W['properties'],
+	properties?: W['properties'],
 	children?: W['children']
 ): TestWidget<W> {
 	const testWidget = new class extends WidgetBase implements TestWidget<W> {
-		private _testProperties: W['properties'] = properties;
+		private _testProperties: W['properties'] = properties || {};
 		private _testChildren: W['children'] = children || [];
 
 		getAttribute(key: string): any {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -9,8 +9,7 @@ import {
 	WidgetBase,
 	diffProperty,
 	afterRender,
-	beforeRender,
-	registryItem
+	beforeRender
 } from '../../src/WidgetBase';
 import { ignore, always, auto } from '../../src/diff';
 import WidgetRegistry, { WIDGET_BASE_TYPE } from './../../src/WidgetRegistry';
@@ -522,98 +521,6 @@ registerSuite({
 			testWidget.callWidgetSpy();
 			assert.isFalse(testWidget.functionIsBound);
 			assert.isTrue(testWidget.properties.functionIsBound);
-		}
-	},
-	register: {
-		'register items against created default registry'() {
-			class RegistryWidget extends WidgetBase {
-				render() {
-					return v('registry-item');
-				}
-			}
-
-			@registryItem('registry-item', RegistryWidget)
-			class TestWidget extends WidgetBase {
-				render() {
-					return w('registry-item', {});
-				}
-			}
-
-			const widget = new TestWidget();
-			const vnode = widget.__render__() as VNode;
-			assert.strictEqual(vnode.vnodeSelector, 'registry-item');
-		},
-		'register items against passed default registry'() {
-			class RegistryWidget extends WidgetBase {
-				render() {
-					return v('registry-item');
-				}
-			}
-
-			@registryItem('registry-item', RegistryWidget)
-			class TestWidget extends WidgetBase {
-				render() {
-					return w('registry-item', {});
-				}
-			}
-
-			const defaultRegistry = new WidgetRegistry();
-
-			const widget = new TestWidget();
-			widget.__setProperties__({ defaultRegistry } as any);
-			const vnode = widget.__render__() as VNode;
-			assert.strictEqual(vnode.vnodeSelector, 'registry-item');
-		},
-		're-registers items when the default registry changes'() {
-			class RegistryWidget extends WidgetBase {
-				render() {
-					return v('registry-item');
-				}
-			}
-
-			@registryItem('registry-item', RegistryWidget)
-			class TestWidget extends WidgetBase {
-				render() {
-					return w('registry-item', {});
-				}
-			}
-
-			const defaultRegistry = new WidgetRegistry();
-
-			const widget = new TestWidget();
-			widget.__setProperties__({ defaultRegistry } as any);
-			let vnode = widget.__render__() as VNode;
-			assert.strictEqual(vnode.vnodeSelector, 'registry-item');
-			widget.__setProperties__({ defaultRegistry: new WidgetRegistry() } as any);
-			vnode = widget.__render__() as VNode;
-			assert.strictEqual(vnode.vnodeSelector, 'registry-item');
-		},
-		'supports the same widget being used twice'() {
-			class RegistryWidget extends WidgetBase {
-				render() {
-					return v('registry-item');
-				}
-			}
-
-			@registryItem('registry-item', RegistryWidget)
-			class RegistryItemWidget extends WidgetBase {
-				render() {
-					return w('registry-item', {});
-				}
-			}
-
-			class TestWidget extends WidgetBase {
-				render() {
-					return [
-						w(RegistryItemWidget, { key: '1' }),
-						w(RegistryItemWidget, { key: '2' })
-					];
-				}
-			}
-			const widget = new TestWidget();
-			let vnode = widget.__render__() as VNode[];
-			assert.strictEqual(vnode[0].vnodeSelector, 'registry-item');
-			assert.strictEqual(vnode[1].vnodeSelector, 'registry-item');
 		}
 	},
 	beforeRender: {

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -7,6 +7,7 @@ import './customElements';
 import './d';
 import './mixins/all';
 import './util/all';
+import './decorators/all';
 import './main';
 import './diff';
 import './RegistryHandler';

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -1,0 +1,1 @@
+import './registry';

--- a/tests/unit/decorators/registry.ts
+++ b/tests/unit/decorators/registry.ts
@@ -1,0 +1,102 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+import { VNode } from '@dojo/interfaces/vdom';
+import { WidgetBase } from './../../../src/WidgetBase';
+import { define } from './../../../src/decorators/registry';
+import { v, w } from './../../../src/d';
+import { WidgetRegistry } from './../../../src/WidgetRegistry';
+
+registerSuite({
+	name: 'decorators/registry',
+	'register items against created default registry'() {
+		class RegistryWidget extends WidgetBase {
+			render() {
+				return v('registry-item');
+			}
+		}
+
+		@define('registry-item', RegistryWidget)
+		class TestWidget extends WidgetBase {
+			render() {
+				return w('registry-item', {});
+			}
+		}
+
+		const widget = new TestWidget();
+		const vnode = widget.__render__() as VNode;
+		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
+	},
+	'register items against passed default registry'() {
+		class RegistryWidget extends WidgetBase {
+			render() {
+				return v('registry-item');
+			}
+		}
+
+		@define('registry-item', RegistryWidget)
+		class TestWidget extends WidgetBase {
+			render() {
+				return w('registry-item', {});
+			}
+		}
+
+		const defaultRegistry = new WidgetRegistry();
+
+		const widget = new TestWidget();
+		widget.__setProperties__({ defaultRegistry } as any);
+		const vnode = widget.__render__() as VNode;
+		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
+	},
+	're-registers items when the default registry changes'() {
+		class RegistryWidget extends WidgetBase {
+			render() {
+				return v('registry-item');
+			}
+		}
+
+		@define('registry-item', RegistryWidget)
+		class TestWidget extends WidgetBase {
+			render() {
+				return w('registry-item', {});
+			}
+		}
+
+		const defaultRegistry = new WidgetRegistry();
+
+		const widget = new TestWidget();
+		widget.__setProperties__({ defaultRegistry } as any);
+		let vnode = widget.__render__() as VNode;
+		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
+		widget.__setProperties__({ defaultRegistry: new WidgetRegistry() } as any);
+		vnode = widget.__render__() as VNode;
+		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
+	},
+	'supports the same widget being used twice'() {
+		class RegistryWidget extends WidgetBase {
+			render() {
+				return v('registry-item');
+			}
+		}
+
+		@define('registry-item', RegistryWidget)
+		class RegistryItemWidget extends WidgetBase {
+			render() {
+				return w('registry-item', {});
+			}
+		}
+
+		class TestWidget extends WidgetBase {
+			render() {
+				return [
+					w(RegistryItemWidget, { key: '1' }),
+					w(RegistryItemWidget, { key: '2' })
+				];
+			}
+		}
+		const widget = new TestWidget();
+		let vnode = widget.__render__() as VNode[];
+		assert.strictEqual(vnode[0].vnodeSelector, 'registry-item');
+		assert.strictEqual(vnode[1].vnodeSelector, 'registry-item');
+	}
+});

--- a/tests/unit/decorators/registry.ts
+++ b/tests/unit/decorators/registry.ts
@@ -7,6 +7,8 @@ import { define } from './../../../src/decorators/registry';
 import { v, w } from './../../../src/d';
 import { WidgetRegistry } from './../../../src/WidgetRegistry';
 
+import createTestWidget from './../../support/createTestWidget';
+
 registerSuite({
 	name: 'decorators/registry',
 	'register items against created default registry'() {
@@ -23,7 +25,7 @@ registerSuite({
 			}
 		}
 
-		const widget = new TestWidget();
+		const widget = createTestWidget(TestWidget);
 		const vnode = widget.__render__() as VNode;
 		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
 	},
@@ -43,8 +45,7 @@ registerSuite({
 
 		const defaultRegistry = new WidgetRegistry();
 
-		const widget = new TestWidget();
-		widget.__setProperties__({ defaultRegistry } as any);
+		const widget = createTestWidget(TestWidget, { defaultRegistry } as any);
 		const vnode = widget.__render__() as VNode;
 		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
 	},
@@ -64,11 +65,10 @@ registerSuite({
 
 		const defaultRegistry = new WidgetRegistry();
 
-		const widget = new TestWidget();
-		widget.__setProperties__({ defaultRegistry } as any);
+		const widget = createTestWidget(TestWidget, { defaultRegistry } as any);
 		let vnode = widget.__render__() as VNode;
 		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
-		widget.__setProperties__({ defaultRegistry: new WidgetRegistry() } as any);
+		widget.setProperties({ defaultRegistry: new WidgetRegistry() } as any);
 		vnode = widget.__render__() as VNode;
 		assert.strictEqual(vnode.vnodeSelector, 'registry-item');
 	},
@@ -94,7 +94,7 @@ registerSuite({
 				];
 			}
 		}
-		const widget = new TestWidget();
+		const widget = createTestWidget(TestWidget);
 		let vnode = widget.__render__() as VNode[];
 		assert.strictEqual(vnode[0].vnodeSelector, 'registry-item');
 		assert.strictEqual(vnode[1].vnodeSelector, 'registry-item');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for a decorator `@define` that accepts a registry label and widget to register in the default widget registry if the widget.

Resolves #652 
