### PR TITLE
use the global precedence when checking to invalidate

### DIFF
--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -59,7 +59,7 @@ export class RegistryHandler extends Evented {
 			}
 			else if (registeredLabels.indexOf(label) === -1) {
 				const handle = registry.on(label, (event: RegistryEventObject) => {
-					if (event.action === 'loaded' && (this as any)[getFunctionName](label) === event.item) {
+					if (event.action === 'loaded' && (this as any)[getFunctionName](label, globalPrecedence) === event.item) {
 						this.emit({ type: 'invalidate' });
 					}
 				});

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -6,7 +6,7 @@ import '@dojo/shim/Promise'; // Imported for side-effects
 import WeakMap from '@dojo/shim/WeakMap';
 import { Handle } from '@dojo/interfaces/core';
 import { isWNode, v, isHNode } from './d';
-import { auto, ignore } from './diff';
+import { auto } from './diff';
 import {
 	AfterRender,
 	BeforeProperties,
@@ -122,7 +122,6 @@ const boundAuto = auto.bind(null);
 /**
  * Main widget base for all widgets to extend
  */
-@diffProperty('registry', ignore)
 export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends Evented implements WidgetBaseInterface<P, C> {
 
 	/**

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -121,6 +121,20 @@ registerSuite({
 				registry.define('widget', GlobalWidget);
 				assert.strictEqual(invalidateCount, 1);
 			},
+			'no `invalidate` events emitted once the with registry with the highest precedence has loaded - with global'() {
+				const registryHandler = new RegistryHandler();
+				const registry = new Registry();
+				registryHandler.base = registry;
+				let invalidateCount = 0;
+				registryHandler.on('invalidate', () => {
+					invalidateCount++;
+				});
+				registryHandler.get('widget', true);
+				registry.define('widget', GlobalWidget);
+				assert.strictEqual(invalidateCount, 1);
+				registryHandler.define('widget', LocalWidget);
+				assert.strictEqual(invalidateCount, 1);
+			},
 			'ignores unknown event actions'() {
 				const registryHandler = new RegistryHandler();
 				const registry = new Registry();
@@ -243,6 +257,21 @@ registerSuite({
 				registryHandler.defineInjector('injector', localInjector);
 				assert.strictEqual(invalidateCount, 1);
 				registry.defineInjector('injector', globalInjector);
+				assert.strictEqual(invalidateCount, 1);
+			},
+			'no `invalidate` events emitted once the with registry with the highest precedence has loaded - with global'() {
+				const registryHandler = new RegistryHandler();
+				const registry = new Registry();
+				registryHandler.base = registry;
+				const localInjector = new Injector({});
+				let invalidateCount = 0;
+				registryHandler.on('invalidate', () => {
+					invalidateCount++;
+				});
+				registryHandler.getInjector('injector', true);
+				registry.defineInjector('injector', globalInjector);
+				assert.strictEqual(invalidateCount, 1);
+				registryHandler.defineInjector('injector', localInjector);
 				assert.strictEqual(invalidateCount, 1);
 			},
 			'ignores unknown event actions'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that the `globalPrecedence` flag is used when checking if registered widgets need invalidation.

Also removes the `diffProperty` for `registry`, as no longer required.