### PR TITLE
add beforeProperties lifecycle hook

### DIFF
--- a/src/decorators/beforeProperties.ts
+++ b/src/decorators/beforeProperties.ts
@@ -2,7 +2,8 @@ import { handleDecorator } from './../WidgetBase';
 import { BeforeProperties } from './../interfaces';
 
 /**
- *
+ * Decorator that adds the function passed of target method to be run
+ * in the `beforeProperties` lifecycle.
  */
 export function beforeProperties(method: BeforeProperties): (target: any) => void;
 export function beforeProperties(): (target: any, propertyKey: string) => void;

--- a/src/decorators/beforeProperties.ts
+++ b/src/decorators/beforeProperties.ts
@@ -1,0 +1,15 @@
+import { handleDecorator } from './../WidgetBase';
+import { BeforeProperties } from './../interfaces';
+
+/**
+ *
+ */
+export function beforeProperties(method: BeforeProperties): (target: any) => void;
+export function beforeProperties(): (target: any, propertyKey: string) => void;
+export function beforeProperties(method?: BeforeProperties) {
+	return handleDecorator((target, propertyKey) => {
+		target.addDecorator('beforeProperties', propertyKey ? target[propertyKey] : method);
+	});
+}
+
+export default beforeProperties;

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -442,3 +442,10 @@ export interface BeforeRender {
 export interface AfterRender {
 	(dNode: DNode | DNode []): DNode | DNode[];
 }
+
+/**
+ * Interface for beforeProperties function
+ */
+export interface BeforeProperties<P = any> {
+	(properties: P): P;
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -5,6 +5,7 @@ import './WidgetRegistry';
 import './lifecycle';
 import './customElements';
 import './d';
+import './decorators/all';
 import './mixins/all';
 import './util/all';
 import './main';

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -1,0 +1,1 @@
+import './beforeProperties';

--- a/tests/unit/decorators/beforeProperties.ts
+++ b/tests/unit/decorators/beforeProperties.ts
@@ -1,0 +1,69 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+import { beforeProperties } from './../../../src/decorators/beforeProperties';
+import { WidgetBase } from './../../../src/WidgetBase';
+import { WidgetProperties } from './../../../src/interfaces';
+
+registerSuite({
+	name: 'decorators/beforeProperties',
+	beforeProperties() {
+		function before(properties: WidgetProperties): WidgetProperties {
+			return { key: 'foo' };
+		}
+
+		@beforeProperties(before)
+		class TestWidget extends WidgetBase<any> {}
+		const widget = new TestWidget();
+		widget.__setProperties__({});
+		assert.strictEqual(widget.properties.key, 'foo');
+	},
+	'multiple beforeProperties decorators'() {
+		function beforeOne(properties: WidgetProperties): WidgetProperties {
+			return { key: 'foo' };
+		}
+		function beforeTwo(properties: any): any {
+			return { other: 'bar' };
+		}
+
+		@beforeProperties(beforeOne)
+		@beforeProperties(beforeTwo)
+		class TestWidget extends WidgetBase<any> {}
+		const widget = new TestWidget();
+		widget.__setProperties__({});
+		assert.strictEqual(widget.properties.key, 'foo');
+		assert.strictEqual(widget.properties.other, 'bar');
+	},
+	'beforeProperties on class method'() {
+		class TestWidget extends WidgetBase<any> {
+			@beforeProperties()
+			before(properties: WidgetProperties): WidgetProperties {
+				return { key: 'foo' };
+			}
+		}
+		const widget = new TestWidget();
+		widget.__setProperties__({});
+		assert.strictEqual(widget.properties.key, 'foo');
+
+	},
+	'programmatic beforeProperties'() {
+		function beforeOne(properties: WidgetProperties): WidgetProperties {
+			return { key: 'foo' };
+		}
+		function beforeTwo(properties: any): any {
+			return { other: 'bar' };
+		}
+
+		class TestWidget extends WidgetBase<any> {
+			constructor() {
+				super();
+				beforeProperties(beforeOne)(this);
+				beforeProperties(beforeTwo)(this);
+			}
+		}
+		const widget = new TestWidget();
+		widget.__setProperties__({});
+		assert.strictEqual(widget.properties.key, 'foo');
+		assert.strictEqual(widget.properties.other, 'bar');
+	}
+});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds `beforeProperties` lifecycle hook that enables a user to inject properties into that will get processed through the properties lifecycle.

Resolves #660 
