### PR TITLE
Add support for core properties

### DIFF
--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -9,7 +9,9 @@ import { always } from './diff';
 import {
 	Constructor,
 	DNode,
-	WidgetProperties
+	HNode,
+	WidgetProperties,
+	WNode
 } from './interfaces';
 
 export interface GetProperties {
@@ -112,9 +114,13 @@ export function Injector<C, T extends Constructor<Base<C>>>(Base: T, context: C)
 
 		protected decorateBind(node: DNode | DNode[]): DNode | DNode[] {
 			const { scope } = this.properties;
-			decorate(node, (node: any) => {
-				const { properties } = node;
-				properties.bind = scope;
+			decorate(node, (node: WNode | HNode) => {
+				if (isHNode(node)) {
+					(<any> node.properties).bind = scope;
+				}
+				else {
+					node.coreProperties.bind = scope;
+				}
 			}, (node: DNode) => { return isHNode(node) || isWNode(node); });
 
 			return node;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -464,7 +464,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 					}
 				}
 				else {
-					const { defaultRegistry, registry } = this.getCoreProperties(node.properties);
+					const { defaultRegistry, registry } = this.__getCoreProperties__(node.properties);
 					node.coreProperties = node.coreProperties || {};
 
 					if (node.coreProperties.bind === undefined) {
@@ -478,7 +478,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		}
 	}
 
-	protected getCoreProperties(properties: any): CoreProperties {
+	protected __getCoreProperties__(properties: any): CoreProperties {
 		const {
 			registry
 		} = properties;

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -4,7 +4,7 @@ import Map from '@dojo/shim/Map';
 import '@dojo/shim/Promise'; // Imported for side-effects
 import WeakMap from '@dojo/shim/WeakMap';
 import { isWNode, v, isHNode } from './d';
-import { auto } from './diff';
+import { auto, ignore } from './diff';
 import {
 	AfterRender,
 	BeforeRender,
@@ -120,6 +120,7 @@ const boundAuto = auto.bind(null);
 /**
  * Main widget base for all widgets to extend
  */
+@diffProperty('registry', ignore)
 export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends Evented implements WidgetBaseInterface<P, C> {
 
 	/**

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -371,9 +371,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	}
 
 	public __setProperties__(properties: this['properties']): void {
-		const props: any = properties;
 		const changedPropertyKeys: string[] = [];
-		const allProperties = [ ...Object.keys(props), ...Object.keys(this._properties) ];
+		const allProperties = [ ...Object.keys(properties), ...Object.keys(this._properties) ];
 		const checkedProperties: string[] = [];
 		const diffPropertyResults: any = {};
 		const registeredDiffPropertyNames = this.getDecorator('registeredDiffProperty');
@@ -388,7 +387,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			}
 			checkedProperties.push(propertyName);
 			const previousProperty = this._properties[propertyName];
-			const newProperty = this._bindFunctionProperty(props[propertyName], this._baseProperties.bind);
+			const newProperty = this._bindFunctionProperty((properties as any)[propertyName], this._baseProperties.bind);
 			if (registeredDiffPropertyNames.indexOf(propertyName) !== -1) {
 				runReactions = true;
 				const diffFunctions = this.getDecorator(`diffProperty:${propertyName}`);
@@ -397,7 +396,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 					if (result.changed && changedPropertyKeys.indexOf(propertyName) === -1) {
 						changedPropertyKeys.push(propertyName);
 					}
-					if (propertyName in props) {
+					if (propertyName in properties) {
 						diffPropertyResults[propertyName] = result.value;
 					}
 				}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -337,7 +337,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		else if (previousRegistry) {
 			_registries.remove(previousRegistry);
 		}
-
 	}
 
 	protected processDefaultRegistry(previousRegistry: WidgetRegistry | undefined, newRegistry: WidgetRegistry | undefined): void {
@@ -357,13 +356,16 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	}
 
 	public __setBaseProperties__(baseProperties: BaseProperties) {
+		this._renderState = WidgetRenderState.PROPERTIES;
 		const { registry, defaultRegistry } = baseProperties;
 
 		if (this._baseProperties.registry !== registry) {
 			this.processRegistry(this._baseProperties.registry, registry);
+			this.invalidate();
 		}
 		if (this._baseProperties.defaultRegistry !== defaultRegistry) {
 			this.processDefaultRegistry(this._baseProperties.defaultRegistry, defaultRegistry);
+			this.invalidate();
 		}
 		this._baseProperties = baseProperties;
 	}

--- a/src/d.ts
+++ b/src/d.ts
@@ -73,7 +73,8 @@ export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<
 		children,
 		widgetConstructor,
 		properties,
-		type: WNODE
+		type: WNODE,
+		coreProperties: {}
 	};
 }
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -231,6 +231,27 @@ export interface WidgetProperties {
 }
 
 /**
+ *
+ */
+interface BaseProperties {
+
+	/**
+	 *
+	 */
+	registry?: any;
+
+	/**
+	 *
+	 */
+	defaultRegistry?: any;
+
+	/**
+	 *
+	 */
+	bind: any;
+}
+
+/**
  * Virtual DOM Node type
  */
 export type VirtualDomNode = VNode | string | null | undefined;
@@ -350,6 +371,12 @@ export interface WidgetBaseInterface<
 	 * @param properties The new widget properties
 	 */
 	__setProperties__(properties: P & { [index: string]: any }): void;
+
+	/**
+	 *
+	 * @param baseProperties
+	 */
+	__setBaseProperties__(baseProperties: BaseProperties): any;
 
 	/**
 	 * Sets the widget's children

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -233,22 +233,22 @@ export interface WidgetProperties {
 /**
  *
  */
-interface BaseProperties {
+interface CoreProperties {
 
 	/**
-	 *
+	 * The user registry
 	 */
 	registry?: any;
 
 	/**
-	 *
+	 * The default registry for the projection
 	 */
 	defaultRegistry?: any;
 
 	/**
-	 *
+	 * The scope used to bind functions
 	 */
-	bind: any;
+	bind?: any;
 }
 
 /**
@@ -303,6 +303,11 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	 * Properties to set against a widget instance
 	 */
 	properties: W['properties'];
+
+	/**
+	 * Core properties that are used by the widget core system
+	 */
+	coreProperties: CoreProperties;
 
 	/**
 	 * DNode children
@@ -373,10 +378,11 @@ export interface WidgetBaseInterface<
 	__setProperties__(properties: P & { [index: string]: any }): void;
 
 	/**
+	 * Sets core properties on the widget.
 	 *
-	 * @param baseProperties
+	 * @param coreProperties The core properties
 	 */
-	__setBaseProperties__(baseProperties: BaseProperties): any;
+	__setCoreProperties__(coreProperties: CoreProperties): any;
 
 	/**
 	 * Sets the widget's children

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -272,11 +272,11 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		}
 
 		public setProperties(properties: this['properties']): void {
-			const { properties: props, baseProperties } = this.parseBaseProperties(properties);
+			const baseProperties = this.getCoreProperties(properties);
 			this._projectorProperties = assign({}, properties);
 
-			super.__setBaseProperties__(baseProperties);
-			super.__setProperties__(props);
+			super.__setCoreProperties__(baseProperties);
+			super.__setProperties__(properties);
 		}
 
 		public toHtml(): string {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -272,8 +272,11 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		}
 
 		public setProperties(properties: this['properties']): void {
+			const { properties: props, baseProperties } = this.parseBaseProperties(properties);
 			this._projectorProperties = assign({}, properties);
-			super.__setProperties__(properties);
+
+			super.__setBaseProperties__(baseProperties);
+			super.__setProperties__(props);
 		}
 
 		public toHtml(): string {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -272,7 +272,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		}
 
 		public setProperties(properties: this['properties']): void {
-			const baseProperties = this.getCoreProperties(properties);
+			const baseProperties = this.__getCoreProperties__(properties);
 			this._projectorProperties = assign({}, properties);
 
 			super.__setCoreProperties__(baseProperties);

--- a/tests/support/createTestWidget.ts
+++ b/tests/support/createTestWidget.ts
@@ -1,0 +1,52 @@
+import { WidgetBase } from './../../src/WidgetBase';
+import { w } from './../../src/d';
+import { Constructor, WidgetBaseInterface } from './../../src/interfaces';
+
+interface TestWidget<W extends WidgetBase> extends WidgetBaseInterface {
+	getWidgetUnderTest(): W;
+	getAttribute(key: string): any;
+	setProperties(properties: W['properties']): void;
+	setChildren(children: W['children']): void;
+	invalidate(): void;
+}
+
+function createTestWidget<W extends WidgetBase>(
+	component: Constructor<W>,
+	properties: W['properties'],
+	children?: W['children']
+): TestWidget<W> {
+	const testWidget = new class extends WidgetBase implements TestWidget<W> {
+		private _testProperties: W['properties'] = properties;
+		private _testChildren: W['children'] = children || [];
+
+		getAttribute(key: string): any {
+			return (<any> this)[key];
+		}
+
+		setProperties(properties: W['properties']): void {
+			this._testProperties = properties;
+			this.invalidate();
+		}
+
+		setChildren(children: W['children']): void {
+			this._testChildren = children;
+			this.invalidate();
+		}
+
+		invalidate(): void {
+			super.invalidate();
+		}
+
+		getWidgetUnderTest(): W {
+			return (<any> this)._cachedChildrenMap.get(component)[0].child;
+		}
+
+		render() {
+			return w(component, this._testProperties, this._testChildren);
+		}
+	}();
+
+	return testWidget;
+}
+
+export default createTestWidget;

--- a/tests/unit/Container.ts
+++ b/tests/unit/Container.ts
@@ -128,7 +128,7 @@ registerSuite({
 
 		const TestWidgetContainer = Container<TestWidget>('test-widget', 'test-state-1');
 		const widget = createTestWidget(TestWidgetContainer, { foo: 'bar' });
-		widget.__setBaseProperties__({ bind: this, registry });
+		widget.__setCoreProperties__({ bind: this, registry });
 		const renderResult: any = widget.__render__();
 		assert.strictEqual(renderResult.vnodeSelector, 'test');
 	}

--- a/tests/unit/Container.ts
+++ b/tests/unit/Container.ts
@@ -5,6 +5,8 @@ import { WidgetBase } from '../../src/WidgetBase';
 import { Container } from './../../src/Container';
 import { WidgetRegistry } from './../../src/WidgetRegistry';
 
+import createTestWidget from './../support/createTestWidget';
+
 interface TestWidgetProperties {
 	foo: string;
 	boo: number;
@@ -36,6 +38,7 @@ class StubInjector extends WidgetBase<any> {
 		return this.properties.render();
 	}
 }
+
 const registry = new WidgetRegistry();
 registry.define('test-state-1', StubInjector);
 registry.define('test-widget', TestWidget);
@@ -119,13 +122,13 @@ registerSuite({
 			assert.isFalse(propertiesCalled);
 			assert.deepEqual(calculatedProperties, {});
 			assert.deepEqual(calculatedChildren, []);
-			assert.deepEqual(properties.properties, { foo: 'bar', registry });
+			assert.deepEqual(properties.properties, { foo: 'bar' });
 			assert.deepEqual(properties.children, []);
 		};
 
 		const TestWidgetContainer = Container<TestWidget>('test-widget', 'test-state-1');
-		const widget = new TestWidgetContainer();
-		widget.__setProperties__({ foo: 'bar', registry });
+		const widget = createTestWidget(TestWidgetContainer, { foo: 'bar' });
+		widget.__setBaseProperties__({ bind: this, registry });
 		const renderResult: any = widget.__render__();
 		assert.strictEqual(renderResult.vnodeSelector, 'test');
 	}

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1423,6 +1423,39 @@ registerSuite({
 			widget.__setBaseProperties__({ bind: widget });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
+			widget.__setBaseProperties__({ bind: widget, defaultRegistry: null });
+			widget.__render__();
+			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
+		},
+		'Removes registry when not passed on subsequent renders'() {
+			class TestWidget extends WidgetBase {
+				render() {
+					return 'test';
+				}
+			}
+			class RegistryWidget extends ThemableWidgetBase {
+				getRegistries() {
+					return super.getRegistries();
+				}
+				getDefaultRegistry() {
+					return (<any> this)._defaultRegistry;
+				}
+				render() {
+					return w('test', {});
+				}
+			}
+			const registry = new WidgetRegistry();
+			registry.define('test', TestWidget);
+			const widget = new RegistryWidget();
+			widget.__setBaseProperties__({ bind: widget, registry });
+			let node: any = widget.__render__();
+			assert.strictEqual(node, 'test');
+			widget.__setBaseProperties__({ bind: widget });
+			node = widget.__render__();
+			assert.isNull(node);
+			widget.__setBaseProperties__({ bind: widget, registry: null });
+			node = widget.__render__();
+			assert.isNull(node);
 		}
 	},
 	'child invalidation invalidates parent'() {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -14,6 +14,7 @@ import {
 import { ignore, always, auto } from '../../src/diff';
 import WidgetRegistry, { WIDGET_BASE_TYPE } from './../../src/WidgetRegistry';
 import { ThemeableMixin } from './../../src/mixins/Themeable';
+import createTestWidget from './../support/createTestWidget';
 
 interface TestProperties {
 	id?: string;
@@ -766,8 +767,7 @@ registerSuite({
 					return v('header');
 				}
 			}
-			const myWidget: any = new TestWidget();
-			myWidget.__setProperties__({ registry });
+			const myWidget: any = createTestWidget(TestWidget, { registry });
 			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 0);
 			registry.define('my-header3', TestHeaderWidget);
@@ -789,8 +789,7 @@ registerSuite({
 					return v('header');
 				}
 			}
-			const myWidget: any = new TestWidget();
-			myWidget.__setProperties__({ registry });
+			const myWidget: any = createTestWidget(TestWidget, { registry });
 			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 0);
 			registry.define(myHeader, TestHeaderWidget);
@@ -860,8 +859,7 @@ registerSuite({
 
 			let invalidateCount = 0;
 
-			const myWidget = new TestWidget();
-			myWidget.__setProperties__({ registry });
+			const myWidget = createTestWidget(TestWidget, { registry });
 			myWidget.on('invalidated', () => {
 				invalidateCount++;
 			});
@@ -907,8 +905,7 @@ registerSuite({
 				}
 			}
 
-			const myWidget = new TestWidget();
-			myWidget.__setProperties__({ registry });
+			const myWidget = createTestWidget(TestWidget, { registry });
 
 			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 0);
@@ -1270,8 +1267,9 @@ registerSuite({
 					return w(ChildRegistryWidget, {});
 				}
 			}
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setProperties__');
+			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setBaseProperties__');
 			const widget = new RegistryWidget();
+			widget.__setBaseProperties__({ bind: widget });
 			widget.__render__();
 			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
 			assert.strictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
@@ -1291,9 +1289,9 @@ registerSuite({
 				}
 			}
 			const defaultRegistry = new WidgetRegistry();
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setProperties__');
+			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setBaseProperties__');
 			const widget = new RegistryWidget();
-			(<any> widget).__setProperties__({ defaultRegistry });
+			(<any> widget).__setBaseProperties__({ bind: widget, defaultRegistry });
 			widget.__render__();
 			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
 			assert.notStrictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
@@ -1314,9 +1312,9 @@ registerSuite({
 				}
 			}
 			const registry = new WidgetRegistry();
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setProperties__');
+			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setBaseProperties__');
 			const widget = new RegistryWidget();
-			widget.__setProperties__({ registry });
+			widget.__setBaseProperties__({ registry } as any);
 			widget.__render__();
 			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
 			assert.notStrictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
@@ -1331,10 +1329,10 @@ registerSuite({
 			const registryOne = new WidgetRegistry();
 			const registryTwo = new WidgetRegistry();
 			const widget = new RegistryWidget();
-			widget.__setProperties__({ registry: registryOne });
+			widget.__setBaseProperties__({ bind: widget, registry: registryOne });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryOne);
-			widget.__setProperties__({ registry: registryTwo });
+			widget.__setBaseProperties__({ bind: widget, registry: registryTwo });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryTwo);
 		},
@@ -1346,11 +1344,11 @@ registerSuite({
 			}
 			const registryOne = new WidgetRegistry();
 			const registryTwo = new WidgetRegistry();
-			const widget: any = new RegistryWidget();
-			widget.__setProperties__({ defaultRegistry: registryOne });
+			const widget = new RegistryWidget();
+			widget.__setBaseProperties__({ bind: widget, defaultRegistry: registryOne });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryOne);
-			widget.__setProperties__({ defaultRegistry: registryTwo });
+			widget.__setBaseProperties__({ bind: widget, defaultRegistry: registryTwo });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryTwo);
 		},
@@ -1364,11 +1362,11 @@ registerSuite({
 				}
 			}
 			const defaultRegistry = new WidgetRegistry();
-			const widget: any = new RegistryWidget();
-			widget.__setProperties__({ defaultRegistry });
+			const widget = new RegistryWidget();
+			widget.__setBaseProperties__({ bind: widget, defaultRegistry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, defaultRegistry);
-			widget.__setProperties__({ });
+			widget.__setBaseProperties__({ bind: widget });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
 		},
@@ -1383,11 +1381,11 @@ registerSuite({
 			}
 			const defaultRegistry = new WidgetRegistry();
 			const registry = new WidgetRegistry();
-			const widget: any = new RegistryWidget();
-			widget.__setProperties__({ defaultRegistry, registry });
+			const widget = new RegistryWidget();
+			widget.__setBaseProperties__({ bind: widget, defaultRegistry, registry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, defaultRegistry);
-			widget.__setProperties__({ registry });
+			widget.__setBaseProperties__({ bind: widget, registry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registry);
 		},
@@ -1401,10 +1399,10 @@ registerSuite({
 				}
 			}
 			const registry = new WidgetRegistry();
-			const widget: any = new RegistryWidget();
+			const widget = new RegistryWidget();
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
-			widget.__setProperties__({ registry });
+			widget.__setBaseProperties__({ bind: widget, registry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registry);
 		},
@@ -1418,45 +1416,13 @@ registerSuite({
 				}
 			}
 			const defaultRegistry = new WidgetRegistry();
-			const widget: any = new RegistryWidget();
-			widget.__setProperties__({ defaultRegistry });
+			const widget = new RegistryWidget();
+			widget.__setBaseProperties__({ bind: widget, defaultRegistry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, defaultRegistry);
-			widget.__setProperties__({});
+			widget.__setBaseProperties__({ bind: widget });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
-		},
-		'Can add widgets to the default widget registry'() {
-			class MyWidgetOne extends ThemableWidgetBase {}
-			class MyWidgetTwo extends ThemableWidgetBase {}
-			class RegistryWidget extends ThemableWidgetBase {
-				getRegistries() {
-					return super.getRegistries();
-				}
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-				@diffProperty('defaultRegistry', auto)
-				addItemsToDefaultRegistry() {
-					const defaultRegistry = this.getRegistries().defaultRegistry;
-					if (defaultRegistry) {
-						defaultRegistry.define('my-widget-1', MyWidgetOne);
-						defaultRegistry.define('my-widget-2', MyWidgetTwo);
-					}
-				}
-			}
-			const defaultRegistry = new WidgetRegistry();
-			const widget: any = new RegistryWidget();
-			widget.__setProperties__({ defaultRegistry });
-			widget.__render__();
-			assert.strictEqual(widget.getRegistries().defaultRegistry, defaultRegistry);
-			assert.strictEqual(widget.getRegistries().defaultRegistry.get('my-widget-1'), MyWidgetOne);
-			assert.strictEqual(widget.getRegistries().defaultRegistry.get('my-widget-2'), MyWidgetTwo);
-			widget.__setProperties__({ });
-			widget.__render__();
-			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
-			assert.strictEqual(widget.getRegistries().defaultRegistry.get('my-widget-1'), MyWidgetOne);
-			assert.strictEqual(widget.getRegistries().defaultRegistry.get('my-widget-2'), MyWidgetTwo);
 		}
 	},
 	'child invalidation invalidates parent'() {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1267,9 +1267,9 @@ registerSuite({
 					return w(ChildRegistryWidget, {});
 				}
 			}
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setBaseProperties__');
+			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setCoreProperties__');
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ bind: widget });
+			widget.__setCoreProperties__({ bind: widget });
 			widget.__render__();
 			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
 			assert.strictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
@@ -1289,9 +1289,9 @@ registerSuite({
 				}
 			}
 			const defaultRegistry = new WidgetRegistry();
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setBaseProperties__');
+			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setCoreProperties__');
 			const widget = new RegistryWidget();
-			(<any> widget).__setBaseProperties__({ bind: widget, defaultRegistry });
+			(<any> widget).__setCoreProperties__({ bind: widget, defaultRegistry });
 			widget.__render__();
 			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
 			assert.notStrictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
@@ -1312,9 +1312,9 @@ registerSuite({
 				}
 			}
 			const registry = new WidgetRegistry();
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setBaseProperties__');
+			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setCoreProperties__');
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ registry } as any);
+			widget.__setCoreProperties__({ registry } as any);
 			widget.__render__();
 			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
 			assert.notStrictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
@@ -1329,10 +1329,10 @@ registerSuite({
 			const registryOne = new WidgetRegistry();
 			const registryTwo = new WidgetRegistry();
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ bind: widget, registry: registryOne });
+			widget.__setCoreProperties__({ bind: widget, registry: registryOne });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryOne);
-			widget.__setBaseProperties__({ bind: widget, registry: registryTwo });
+			widget.__setCoreProperties__({ bind: widget, registry: registryTwo });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryTwo);
 		},
@@ -1345,10 +1345,10 @@ registerSuite({
 			const registryOne = new WidgetRegistry();
 			const registryTwo = new WidgetRegistry();
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ bind: widget, defaultRegistry: registryOne });
+			widget.__setCoreProperties__({ bind: widget, defaultRegistry: registryOne });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryOne);
-			widget.__setBaseProperties__({ bind: widget, defaultRegistry: registryTwo });
+			widget.__setCoreProperties__({ bind: widget, defaultRegistry: registryTwo });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registryTwo);
 		},
@@ -1363,10 +1363,10 @@ registerSuite({
 			}
 			const defaultRegistry = new WidgetRegistry();
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ bind: widget, defaultRegistry });
+			widget.__setCoreProperties__({ bind: widget, defaultRegistry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, defaultRegistry);
-			widget.__setBaseProperties__({ bind: widget });
+			widget.__setCoreProperties__({ bind: widget });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
 		},
@@ -1382,10 +1382,10 @@ registerSuite({
 			const defaultRegistry = new WidgetRegistry();
 			const registry = new WidgetRegistry();
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ bind: widget, defaultRegistry, registry });
+			widget.__setCoreProperties__({ bind: widget, defaultRegistry, registry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, defaultRegistry);
-			widget.__setBaseProperties__({ bind: widget, registry });
+			widget.__setCoreProperties__({ bind: widget, registry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registry);
 		},
@@ -1402,7 +1402,7 @@ registerSuite({
 			const widget = new RegistryWidget();
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
-			widget.__setBaseProperties__({ bind: widget, registry });
+			widget.__setCoreProperties__({ bind: widget, registry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, registry);
 		},
@@ -1417,13 +1417,13 @@ registerSuite({
 			}
 			const defaultRegistry = new WidgetRegistry();
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ bind: widget, defaultRegistry });
+			widget.__setCoreProperties__({ bind: widget, defaultRegistry });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, defaultRegistry);
-			widget.__setBaseProperties__({ bind: widget });
+			widget.__setCoreProperties__({ bind: widget });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
-			widget.__setBaseProperties__({ bind: widget, defaultRegistry: null });
+			widget.__setCoreProperties__({ bind: widget, defaultRegistry: null });
 			widget.__render__();
 			assert.strictEqual(widget.getRegistries().defaultRegistry, widget.getDefaultRegistry());
 		},
@@ -1447,13 +1447,13 @@ registerSuite({
 			const registry = new WidgetRegistry();
 			registry.define('test', TestWidget);
 			const widget = new RegistryWidget();
-			widget.__setBaseProperties__({ bind: widget, registry });
+			widget.__setCoreProperties__({ bind: widget, registry });
 			let node: any = widget.__render__();
 			assert.strictEqual(node, 'test');
-			widget.__setBaseProperties__({ bind: widget });
+			widget.__setCoreProperties__({ bind: widget });
 			node = widget.__render__();
 			assert.isNull(node);
-			widget.__setBaseProperties__({ bind: widget, registry: null });
+			widget.__setCoreProperties__({ bind: widget, registry: null });
 			node = widget.__render__();
 			assert.isNull(node);
 		}

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -22,6 +22,7 @@ import * as extraClasses2 from './../../support/styles/extraClasses2.css';
 import testTheme1 from './../../support/styles/theme1.css';
 import testTheme2 from './../../support/styles/theme2.css';
 import testTheme3 from './../../support/styles/theme3.css';
+import createTestWidget from './../../support/createTestWidget';
 
 (<any> baseThemeClasses1)[' _key'] = 'testPath1';
 (<any> baseThemeClasses2)[' _key'] = 'testPath2';
@@ -386,8 +387,7 @@ registerSuite({
 					return v('div', { classes: this.classes(baseThemeClasses1.class1) });
 				}
 			}
-			const themeableInstance = new InjectedTheme();
-			themeableInstance.__setProperties__({ registry: testRegistry });
+			const themeableInstance = createTestWidget(InjectedTheme, { registry: testRegistry });
 			const vNode: any = themeableInstance.__render__();
 			assert.deepEqual(vNode.properties.classes, { theme1Class1: true });
 		},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for `coreProperties` and processes them before the normally `__setProperties__` phase.

Resolves #658 
