### PR TITLE
Interface updates

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -15,7 +15,6 @@ import {
 	DiffPropertyFunction,
 	DiffPropertyReaction,
 	DNode,
-	RegistryLabel,
 	Render,
 	VirtualDomNode,
 	WidgetMetaBase,
@@ -156,7 +155,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	/**
 	 * cached chldren map for instance management
 	 */
-	private _cachedChildrenMap: Map<RegistryLabel | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
+	private _cachedChildrenMap: Map<string | number | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
 
 	/**
 	 * map of specific property diff functions

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -230,12 +230,24 @@ export interface WidgetProperties {
 	 * The key for a widget. Used to differentiate uniquely identify child widgets for
 	 * rendering and instance management
 	 */
-	key?: string;
+	key?: string | number;
 
 	/**
 	 * Optional registry
 	 */
 	registry?: any;
+}
+
+/**
+ * Widget properties that require a key
+ */
+export interface KeyedWidgetProperties extends WidgetProperties {
+
+	/**
+	 * The key for a widget. Used to differentiate uniquely identify child widgets for
+	 * rendering and instance management
+	 */
+	key: string | number;
 }
 
 /**
@@ -407,7 +419,7 @@ export interface WidgetBaseInterface<
  * Meta Base type
  */
 export interface WidgetMetaBase extends Destroyable {
-	has(key: string): boolean;
+	has(key: string | number): boolean;
 }
 
 /**
@@ -418,8 +430,8 @@ export interface WidgetMetaConstructor<T extends WidgetMetaBase> {
 }
 
 export interface NodeHandlerInterface extends Evented {
-	get(key: string): HTMLElement | undefined;
-	has(key: string): boolean;
+	get(key: string | number): HTMLElement | undefined;
+	has(key: string | number): boolean;
 	add(element: HTMLElement, properties: VNodeProperties): void;
 	addRoot(element: HTMLElement, properties: VNodeProperties): void;
 	addProjector(element: HTMLElement, properties: VNodeProperties): void;

--- a/src/meta/Base.ts
+++ b/src/meta/Base.ts
@@ -23,7 +23,7 @@ export class Base extends Destroyable implements WidgetMetaBase {
 		const node = this.nodeHandler.get(key);
 
 		if (!node && !this._requestedNodeKeys.has(key)) {
-			const handle = this.nodeHandler.on(key as string, () => {
+			const handle = this.nodeHandler.on(`${key}`, () => {
 				handle.destroy();
 				this._requestedNodeKeys.delete(key);
 				this.invalidate();

--- a/src/meta/Base.ts
+++ b/src/meta/Base.ts
@@ -6,7 +6,7 @@ export class Base extends Destroyable implements WidgetMetaBase {
 	private _invalidate: () => void;
 	protected nodeHandler: NodeHandlerInterface;
 
-	private _requestedNodeKeys = new Set<string>();
+	private _requestedNodeKeys = new Set<string | number>();
 
 	constructor(properties: WidgetMetaProperties) {
 		super();
@@ -15,15 +15,15 @@ export class Base extends Destroyable implements WidgetMetaBase {
 		this.nodeHandler = properties.nodeHandler;
 	}
 
-	public has(key: string): boolean {
+	public has(key: string | number): boolean {
 		return this.nodeHandler.has(key);
 	}
 
-	protected getNode(key: string): HTMLElement | undefined {
+	protected getNode(key: string | number): HTMLElement | undefined {
 		const node = this.nodeHandler.get(key);
 
 		if (!node && !this._requestedNodeKeys.has(key)) {
-			const handle = this.nodeHandler.on(key, () => {
+			const handle = this.nodeHandler.on(key as string, () => {
 				handle.destroy();
 				this._requestedNodeKeys.delete(key);
 				this.invalidate();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR updates the `WidgetProperties` interface so that `key` can be a number or a string. A new `KeyedWidgetProperties` interface was also added that extends `WidgetProperties` and makes `key` required.

Resolves #672 
