### PR TITLE
gitignore for package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage-final.lcov
 npm-debug.log
 /_apidoc
 deploy_key
+package-lock.json


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add `package-lock.json` to `.gitignore`
