### PR TITLE
revert: Add prototype and name to Constructor #647

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -6,11 +6,7 @@ import Map from '@dojo/shim/Map';
 /**
  * Generic constructor type
  */
-export interface Constructor<T> {
-	new (...args: any[]): T;
-	name?: string;
-	prototype: T;
-}
+export type Constructor<T> = new (...args: any[]) => T;
 
 /**
  * Typed target event


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changing the `Constructor` type to an interface and including `prototype` and `name` causing errors in downstream projects. Error:

```
src/timepicker/TimePicker.ts(164,14): error TS4023: Exported variable 'TimePickerBase' has or is using name 'Constructor' from external module "./development/dojo2/widgets/node_modules/@dojo/widget-core/interfaces" but cannot be named.
```
