### PR TITLE
Enable support for typed children using TSX

### DIFF
--- a/src/tsx.ts
+++ b/src/tsx.ts
@@ -8,6 +8,9 @@ declare global {
 		interface ElementAttributesProperty {
 			properties: {};
 		}
+		interface ElementChildrenAttribute {
+			children: {};
+		}
 		interface IntrinsicElements {
 			[key: string]: VirtualDomProperties;
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR adds the `ElementChildrenAttribute` interface inside the `jsx` namespace to enable typed children.

Resolves #675 
