### PR TITLE
Simplify Widget Registries

### DIFF
--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -150,6 +150,7 @@ export class Registry extends Evented implements RegistryInterface {
 		}
 
 		this._injectorRegistry.set(label, item);
+		this.emitLoadedEvent(label);
 	}
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel): Constructor<T> | null {

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -17,6 +17,7 @@ export const WIDGET_BASE_TYPE = Symbol('Widget Base');
 
 export interface RegistryEventObject extends EventObject {
 	action: string;
+	item: WidgetBaseConstructor | Injector;
 }
 
 export interface RegistryListener {
@@ -108,10 +109,11 @@ export class Registry extends Evented implements RegistryInterface {
 	/**
 	 * Emit loaded event for registry label
 	 */
-	private emitLoadedEvent(widgetLabel: RegistryLabel): void {
+	private emitLoadedEvent(widgetLabel: RegistryLabel, item: WidgetBaseConstructorFunction | WidgetBaseConstructor | Injector): void {
 		this.emit({
 			type: widgetLabel,
-			action: 'loaded'
+			action: 'loaded',
+			item
 		});
 	}
 
@@ -129,14 +131,14 @@ export class Registry extends Evented implements RegistryInterface {
 		if (item instanceof Promise) {
 			item.then((widgetCtor) => {
 				this._widgetRegistry.set(label, widgetCtor);
-				this.emitLoadedEvent(label);
+				this.emitLoadedEvent(label, widgetCtor);
 				return widgetCtor;
 			}, (error) => {
 				throw error;
 			});
 		}
 		else {
-			this.emitLoadedEvent(label);
+			this.emitLoadedEvent(label, item);
 		}
 	}
 
@@ -150,7 +152,7 @@ export class Registry extends Evented implements RegistryInterface {
 		}
 
 		this._injectorRegistry.set(label, item);
-		this.emitLoadedEvent(label);
+		this.emitLoadedEvent(label, item);
 	}
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel): Constructor<T> | null {
@@ -173,7 +175,7 @@ export class Registry extends Evented implements RegistryInterface {
 
 		promise.then((widgetCtor) => {
 			this._widgetRegistry.set(label, widgetCtor);
-			this.emitLoadedEvent(label);
+			this.emitLoadedEvent(label, widgetCtor);
 			return widgetCtor;
 		}, (error) => {
 			throw error;

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,7 +1,7 @@
 import { Map } from '@dojo/shim/Map';
 import { Evented } from '@dojo/core/Evented';
 import { Constructor, RegistryLabel, WidgetBaseInterface } from './interfaces';
-import { Registry, RegistryEventObject } from './Registry';
+import { Registry, RegistryEventObject, RegistryItem } from './Registry';
 import { Injector } from './Injector';
 
 export class RegistryHandler extends Evented {
@@ -21,7 +21,7 @@ export class RegistryHandler extends Evented {
 		this._baseRegistry = baseRegistry;
 	}
 
-	public define(label: RegistryLabel, widget: Constructor<WidgetBaseInterface>): void {
+	public define(label: RegistryLabel, widget: RegistryItem): void {
 		this._registry.define(label, widget);
 	}
 
@@ -41,7 +41,7 @@ export class RegistryHandler extends Evented {
 		return this._get(label, globalPrecedence, 'get', this._registryWidgetLabelMap);
 	}
 
-	public getInjector(label: RegistryLabel, globalPrecedence: boolean = false): Injector | null {
+	public getInjector<T extends Injector>(label: RegistryLabel, globalPrecedence: boolean = false): T | null {
 		return this._get(label, globalPrecedence, 'getInjector', this._registryInjectorLabelMap);
 	}
 

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,96 +1,28 @@
-import { Handle } from '@dojo/interfaces/core';
 import { Map } from '@dojo/shim/Map';
-import { Destroyable } from '@dojo/core/Destroyable';
 import { Evented } from '@dojo/core/Evented';
 import { Constructor, RegistryLabel, WidgetBaseInterface } from './interfaces';
 import { Registry, RegistryEventObject } from './Registry';
 import { Injector } from './Injector';
 
-/**
- * Interface for the primary and secondary registry handles
- */
-interface Handles {
-	primary: Handle;
-	secondary?: Handle;
-}
-
-/**
- * Manages primary and secondary handles for a widget label
- */
-class RegistryHandles extends Destroyable {
-	private _handles: Map<RegistryLabel, Handles> = new Map();
-
-	/**
-	 * Removes and destroys the handles for the label
-	 *
-	 * @param label the widget label to remove
-	 */
-	public delete(label: RegistryLabel): boolean {
-		const handles = this._handles.get(label);
-		if (handles) {
-			handles.primary.destroy();
-			if (handles.secondary) {
-				handles.secondary.destroy();
-			}
-			return this._handles.delete(label);
-		}
-		return false;
-	}
-
-	/**
-	 * Sets the primary handle, will destroy the existing handle if it exists.
-	 *
-	 * @param label The label to set the handle for.
-	 * @param handle The listener handle.
-	 */
-	public setPrimary(label: RegistryLabel, handle: Handle): void {
-		this.delete(label);
-		const handles = {
-			primary: handle
-		};
-		this.own(handle);
-		this._handles.set(label, handles);
-	}
-
-	/**
-	 * Sets the secondary handle, will destroy the existing handle if it exists.
-	 *
-	 * Passing undefined will destroy an existing handle and clear the reference.
-	 *
-	 * @param label The label to set the handle for.
-	 * @param handle The listener handle.
-	 */
-	public setSecondary(label: RegistryLabel, handle?: Handle): void {
-		let handles = this._handles.get(label);
-		if (handles) {
-			if (handles && handles.secondary) {
-				handles.secondary.destroy();
-			}
-			if (handle) {
-				this.own(handle);
-			}
-			handles.secondary = handle;
-			this._handles.set(label, handles);
-		}
-	}
-}
-
 export class RegistryHandler extends Evented {
 	private _registry = new Registry();
 	private _baseRegistry: Registry;
-	private _widgetHandles = new RegistryHandles();
-	private _injectorHandles = new RegistryHandles();
+	private _registryWidgetLabelMap: Map<Registry, RegistryLabel[]> = new Map();
+	private _registryInjectorLabelMap: Map<Registry, RegistryLabel[]> = new Map();
 
 	constructor() {
 		super();
 		this.own(this._registry);
-		this.own(this._widgetHandles);
-		this.own(this._injectorHandles);
+		this._registryWidgetLabelMap.set(this._registry, []);
+		this._registryInjectorLabelMap.set(this._registry, []);
 	}
 
 	public set base(baseRegistry: Registry) {
+		this._registryWidgetLabelMap.delete(this._baseRegistry);
+		this._registryInjectorLabelMap.delete(this._baseRegistry);
 		this._baseRegistry = baseRegistry;
-
+		this._registryWidgetLabelMap.set(baseRegistry, []);
+		this._registryInjectorLabelMap.set(baseRegistry, []);
 	}
 
 	public define(label: RegistryLabel, widget: Constructor<WidgetBaseInterface>): void {
@@ -110,77 +42,53 @@ export class RegistryHandler extends Evented {
 	}
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel, globalPrecedence: boolean = false): Constructor<T> | null {
-		let primaryRegistry = this._registry;
-		let secondaryRegistry = this._baseRegistry ? this._baseRegistry : undefined;
+		const registries = globalPrecedence ? [ this._baseRegistry, this._registry ] : [ this._registry, this._baseRegistry ];
 
-		if (globalPrecedence && secondaryRegistry) {
-			primaryRegistry = this._baseRegistry;
-			secondaryRegistry = this._registry;
-		}
-
-		let item = primaryRegistry.get<T>(label);
-		if (item) {
-			return item;
-		}
-
-		const primaryHandle = primaryRegistry.on(label, (event: RegistryEventObject) => {
-			if (event.action === 'loaded') {
-				this.emit({ type: 'invalidate' });
-				this._widgetHandles.delete(label);
+		for (let i = 0; i < registries.length; i++) {
+			const registry = registries[i];
+			if (!registry) {
+				continue;
 			}
-		});
-		this._widgetHandles.setPrimary(label, primaryHandle);
-
-		if (secondaryRegistry) {
-			item = secondaryRegistry.get<T>(label);
+			const item = registry.get<T>(label);
+			const registeredLabels = this._registryWidgetLabelMap.get(registry) || [];
 			if (item) {
 				return item;
 			}
-			const secondaryHandle = secondaryRegistry.on(label, (event: RegistryEventObject) => {
-				if (event.action === 'loaded') {
-					this.emit({ type: 'invalidate' });
-					this._widgetHandles.setSecondary(label);
-				}
-			});
-			this._widgetHandles.setSecondary(label, secondaryHandle);
+			else if (registeredLabels.indexOf(label) === -1) {
+				const handle = registry.on(label, (event: RegistryEventObject) => {
+					if (event.action === 'loaded') {
+						this.emit({ type: 'invalidate' });
+					}
+				});
+				this.own(handle);
+				this._registryWidgetLabelMap.set(registry, [ ...registeredLabels, label]);
+			}
 		}
 		return null;
 	}
 
 	public getInjector(label: RegistryLabel, globalPrecedence: boolean = false): Injector | null {
-		let primaryRegistry = this._registry;
-		let secondaryRegistry = this._baseRegistry ? this._baseRegistry : undefined;
+		const registries = globalPrecedence ? [ this._baseRegistry, this._registry ] : [ this._registry, this._baseRegistry ];
 
-		if (globalPrecedence && secondaryRegistry) {
-			primaryRegistry = this._baseRegistry;
-			secondaryRegistry = this._registry;
-		}
-
-		let item = primaryRegistry.getInjector(label);
-		if (item) {
-			return item;
-		}
-
-		const primaryHandle = primaryRegistry.on(label, (event: RegistryEventObject) => {
-			if (event.action === 'loaded') {
-				this.emit({ type: 'invalidate' });
-				this._injectorHandles.delete(label);
+		for (let i = 0; i < registries.length; i++) {
+			const registry = registries[i];
+			if (!registry) {
+				continue;
 			}
-		});
-		this._injectorHandles.setPrimary(label, primaryHandle);
-
-		if (secondaryRegistry) {
-			item = secondaryRegistry.getInjector(label);
+			const item = registry.getInjector(label);
+			const registeredLabels = this._registryInjectorLabelMap.get(registry) || [];
 			if (item) {
 				return item;
 			}
-			const secondaryHandle = secondaryRegistry.on(label, (event: RegistryEventObject) => {
-				if (event.action === 'loaded') {
-					this.emit({ type: 'invalidate' });
-					this._injectorHandles.setSecondary(label);
-				}
-			});
-			this._injectorHandles.setSecondary(label, secondaryHandle);
+			else if (registeredLabels.indexOf(label) === -1) {
+				const handle = registry.on(label, (event: RegistryEventObject) => {
+					if (event.action === 'loaded') {
+						this.emit({ type: 'invalidate' });
+					}
+				});
+				this.own(handle);
+				this._registryInjectorLabelMap.set(registry, [ ...registeredLabels, label]);
+			}
 		}
 		return null;
 	}

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -52,7 +52,7 @@ export class RegistryHandler extends Evented {
 			}
 			else if (registeredLabels.indexOf(label) === -1) {
 				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded' && registry.get(label) === event.item) {
+					if (event.action === 'loaded' && this.get(label) === event.item) {
 						this.emit({ type: 'invalidate' });
 					}
 				});
@@ -78,7 +78,7 @@ export class RegistryHandler extends Evented {
 			}
 			else if (registeredLabels.indexOf(label) === -1) {
 				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded' && registry.getInjector(label) === event.item) {
+					if (event.action === 'loaded' && this.getInjector(label) === event.item) {
 						this.emit({ type: 'invalidate' });
 					}
 				});

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -93,8 +93,12 @@ export class RegistryHandler extends Evented {
 
 	}
 
-	public define(label: RegistryLabel, widget: any): void {
+	public define(label: RegistryLabel, widget: Constructor<WidgetBaseInterface>): void {
 		this._registry.define(label, widget);
+	}
+
+	public defineInjector(label: RegistryLabel, injector: Injector): void {
+		this._registry.defineInjector(label, injector);
 	}
 
 	public has(label: RegistryLabel): boolean {

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -59,7 +59,7 @@ export class RegistryHandler extends Evented {
 			}
 			else if (registeredLabels.indexOf(label) === -1) {
 				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded' && (<any> this)[getFunctionName](label) === event.item) {
+					if (event.action === 'loaded' && (this as any)[getFunctionName](label) === event.item) {
 						this.emit({ type: 'invalidate' });
 					}
 				});

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -38,52 +38,33 @@ export class RegistryHandler extends Evented {
 	}
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel, globalPrecedence: boolean = false): Constructor<T> | null {
-		const registries = globalPrecedence ? [ this._baseRegistry, this._registry ] : [ this._registry, this._baseRegistry ];
-
-		for (let i = 0; i < registries.length; i++) {
-			const registry = registries[i];
-			if (!registry) {
-				continue;
-			}
-			const item = registry.get<T>(label);
-			const registeredLabels = this._registryWidgetLabelMap.get(registry) || [];
-			if (item) {
-				return item;
-			}
-			else if (registeredLabels.indexOf(label) === -1) {
-				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded' && this.get(label) === event.item) {
-						this.emit({ type: 'invalidate' });
-					}
-				});
-				this.own(handle);
-				this._registryWidgetLabelMap.set(registry, [ ...registeredLabels, label]);
-			}
-		}
-		return null;
+		return this._get(label, globalPrecedence, 'get', this._registryWidgetLabelMap);
 	}
 
 	public getInjector(label: RegistryLabel, globalPrecedence: boolean = false): Injector | null {
-		const registries = globalPrecedence ? [ this._baseRegistry, this._registry ] : [ this._registry, this._baseRegistry ];
+		return this._get(label, globalPrecedence, 'getInjector', this._registryInjectorLabelMap);
+	}
 
+	private _get(label: RegistryLabel, globalPrecedence: boolean, getFunctionName: 'getInjector' | 'get', labelMap: Map<Registry, RegistryLabel[]>): any {
+		const registries = globalPrecedence ? [ this._baseRegistry, this._registry ] : [ this._registry, this._baseRegistry ];
 		for (let i = 0; i < registries.length; i++) {
-			const registry = registries[i];
+			const registry: any = registries[i];
 			if (!registry) {
 				continue;
 			}
-			const item = registry.getInjector(label);
-			const registeredLabels = this._registryInjectorLabelMap.get(registry) || [];
+			const item = registry[getFunctionName](label);
+			const registeredLabels = labelMap.get(registry) || [];
 			if (item) {
 				return item;
 			}
 			else if (registeredLabels.indexOf(label) === -1) {
 				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded' && this.getInjector(label) === event.item) {
+					if (event.action === 'loaded' && (<any> this)[getFunctionName](label) === event.item) {
 						this.emit({ type: 'invalidate' });
 					}
 				});
 				this.own(handle);
-				this._registryInjectorLabelMap.set(registry, [ ...registeredLabels, label]);
+				labelMap.set(registry, [ ...registeredLabels, label]);
 			}
 		}
 		return null;

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,18 +1,91 @@
 import { Handle } from '@dojo/interfaces/core';
+import { Map } from '@dojo/shim/Map';
+import { Destroyable } from '@dojo/core/Destroyable';
 import { Evented } from '@dojo/core/Evented';
 import { Constructor, RegistryLabel, WidgetBaseInterface } from './interfaces';
 import { Registry, RegistryEventObject } from './Registry';
 import { Injector } from './Injector';
 
-export default class RegistryHandler extends Evented {
-	private _registry = new Registry();
-	private _baseRegistry = this._registry;
+/**
+ * Interface for the primary and secondary registry handles
+ */
+interface Handles {
+	primary: Handle;
+	secondary?: Handle;
+}
 
-	private _widgetLabels: RegistryLabel[] = [];
+/**
+ * Manages primary and secondary handles for a widget label
+ */
+class RegistryHandles extends Destroyable {
+	private _handles: Map<RegistryLabel, Handles> = new Map();
+
+	/**
+	 * Removes and destroys the handles for the label
+	 *
+	 * @param label the widget label to remove
+	 */
+	public delete(label: RegistryLabel): boolean {
+		const handles = this._handles.get(label);
+		if (handles) {
+			handles.primary.destroy();
+			if (handles.secondary) {
+				handles.secondary.destroy();
+			}
+			return this._handles.delete(label);
+		}
+		return false;
+	}
+
+	/**
+	 * Sets the primary handle, will destroy the existing handle if it exists.
+	 *
+	 * @param label The label to set the handle for.
+	 * @param handle The listener handle.
+	 */
+	public setPrimary(label: RegistryLabel, handle: Handle): void {
+		this.delete(label);
+		const handles = {
+			primary: handle
+		};
+		this.own(handle);
+		this._handles.set(label, handles);
+	}
+
+	/**
+	 * Sets the secondary handle, will destroy the existing handle if it exists.
+	 *
+	 * Passing undefined will destroy an existing handle and clear the reference.
+	 *
+	 * @param label The label to set the handle for.
+	 * @param handle The listener handle.
+	 */
+	public setSecondary(label: RegistryLabel, handle?: Handle): void {
+		let handles = this._handles.get(label);
+		if (handles) {
+			if (handles && handles.secondary) {
+				handles.secondary.destroy();
+			}
+			if (handle) {
+				this.own(handle);
+			}
+			handles.secondary = handle;
+			this._handles.set(label, handles);
+		}
+	}
+}
+
+export class RegistryHandler extends Evented {
+	private _registry = new Registry();
+	private _baseRegistry: Registry;
+	private _widgetHandles = new RegistryHandles();
+	private _injectorHandles = new RegistryHandles();
 
 	constructor() {
 		super();
 		this.own(this._registry);
+		this.own(this._widgetHandles);
+		this.own(this._injectorHandles);
 	}
 
 	public set base(baseRegistry: Registry) {
@@ -34,9 +107,9 @@ export default class RegistryHandler extends Evented {
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel, globalPrecedence: boolean = false): Constructor<T> | null {
 		let primaryRegistry = this._registry;
-		let secondaryRegistry = this._baseRegistry;
+		let secondaryRegistry = this._baseRegistry ? this._baseRegistry : undefined;
 
-		if (globalPrecedence) {
+		if (globalPrecedence && secondaryRegistry) {
 			primaryRegistry = this._baseRegistry;
 			secondaryRegistry = this._registry;
 		}
@@ -46,46 +119,67 @@ export default class RegistryHandler extends Evented {
 			return item;
 		}
 
-		const handles: Handle[] = [];
-		if (this._widgetLabels.indexOf(label) === -1) {
-			const primaryHandle = primaryRegistry.on(label, (event: RegistryEventObject) => {
-				if (event.action === 'loaded') {
-					this.emit({ type: 'invalidate' });
-					handles.forEach((handle) => {
-						handle.destroy();
-					});
-				}
-			});
-			handles.push(primaryHandle);
-			this.own(primaryHandle);
-		}
+		const primaryHandle = primaryRegistry.on(label, (event: RegistryEventObject) => {
+			if (event.action === 'loaded') {
+				this.emit({ type: 'invalidate' });
+				this._widgetHandles.delete(label);
+			}
+		});
+		this._widgetHandles.setPrimary(label, primaryHandle);
 
-		if (secondaryRegistry !== primaryRegistry) {
+		if (secondaryRegistry) {
 			item = secondaryRegistry.get<T>(label);
 			if (item) {
-				this._widgetLabels.push(label);
 				return item;
 			}
-			if (this._widgetLabels.indexOf(label) === -1) {
-				const secondaryHandle = secondaryRegistry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded') {
-						this.emit({ type: 'invalidate' });
-						secondaryHandle.destroy();
-					}
-				});
-				handles.push(secondaryHandle);
-				this.own(secondaryHandle);
-				this._widgetLabels.push(label);
-			}
+			const secondaryHandle = secondaryRegistry.on(label, (event: RegistryEventObject) => {
+				if (event.action === 'loaded') {
+					this.emit({ type: 'invalidate' });
+					this._widgetHandles.setSecondary(label);
+				}
+			});
+			this._widgetHandles.setSecondary(label, secondaryHandle);
 		}
 		return null;
 	}
 
-	public getInjector(label: RegistryLabel): Injector | null {
-		const item = this._registry.getInjector(label) || this._baseRegistry.getInjector(label);
+	public getInjector(label: RegistryLabel, globalPrecedence: boolean = false): Injector | null {
+		let primaryRegistry = this._registry;
+		let secondaryRegistry = this._baseRegistry ? this._baseRegistry : undefined;
+
+		if (globalPrecedence && secondaryRegistry) {
+			primaryRegistry = this._baseRegistry;
+			secondaryRegistry = this._registry;
+		}
+
+		let item = primaryRegistry.getInjector(label);
 		if (item) {
 			return item;
+		}
+
+		const primaryHandle = primaryRegistry.on(label, (event: RegistryEventObject) => {
+			if (event.action === 'loaded') {
+				this.emit({ type: 'invalidate' });
+				this._injectorHandles.delete(label);
+			}
+		});
+		this._injectorHandles.setPrimary(label, primaryHandle);
+
+		if (secondaryRegistry) {
+			item = secondaryRegistry.getInjector(label);
+			if (item) {
+				return item;
+			}
+			const secondaryHandle = secondaryRegistry.on(label, (event: RegistryEventObject) => {
+				if (event.action === 'loaded') {
+					this.emit({ type: 'invalidate' });
+					this._injectorHandles.setSecondary(label);
+				}
+			});
+			this._injectorHandles.setSecondary(label, secondaryHandle);
 		}
 		return null;
 	}
 }
+
+export default RegistryHandler;

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -13,16 +13,12 @@ export class RegistryHandler extends Evented {
 	constructor() {
 		super();
 		this.own(this._registry);
-		this._registryWidgetLabelMap.set(this._registry, []);
-		this._registryInjectorLabelMap.set(this._registry, []);
 	}
 
 	public set base(baseRegistry: Registry) {
 		this._registryWidgetLabelMap.delete(this._baseRegistry);
 		this._registryInjectorLabelMap.delete(this._baseRegistry);
 		this._baseRegistry = baseRegistry;
-		this._registryWidgetLabelMap.set(baseRegistry, []);
-		this._registryInjectorLabelMap.set(baseRegistry, []);
 	}
 
 	public define(label: RegistryLabel, widget: Constructor<WidgetBaseInterface>): void {
@@ -56,7 +52,7 @@ export class RegistryHandler extends Evented {
 			}
 			else if (registeredLabels.indexOf(label) === -1) {
 				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded') {
+					if (event.action === 'loaded' && registry.get(label) === event.item) {
 						this.emit({ type: 'invalidate' });
 					}
 				});
@@ -82,7 +78,7 @@ export class RegistryHandler extends Evented {
 			}
 			else if (registeredLabels.indexOf(label) === -1) {
 				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded') {
+					if (event.action === 'loaded' && registry.getInjector(label) === event.item) {
 						this.emit({ type: 'invalidate' });
 					}
 				});

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -25,7 +25,7 @@ import {
 } from './interfaces';
 import RegistryHandler from './RegistryHandler';
 import NodeHandler from './NodeHandler';
-import { isWidgetBaseConstructor, WIDGET_BASE_TYPE, Registry } from './Registry';
+import { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './Registry';
 
 /**
  * Widget cache wrapper for instance management
@@ -306,18 +306,14 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		return this._properties;
 	}
 
-	protected setBaseRegistry(previousBaseRegistry: Registry, newBaseRegistry: Registry): void {
-		if (previousBaseRegistry !== newBaseRegistry) {
-			this._registry.base = newBaseRegistry;
-			this.invalidate();
-		}
-	}
-
 	public __setCoreProperties__(coreProperties: CoreProperties): void {
 		this._renderState = WidgetRenderState.PROPERTIES;
 		const { baseRegistry } = coreProperties;
 
-		this.setBaseRegistry(this._coreProperties.baseRegistry, baseRegistry);
+		if (this._coreProperties.baseRegistry !== baseRegistry) {
+			this._registry.base = baseRegistry;
+			this.invalidate();
+		}
 		this._coreProperties = coreProperties;
 	}
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -167,7 +167,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	 */
 	private _decoratorCache: Map<string, any[]>;
 
-	private _registries: RegistryHandler;
+	private _registry: RegistryHandler;
 
 	/**
 	 * Map of functions properties for the bound function
@@ -204,14 +204,14 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		this._cachedChildrenMap = new Map<string | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>();
 		this._diffPropertyFunctionMap = new Map<string, string>();
 		this._bindFunctionPropertyMap = new WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>();
-		this._registries = new RegistryHandler();
+		this._registry = new RegistryHandler();
 		this._nodeHandler = new NodeHandler();
-		this.own(this._registries);
+		this.own(this._registry);
 		this.own(this._nodeHandler);
 		this._boundRenderFunc = this.render.bind(this);
 		this._boundInvalidate = this.invalidate.bind(this);
 
-		this.own(this._registries.on('invalidate', this._boundInvalidate));
+		this.own(this._registry.on('invalidate', this._boundInvalidate));
 		this._checkOnElementUsage();
 	}
 
@@ -308,7 +308,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 
 	protected setBaseRegistry(previousBaseRegistry: Registry, newBaseRegistry: Registry): void {
 		if (previousBaseRegistry !== newBaseRegistry) {
-			this.registries.base = newBaseRegistry;
+			this._registry.base = newBaseRegistry;
 			this.invalidate();
 		}
 	}
@@ -589,8 +589,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		return property;
 	}
 
-	public get registries(): RegistryHandler {
-		return this._registries;
+	public get registry(): RegistryHandler {
+		return this._registry;
 	}
 
 	private _runBeforeProperties(properties: any) {
@@ -664,7 +664,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			let child: WidgetBaseInterface<WidgetProperties>;
 
 			if (!isWidgetBaseConstructor(widgetConstructor)) {
-				const item = this._registries.get(widgetConstructor);
+				const item = this._registry.get(widgetConstructor);
 				if (item === null) {
 					return null;
 				}

--- a/src/d.ts
+++ b/src/d.ts
@@ -73,8 +73,7 @@ export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<
 		children,
 		widgetConstructor,
 		properties,
-		type: WNODE,
-		coreProperties: {}
+		type: WNODE
 	};
 }
 

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -44,7 +44,7 @@ export interface InjectConfig {
 export function inject({ name, getProperties }: InjectConfig) {
 	return handleDecorator((target, propertyKey) => {
 		beforeProperties(function(this: WidgetBase, properties: any) {
-			const injector = this.registries.getInjector(name);
+			const injector = this.registry.getInjector(name);
 			if (injector) {
 				const registeredInjectors = registeredInjectorsMap.get(this) || [];
 				if (registeredInjectors.length === 0) {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -231,11 +231,6 @@ export interface WidgetProperties {
 	 * rendering and instance management
 	 */
 	key?: string | number;
-
-	/**
-	 * Optional registry
-	 */
-	registry?: any;
 }
 
 /**
@@ -256,19 +251,14 @@ export interface KeyedWidgetProperties extends WidgetProperties {
 interface CoreProperties {
 
 	/**
-	 * The user registry
-	 */
-	registry?: any;
-
-	/**
 	 * The default registry for the projection
 	 */
-	defaultRegistry?: any;
+	baseRegistry: any;
 
 	/**
 	 * The scope used to bind functions
 	 */
-	bind?: any;
+	bind: any;
 }
 
 /**
@@ -327,7 +317,7 @@ export interface WNode<W extends WidgetBaseInterface = DefaultWidgetBaseInterfac
 	/**
 	 * Core properties that are used by the widget core system
 	 */
-	coreProperties: CoreProperties;
+	coreProperties?: CoreProperties;
 
 	/**
 	 * DNode children
@@ -402,7 +392,7 @@ export interface WidgetBaseInterface<
 	 *
 	 * @param coreProperties The core properties
 	 */
-	__setCoreProperties__(coreProperties: CoreProperties): any;
+	__setCoreProperties__(coreProperties?: CoreProperties): any;
 
 	/**
 	 * Sets the widget's children

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -50,7 +50,7 @@ export interface ProjectorProperties {
 
 export interface ProjectorMixin<P> {
 
-	readonly properties: Readonly<P> & ProjectorProperties;
+	readonly properties: Readonly<P> & Readonly<ProjectorProperties>;
 
 	/**
 	 * Append the projector to the root.
@@ -147,11 +147,11 @@ function setDomNodes(vnode: VNode, domNode: Element | null = null) {
 	}
 }
 
-export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T): T & Constructor<ProjectorMixin<Readonly<P> & ProjectorProperties>> {
+export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T): T & Constructor<ProjectorMixin<P>> {
 	class Projector extends Base {
 
 		public projectorState: ProjectorAttachState;
-		public properties: Readonly<P> & ProjectorProperties;
+		public properties: Readonly<P> & Readonly<ProjectorProperties>;
 
 		private _root: Element;
 		private _async = true;

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -290,7 +290,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 		protected setBaseRegistry(previousBaseRegistry: Registry, newBaseRegistry: Registry = new Registry()): void {
 			if (previousBaseRegistry !== newBaseRegistry) {
-				this.registries.base = newBaseRegistry;
+				this.registry.base = newBaseRegistry;
 				this.own(newBaseRegistry);
 				this.invalidate();
 			}

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -166,7 +166,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		private _projectorProperties: this['properties'] = {} as any;
 		private _rootTagName: string;
 		private _attachType: AttachType;
-		private _baseRegistry = new Registry();
 
 		constructor(...args: any[]) {
 			super(...args);
@@ -182,7 +181,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this._boundDoRender = this._doRender.bind(this);
 			this._boundRender = this.__render__.bind(this);
-			this.own(this._baseRegistry);
 			this.own(this.on('invalidated', this.scheduleRender));
 
 			this.root = document.body;

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -163,7 +163,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		private _boundDoRender: () => void;
 		private _boundRender: Function;
 		private _projectorChildren: DNode[];
-		private _projectorProperties: this['properties'] = {} as any;
+		private _projectorProperties: this['properties'];
 		private _rootTagName: string;
 		private _attachType: AttachType;
 
@@ -284,10 +284,9 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		}
 
 		public setProperties(properties: this['properties']): void {
-			const { registry: previousRegistry } = this._projectorProperties;
-			if (previousRegistry !== properties.registry) {
-				if (previousRegistry) {
-					previousRegistry.destroy();
+			if (this._projectorProperties && this._projectorProperties.registry !== properties.registry) {
+				if (this._projectorProperties.registry) {
+					this._projectorProperties.registry.destroy();
 				}
 				if (properties.registry) {
 					this.own(properties.registry);

--- a/tests/unit/Container.ts
+++ b/tests/unit/Container.ts
@@ -52,7 +52,8 @@ registerSuite({
 		};
 		const TestWidgetContainer = Container(TestWidget, 'test-state-1', { getProperties });
 		const widget = new TestWidgetContainer();
-		widget.__setProperties__({ foo: 'bar', registry });
+		widget.__setCoreProperties__({ bind: widget, baseRegistry: registry });
+		widget.__setProperties__({ foo: 'bar' });
 		widget.__setChildren__([]);
 		widget.__render__();
 	},
@@ -70,7 +71,8 @@ registerSuite({
 		};
 		const TestWidgetContainer = Container(TestWidget, 'test-state-1', { getProperties });
 		const widget = new TestWidgetContainer();
-		widget.__setProperties__({ foo: 'bar', registry });
+		widget.__setCoreProperties__({ bind: widget, baseRegistry: registry });
+		widget.__setProperties__({ foo: 'bar' });
 		widget.__setChildren__([ child ]);
 		widget.__render__();
 	},
@@ -87,8 +89,7 @@ registerSuite({
 		};
 
 		const TestWidgetContainer = Container<TestWidget>('test-widget', 'test-state-1', { getProperties });
-		const widget = createTestWidget(TestWidgetContainer, { foo: 'bar' });
-		widget.__setCoreProperties__({ registry });
+		const widget = createTestWidget(TestWidgetContainer, { foo: 'bar', registry });
 		const renderResult: any = widget.__render__();
 		assert.strictEqual(renderResult.vnodeSelector, 'test');
 	},
@@ -105,7 +106,7 @@ registerSuite({
 
 		}
 		const widget = new Parent();
-		widget.__setCoreProperties__({ bind: widget, registry });
+		widget.__setCoreProperties__({ bind: widget, baseRegistry: registry });
 		widget.__setProperties__({ foo: 'bar'});
 		const renderResult = widget.__render__();
 		injector.set({ foo: 'bar' });

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -19,59 +19,14 @@ registryB.define(bar, WidgetBase);
 
 registerSuite({
 	name: 'RegistryHandler',
-	'add': {
-		'add standard registry'() {
-			const registryHandler = new RegistryHandler();
-			registryHandler.add(registry);
-			const widget = registry.get('foo');
-			assert.equal(widget, WidgetBase);
-		},
-		'add default registry'() {
-			const registryHandler = new RegistryHandler();
-			registryHandler.add(registry);
-			assert.equal(registryHandler.defaultRegistry, registry);
-			registryHandler.add(registryB, true);
-			assert.equal(registryHandler.defaultRegistry, registryB);
-		}
-	},
-	'remove': {
-		'existing'() {
-			const registryHandler = new RegistryHandler();
-			registryHandler.add(registry);
-			assert.equal(registry.get('foo'), WidgetBase);
-			registryHandler.remove(registry);
-			assert.isNull(registryHandler.get('foo'));
-		},
-		'non-existing'() {
-			const registryHandler = new RegistryHandler();
-			registryHandler.add(registry);
-			assert.equal(registry.get('foo'), WidgetBase);
-			assert.isFalse(registryHandler.remove(registryB));
-		}
-	},
-	'replace': {
-		'existing'() {
-			const registryHandler = new RegistryHandler();
-			registryHandler.add(registry);
-			assert.equal(registry.get('foo'), WidgetBase);
-			registryHandler.replace(registry, registryB);
-			assert.isNull(registryHandler.get('foo'));
-			assert.equal(registryHandler.get('bar'), WidgetBase);
-		},
-		'non-existing'() {
-			const registryHandler = new RegistryHandler();
-			registryHandler.add(registry);
-			assert.equal(registry.get('foo'), WidgetBase);
-			assert.isFalse(registryHandler.replace(registryB, registry));
-		}
-	},
 	'has'() {
 		const registryHandler = new RegistryHandler();
-		registryHandler.add(registry);
-		registryHandler.add(registryB);
+		registryHandler.base = registry;
 		assert.isTrue(registryHandler.has('foo'));
-		assert.isTrue(registryHandler.has('bar'));
 		assert.isTrue(registryHandler.has(foo));
+		registryHandler.define('bar', WidgetBase);
+		registryHandler.define(bar, WidgetBase);
+		assert.isTrue(registryHandler.has('bar'));
 		assert.isTrue(registryHandler.has(bar));
 	},
 	'get'() {
@@ -81,8 +36,8 @@ registerSuite({
 			}, 1);
 		});
 		const registryHandler = new RegistryHandler();
-		registryHandler.add(registry);
-		registry.define('baz', promise);
+		registryHandler.base = registry;
+		registryHandler.define('baz', promise);
 		return promise.then(() => {
 			assert.equal(registryHandler.get('baz'), WidgetBase);
 		});
@@ -95,8 +50,7 @@ registerSuite({
 			}, 1);
 		});
 		const registryHandler = new RegistryHandler();
-		registryHandler.add(registry);
-		registry.define(baz, promise);
+		registryHandler.define(baz, promise);
 		return promise.then(() => {
 			assert.equal(registryHandler.get(baz), WidgetBase);
 		});
@@ -109,8 +63,7 @@ registerSuite({
 			}, 1);
 		});
 		const registryHandler = new RegistryHandler();
-		registryHandler.add(registry);
-		registry.define('baz-1', promise);
+		registryHandler.define('baz-1', promise);
 		return promise.then(() => {
 			const RegistryWidget = registryHandler.get<TestWidget>('baz-1');
 			assert.equal(RegistryWidget, TestWidget);
@@ -137,8 +90,7 @@ registerSuite({
 			invalidateCalled = true;
 		});
 
-		registryHandler.add(registry);
-		registry.define(baz, lazyWidget);
+		registryHandler.define(baz, lazyWidget);
 		registryHandler.get(baz);
 		return promise.then(() => {
 			assert.isTrue(invalidateCalled);
@@ -158,8 +110,7 @@ registerSuite({
 			invalidateCalled = true;
 		});
 
-		registryHandler.add(registry);
-		registry.define(baz, lazyWidget);
+		registryHandler.define(baz, lazyWidget);
 		registryHandler.get(baz);
 		registry.emit({ type: baz, action: 'other' });
 		assert.isFalse(invalidateCalled);

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -74,7 +74,7 @@ registerSuite({
 				registryHandler.get('global');
 				registryHandler.get('global');
 				registry.define('global', GlobalWidget);
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 			},
 			'invalidates when primary registry emits loaded event even when widget is loaded in secondary registry'() {
 				const registryHandler = new RegistryHandler();
@@ -88,9 +88,9 @@ registerSuite({
 				registryHandler.get('global');
 				registryHandler.get('global');
 				registry.define('global', GlobalWidget);
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 				registryHandler.define('global', LocalWidget);
-				assert.strictEqual(2, invalidateCount);
+				assert.strictEqual(invalidateCount, 2);
 			},
 			'no loaded event listeners once the widget is fully loaded (into primary registry)'() {
 				const registryHandler = new RegistryHandler();
@@ -103,9 +103,9 @@ registerSuite({
 
 				registryHandler.get('global');
 				registryHandler.define('global', LocalWidget);
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 				registry.emit({ type: 'global', action: 'other' });
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 			},
 			'ignores unknown event actions'() {
 				const registryHandler = new RegistryHandler();
@@ -119,10 +119,10 @@ registerSuite({
 				registryHandler.base = registry;
 				registryHandler.get('global');
 				registry.emit({ type: 'global', action: 'other' });
-				assert.strictEqual(0, invalidateCount);
+				assert.strictEqual(invalidateCount, 0);
 				registryHandler.get('global', true);
 				registry.emit({ type: 'global', action: 'other' });
-				assert.strictEqual(0, invalidateCount);
+				assert.strictEqual(invalidateCount, 0);
 			}
 		}
 	},
@@ -182,7 +182,7 @@ registerSuite({
 				registryHandler.getInjector('global');
 				registryHandler.getInjector('global');
 				registry.defineInjector('global', globalInjector);
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 			},
 			'invalidates when primary registry emits loaded event even when widget is loaded in secondary registry'() {
 				const registryHandler = new RegistryHandler();
@@ -197,9 +197,9 @@ registerSuite({
 				registryHandler.getInjector('global');
 				registryHandler.getInjector('global');
 				registry.defineInjector('global', globalInjector);
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 				registryHandler.defineInjector('global', localInjector);
-				assert.strictEqual(2, invalidateCount);
+				assert.strictEqual(invalidateCount, 2);
 			},
 			'no loaded event listeners once the widget is fully loaded (into primary registry)'() {
 				const registryHandler = new RegistryHandler();
@@ -212,9 +212,9 @@ registerSuite({
 
 				registryHandler.getInjector('global');
 				registryHandler.defineInjector('global', localInjector);
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 				registry.emit({ type: 'global', action: 'other' });
-				assert.strictEqual(1, invalidateCount);
+				assert.strictEqual(invalidateCount, 1);
 			},
 			'ignores unknown event actions'() {
 				const registryHandler = new RegistryHandler();
@@ -227,10 +227,10 @@ registerSuite({
 
 				registryHandler.getInjector('global');
 				registry.emit({ type: 'global', action: 'other' });
-				assert.strictEqual(0, invalidateCount);
+				assert.strictEqual(invalidateCount, 0);
 				registryHandler.getInjector('global', true);
 				registry.emit({ type: 'global', action: 'other' });
-				assert.strictEqual(0, invalidateCount);
+				assert.strictEqual(invalidateCount, 0);
 			}
 		}
 	}

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -107,6 +107,20 @@ registerSuite({
 				registry.emit({ type: 'global', action: 'other' });
 				assert.strictEqual(invalidateCount, 1);
 			},
+			'no `invalidate` events emitted once the with registry with the highest precedence has loaded'() {
+				const registryHandler = new RegistryHandler();
+				const registry = new Registry();
+				registryHandler.base = registry;
+				let invalidateCount = 0;
+				registryHandler.on('invalidate', () => {
+					invalidateCount++;
+				});
+				registryHandler.get('widget');
+				registryHandler.define('widget', LocalWidget);
+				assert.strictEqual(invalidateCount, 1);
+				registry.define('widget', GlobalWidget);
+				assert.strictEqual(invalidateCount, 1);
+			},
 			'ignores unknown event actions'() {
 				const registryHandler = new RegistryHandler();
 				const registry = new Registry();
@@ -214,6 +228,21 @@ registerSuite({
 				registryHandler.defineInjector('global', localInjector);
 				assert.strictEqual(invalidateCount, 1);
 				registry.emit({ type: 'global', action: 'other' });
+				assert.strictEqual(invalidateCount, 1);
+			},
+			'no `invalidate` events emitted once the with registry with the highest precedence has loaded'() {
+				const registryHandler = new RegistryHandler();
+				const registry = new Registry();
+				registryHandler.base = registry;
+				const localInjector = new Injector({});
+				let invalidateCount = 0;
+				registryHandler.on('invalidate', () => {
+					invalidateCount++;
+				});
+				registryHandler.getInjector('injector');
+				registryHandler.defineInjector('injector', localInjector);
+				assert.strictEqual(invalidateCount, 1);
+				registry.defineInjector('injector', globalInjector);
 				assert.strictEqual(invalidateCount, 1);
 			},
 			'ignores unknown event actions'() {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -13,7 +13,6 @@ import {
 } from '../../src/WidgetBase';
 import { ignore, always, auto } from '../../src/diff';
 import Registry, { WIDGET_BASE_TYPE } from './../../src/Registry';
-import { ThemeableMixin } from './../../src/mixins/Themeable';
 import createTestWidget from './../support/createTestWidget';
 
 interface TestProperties {
@@ -27,8 +26,6 @@ interface TestProperties {
 let consoleStub: SinonStub;
 
 const registry = new Registry();
-
-const ThemableWidgetBase = ThemeableMixin(WidgetBase);
 
 registerSuite({
 	name: 'WidgetBase',
@@ -802,18 +799,24 @@ registerSuite({
 			assert.lengthOf(result.children, 1);
 		},
 		'locally defined widget in registry eventually replaces global one'() {
-			const localRegistry = new Registry();
-
 			class TestWidget extends WidgetBase<any> {
+				private _defineItem = false;
 				constructor() {
 					super();
-					this.registries.add(registry);
-					this.registries.add(localRegistry);
 				}
 				render() {
+					if (this._defineItem) {
+						this.registries.define('my-header4', TestHeaderLocalWidget);
+					}
+					else {
+						this._defineItem = true;
+					}
 					return v('div', [
-						w('my-header4', <any> undefined)
+						w('my-header4', {})
 					]);
+				}
+				invalidate() {
+					super.invalidate();
 				}
 			}
 
@@ -830,9 +833,10 @@ registerSuite({
 			}
 			registry.define('my-header4', TestHeaderWidget);
 			const myWidget = new TestWidget();
+			myWidget.__setCoreProperties__({ bind: myWidget, baseRegistry: registry });
 			let result = <any> myWidget.__render__();
 			assert.equal(result.children[0].vnodeSelector, 'global-header');
-			localRegistry.define('my-header4', TestHeaderLocalWidget);
+			myWidget.invalidate();
 			result = <any> myWidget.__render__();
 			assert.equal(result.children[0].vnodeSelector, 'local-header');
 		},
@@ -845,7 +849,7 @@ registerSuite({
 			};
 			registry.define('my-header', loadFunction);
 
-			class TestWidget extends WidgetBase<any> {
+			class TestWidget extends WidgetBase {
 				public invalidate() {
 					super.invalidate();
 				}
@@ -856,7 +860,7 @@ registerSuite({
 				}
 			}
 
-			class TestHeaderWidget extends WidgetBase<any> {
+			class TestHeaderWidget extends WidgetBase {
 				render() {
 					return v('header');
 				}
@@ -865,8 +869,7 @@ registerSuite({
 			let invalidateCount = 0;
 
 			const myWidget = new TestWidget();
-			myWidget.__setCoreProperties__({ registry });
-			myWidget.__setProperties__({ registry });
+			myWidget.__setCoreProperties__({ bind: myWidget, baseRegistry: registry });
 			myWidget.on('invalidated', () => {
 				invalidateCount++;
 			});
@@ -940,7 +943,7 @@ registerSuite({
 			class TestWidget extends WidgetBase<any> {
 				constructor() {
 					super();
-					this.registries.add(registry);
+					this.registries.define('my-header', TestHeaderWidget);
 				}
 
 				render() {
@@ -1260,192 +1263,6 @@ registerSuite({
 		}
 	},
 	'registry': {
-		'creates and uses a default registry when defaultRegistry & registry properties are not passed'() {
-			class ChildRegistryWidget extends ThemableWidgetBase { }
-
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-				render() {
-					return w(ChildRegistryWidget, {});
-				}
-				getCoreProperties(properties: any) {
-					return super.__getCoreProperties__(properties);
-				}
-			}
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setCoreProperties__');
-			const widget = new RegistryWidget();
-			const properties = {};
-			const coreProperties = widget.getCoreProperties(properties);
-			widget.__setCoreProperties__(coreProperties);
-			widget.__setProperties__(properties);
-			widget.__render__();
-			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
-			assert.strictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
-		},
-		'creates but does not use a default registry when defaultRegistry is passed'() {
-			class ChildRegistryWidget extends ThemableWidgetBase { }
-
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-				render() {
-					return w(ChildRegistryWidget, {});
-				}
-				getCoreProperties(properties: any) {
-					return super.__getCoreProperties__(properties);
-				}
-			}
-			const defaultRegistry = new Registry();
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setCoreProperties__');
-			const widget = new RegistryWidget();
-			widget.__setCoreProperties__({ defaultRegistry });
-			widget.__setProperties__({});
-			widget.__render__();
-			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
-			assert.notStrictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
-			assert.strictEqual(childWidgetProperties.defaultRegistry, defaultRegistry);
-		},
-		'Uses registry property as defaultRegistry when a defaultRegistry property is not passed'() {
-			class ChildRegistryWidget extends ThemableWidgetBase { }
-
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-				render() {
-					return w(ChildRegistryWidget, {});
-				}
-				getCoreProperties(properties: any) {
-					return super.__getCoreProperties__(properties);
-				}
-			}
-			const registry = new Registry();
-			const childPropertiesSpy = spy(ChildRegistryWidget.prototype, '__setCoreProperties__');
-			const widget = new RegistryWidget();
-			const properties = { registry };
-			const coreProperties = widget.getCoreProperties(properties);
-			widget.__setCoreProperties__(coreProperties);
-			widget.__setProperties__(properties);
-			widget.__render__();
-			const childWidgetProperties = childPropertiesSpy.firstCall.args[0];
-			assert.notStrictEqual(childWidgetProperties.defaultRegistry, widget.getDefaultRegistry());
-			assert.strictEqual(childWidgetProperties.defaultRegistry, registry);
-		},
-		'Passing a different registry will replace the previous registry'() {
-			const registryOne = new Registry();
-			const registryTwo = new Registry();
-			const widget = new ThemableWidgetBase();
-			widget.__setCoreProperties__({ bind: widget, registry: registryOne });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, registryOne);
-			widget.__setCoreProperties__({ bind: widget, registry: registryTwo });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, registryTwo);
-		},
-		'Passing a different defaultRegistry will replace the previous defaultRegistry'() {
-			const registryOne = new Registry();
-			const registryTwo = new Registry();
-			const widget = new ThemableWidgetBase();
-			widget.__setCoreProperties__({ bind: widget, defaultRegistry: registryOne });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, registryOne);
-			widget.__setCoreProperties__({ bind: widget, defaultRegistry: registryTwo });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, registryTwo);
-		},
-		'Widgets default registry is used if the defaultRegistry is not passed on a subsequent render'() {
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-			}
-			const defaultRegistry = new Registry();
-			const widget = new RegistryWidget();
-			widget.__setCoreProperties__({ bind: widget, defaultRegistry });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, defaultRegistry);
-			widget.__setCoreProperties__({ bind: widget });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, widget.getDefaultRegistry());
-		},
-		'Widgets registry property is promoted to defaultRegistry if defaultRegistry is received a subsequent render'() {
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-			}
-			const defaultRegistry = new Registry();
-			const registry = new Registry();
-			const widget = new RegistryWidget();
-			widget.__setCoreProperties__({ bind: widget, defaultRegistry, registry });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, defaultRegistry);
-			widget.__setCoreProperties__({ bind: widget, registry });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, registry);
-		},
-		'Registry replaces widgets defaultRegistry when passed'() {
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-			}
-			const registry = new Registry();
-			const widget = new RegistryWidget();
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, widget.getDefaultRegistry());
-			widget.__setCoreProperties__({ bind: widget, registry });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, registry);
-		},
-		'Widgets defaultRegistry is used when neither registry or defaultRegistry is passed on subsequent renders'() {
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-			}
-			const defaultRegistry = new Registry();
-			const widget = new RegistryWidget();
-			widget.__setCoreProperties__({ bind: widget, defaultRegistry });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, defaultRegistry);
-			widget.__setCoreProperties__({ bind: widget });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, widget.getDefaultRegistry());
-			widget.__setCoreProperties__({ bind: widget, defaultRegistry: null });
-			widget.__render__();
-			assert.strictEqual(widget.registries.defaultRegistry, widget.getDefaultRegistry());
-		},
-		'Removes registry when not passed on subsequent renders'() {
-			class TestWidget extends WidgetBase {
-				render() {
-					return 'test';
-				}
-			}
-			class RegistryWidget extends ThemableWidgetBase {
-				getDefaultRegistry() {
-					return (<any> this)._defaultRegistry;
-				}
-				render() {
-					return w('test', {});
-				}
-			}
-			const registry = new Registry();
-			registry.define('test', TestWidget);
-			const widget = new RegistryWidget();
-			widget.__setCoreProperties__({ bind: widget, registry });
-			let node: any = widget.__render__();
-			assert.strictEqual(node, 'test');
-			widget.__setCoreProperties__({ bind: widget });
-			node = widget.__render__();
-			assert.isNull(node);
-			widget.__setCoreProperties__({ bind: widget, registry: null });
-			node = widget.__render__();
-			assert.isNull(node);
-		}
 	},
 	'child invalidation invalidates parent'() {
 		let childInvalidate = () => {};

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -806,7 +806,7 @@ registerSuite({
 				}
 				render() {
 					if (this._defineItem) {
-						this.registries.define('my-header4', TestHeaderLocalWidget);
+						this.registry.define('my-header4', TestHeaderLocalWidget);
 					}
 					else {
 						this._defineItem = true;
@@ -943,7 +943,7 @@ registerSuite({
 			class TestWidget extends WidgetBase<any> {
 				constructor() {
 					super();
-					this.registries.define('my-header', TestHeaderWidget);
+					this.registry.define('my-header', TestHeaderWidget);
 				}
 
 				render() {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1262,8 +1262,6 @@ registerSuite({
 			assert.isTrue(widgetTwoInstantiated);
 		}
 	},
-	'registry': {
-	},
 	'child invalidation invalidates parent'() {
 		let childInvalidate = () => {};
 		let childInvalidateCalled = false;

--- a/tests/unit/decorators/inject.ts
+++ b/tests/unit/decorators/inject.ts
@@ -30,6 +30,7 @@ registerSuite({
 		@inject({ name: 'inject-one', getProperties })
 		class TestWidget extends WidgetBase<any> {}
 		const widget = createTestWidget(TestWidget, { registry });
+
 		assert.strictEqual(widget.getWidgetUnderTest().properties.foo, 'bar');
 	},
 	'multiple injectors'() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -1,6 +1,5 @@
 import global from '@dojo/shim/global';
 import has from '@dojo/has/has';
-import '@dojo/shim/Promise';
 import { VNode } from '@dojo/interfaces/vdom';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
@@ -8,6 +7,7 @@ import { spy, stub, SinonStub } from 'sinon';
 import { v } from '../../../src/d';
 import { ProjectorMixin, ProjectorAttachState } from '../../../src/mixins/Projector';
 import { beforeRender, WidgetBase } from '../../../src/WidgetBase';
+import { Registry } from './../../../src/Registry';
 
 const Event = global.window.Event;
 
@@ -744,6 +744,25 @@ registerSuite({
 		// Demonstrates the type guarding for widget properties
 
 		// projector.setProperties({ foo: true });
+	},
+	'registry destroyed when a new registry is received'() {
+		let registryDestroyedCount = 0;
+		class TestRegistry extends Registry {
+			destroy(): Promise<any> {
+				registryDestroyedCount++;
+				return super.destroy();
+			}
+		}
+		const projector = new BaseTestWidget();
+		projector.setProperties({ registry: new TestRegistry() });
+		assert.strictEqual(registryDestroyedCount, 0);
+		projector.setProperties({ registry: new TestRegistry() });
+		assert.strictEqual(registryDestroyedCount, 1);
+		projector.setProperties({ registry: undefined });
+		assert.strictEqual(registryDestroyedCount, 2);
+		projector.setProperties({ registry: new TestRegistry() });
+		projector.destroy();
+		assert.strictEqual(registryDestroyedCount, 3);
 	},
 	'scheduleRender on setting properties'() {
 		const projector = new BaseTestWidget();

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -399,7 +399,7 @@ registerSuite({
 				}
 			}
 			const themeableInstance = createTestWidget(InjectedTheme, { theme: testTheme2, registry: testRegistry });
-			const vNode: any = themeableInstance.renderResult;
+			const vNode: any = themeableInstance.__render__();
 			assert.deepEqual(vNode.properties.classes, { theme2Class1: true });
 		},
 		'does not attempt to inject if the ThemeInjector has not been defined in the registry'() {
@@ -424,14 +424,14 @@ registerSuite({
 			class MultipleThemedWidgets extends WidgetBase {
 				render() {
 					return v('div', [
-						w(InjectedTheme, { key: '1', registry: this.properties.registry }),
-						w(InjectedTheme, { key: '2', registry: this.properties.registry })
+						w(InjectedTheme, { key: '1' }),
+						w(InjectedTheme, { key: '2' })
 					]);
 				}
 			}
 
 			const testWidget = new MultipleThemedWidgets();
-			testWidget.__setProperties__({ registry: testRegistry });
+			testWidget.__setCoreProperties__({ bind: testWidget, baseRegistry: testRegistry });
 			let vNode: any = testWidget.__render__();
 			assert.lengthOf(vNode.children, 2);
 			assert.deepEqual(vNode.children[0].properties.classes, { theme1Class1: true });

--- a/tests/unit/tsxIntegration.tsx
+++ b/tests/unit/tsxIntegration.tsx
@@ -38,7 +38,7 @@ registerSuite({
 		}
 
 		const bar = new Bar();
-		bar.__setCoreProperties__({ registry });
+		bar.__setCoreProperties__({ bind: bar, baseRegistry: registry });
 		bar.__setProperties__({ registry });
 		const barRender = bar.__render__() as VNode;
 		const barChild = barRender.children![0];
@@ -46,7 +46,7 @@ registerSuite({
 		assert.equal(barChild.text, 'world');
 
 		const qux = new Qux();
-		qux.__setCoreProperties__({ registry });
+		qux.__setCoreProperties__({ bind: qux, baseRegistry: registry });
 		qux.__setProperties__({ registry });
 		const firstQuxRender = qux.__render__();
 		assert.equal(firstQuxRender, null);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

The more that registries have been explored, the more apparent it has become that the main use cases will be to support lazy loading widgets and for injecting values into the widget tree.

These changes remove `registry` as a supported property for all widgets, so that a `registry` is only supported for a `projector` (or app level). This `registry` will be passed as the `baseRegistry` for all widgets within the projector tree. 

As well as the `baseRegistry`, each widget will have access to define entries into a local registry created per instance. These locally defined entries will take precedence over entries with the same label defined in the `baseRegistry`.

The `registries` property (the `RegistryHandler`) on `WidgetBase` has been re-named to `registry`, as consumers will work with the handler as is they would a single registry.

In advanced cases, it is possible to invert the default precedence on a case by case basis, by passing a boolean with the label to the get (`get` / `getInjector`) functions, so that, if there is a item in the base registry it will be returned ahead of an item defined in the local registry. 

```ts
this.registry.get('widget', true);
this.registry.getInjector('widget', true);
```

This could be useful to enable a particular default to be overridden for a widget, for example a loading widget. Locally this would be registered as `this.registry.define('my-widget-loading', DefaultLoading);` but used with the extra boolean flag `this.registry.get('my-widget-loading', true);` so that consumers could add a custom widget to their application registry to override the `DefaultLoading` widget.