### PR TITLE
Move decorators out of WidgetBase

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -12,7 +12,6 @@ import {
 	BeforeProperties,
 	BeforeRender,
 	CoreProperties,
-	DiffPropertyFunction,
 	DiffPropertyReaction,
 	DNode,
 	Render,
@@ -23,6 +22,7 @@ import {
 	WidgetBaseInterface,
 	WidgetProperties
 } from './interfaces';
+import { diffProperty } from './decorators/diffProperty';
 import RegistryHandler from './RegistryHandler';
 import NodeHandler from './NodeHandler';
 import { isWidgetBaseConstructor, WIDGET_BASE_TYPE } from './Registry';
@@ -57,66 +57,6 @@ interface ReactionFunctionConfig {
 export type BoundFunctionData = { boundFunc: (...args: any[]) => any, scope: any };
 
 const decoratorMap = new Map<Function, Map<string, any[]>>();
-
-/**
- * Decorator that can be used to register a function to run as an aspect to `render`
- */
-export function afterRender(method: Function): (target: any) => void;
-export function afterRender(): (target: any, propertyKey: string) => void;
-export function afterRender(method?: Function) {
-	return handleDecorator((target, propertyKey) => {
-		target.addDecorator('afterRender', propertyKey ? target[propertyKey] : method);
-	});
-}
-
-/**
- * Decorator that can be used to register a reducer function to run as an aspect before to `render`
- */
-export function beforeRender(method: Function): (target: any) => void;
-export function beforeRender(): (target: any, propertyKey: string) => void;
-export function beforeRender(method?: Function) {
-	return handleDecorator((target, propertyKey) => {
-		target.addDecorator('beforeRender', propertyKey ? target[propertyKey] : method);
-	});
-}
-
-/**
- * Decorator that can be used to register a function as a specific property diff
- *
- * @param propertyName  The name of the property of which the diff function is applied
- * @param diffType      The diff type, default is DiffType.AUTO.
- * @param diffFunction  A diff function to run if diffType if DiffType.CUSTOM
- */
-export function diffProperty(propertyName: string, diffFunction: DiffPropertyFunction, reactionFunction?: Function) {
-	return handleDecorator((target, propertyKey) => {
-		target.addDecorator(`diffProperty:${propertyName}`, diffFunction.bind(null));
-		target.addDecorator('registeredDiffProperty', propertyName);
-		if (reactionFunction || propertyKey) {
-			target.addDecorator('diffReaction', {
-				propertyName,
-				reaction: propertyKey ? target[propertyKey] : reactionFunction
-			});
-		}
-	});
-}
-
-/**
- * Generic decorator handler to take care of whether or not the decorator was called at the class level
- * or the method level.
- *
- * @param handler
- */
-export function handleDecorator(handler: (target: any, propertyKey?: string) => void) {
-	return function (target: any, propertyKey?: string, descriptor?: PropertyDescriptor) {
-		if (typeof target === 'function') {
-			handler(target.prototype, undefined);
-		}
-		else {
-			handler(target, propertyKey);
-		}
-	};
-}
-
 const boundAuto = auto.bind(null);
 
 /**
@@ -153,7 +93,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	private _coreProperties: CoreProperties = {} as CoreProperties;
 
 	/**
-	 * cached chldren map for instance management
+	 * cached children map for instance management
 	 */
 	private _cachedChildrenMap: Map<string | number | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
 

--- a/src/decorators/afterRender.ts
+++ b/src/decorators/afterRender.ts
@@ -1,0 +1,14 @@
+import { handleDecorator } from './handleDecorator';
+
+/**
+ * Decorator that can be used to register a function to run as an aspect to `render`
+ */
+export function afterRender(method: Function): (target: any) => void;
+export function afterRender(): (target: any, propertyKey: string) => void;
+export function afterRender(method?: Function) {
+	return handleDecorator((target, propertyKey) => {
+		target.addDecorator('afterRender', propertyKey ? target[propertyKey] : method);
+	});
+}
+
+export default afterRender;

--- a/src/decorators/beforeProperties.ts
+++ b/src/decorators/beforeProperties.ts
@@ -1,4 +1,4 @@
-import { handleDecorator } from './../WidgetBase';
+import { handleDecorator } from './handleDecorator';
 import { BeforeProperties } from './../interfaces';
 
 /**

--- a/src/decorators/beforeRender.ts
+++ b/src/decorators/beforeRender.ts
@@ -1,0 +1,14 @@
+import { handleDecorator } from './handleDecorator';
+
+/**
+ * Decorator that can be used to register a reducer function to run as an aspect before to `render`
+ */
+export function beforeRender(method: Function): (target: any) => void;
+export function beforeRender(): (target: any, propertyKey: string) => void;
+export function beforeRender(method?: Function) {
+	return handleDecorator((target, propertyKey) => {
+		target.addDecorator('beforeRender', propertyKey ? target[propertyKey] : method);
+	});
+}
+
+export default beforeRender;

--- a/src/decorators/diffProperty.ts
+++ b/src/decorators/diffProperty.ts
@@ -1,0 +1,24 @@
+import { handleDecorator } from './handleDecorator';
+import { DiffPropertyFunction } from './../interfaces';
+
+/**
+ * Decorator that can be used to register a function as a specific property diff
+ *
+ * @param propertyName  The name of the property of which the diff function is applied
+ * @param diffType      The diff type, default is DiffType.AUTO.
+ * @param diffFunction  A diff function to run if diffType if DiffType.CUSTOM
+ */
+export function diffProperty(propertyName: string, diffFunction: DiffPropertyFunction, reactionFunction?: Function) {
+	return handleDecorator((target, propertyKey) => {
+		target.addDecorator(`diffProperty:${propertyName}`, diffFunction.bind(null));
+		target.addDecorator('registeredDiffProperty', propertyName);
+		if (reactionFunction || propertyKey) {
+			target.addDecorator('diffReaction', {
+				propertyName,
+				reaction: propertyKey ? target[propertyKey] : reactionFunction
+			});
+		}
+	});
+}
+
+export default diffProperty;

--- a/src/decorators/handleDecorator.ts
+++ b/src/decorators/handleDecorator.ts
@@ -1,0 +1,18 @@
+/**
+ * Generic decorator handler to take care of whether or not the decorator was called at the class level
+ * or the method level.
+ *
+ * @param handler
+ */
+export function handleDecorator(handler: (target: any, propertyKey?: string) => void) {
+	return function (target: any, propertyKey?: string, descriptor?: PropertyDescriptor) {
+		if (typeof target === 'function') {
+			handler(target.prototype, undefined);
+		}
+		else {
+			handler(target, propertyKey);
+		}
+	};
+}
+
+export default handleDecorator;

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -1,5 +1,6 @@
 import WeakMap from '@dojo/shim/WeakMap';
-import { handleDecorator, WidgetBase } from './../WidgetBase';
+import { WidgetBase } from './../WidgetBase';
+import { handleDecorator } from './handleDecorator';
 import { Injector } from './../Injector';
 import { beforeProperties } from './beforeProperties';
 import { RegistryLabel } from './../interfaces';
@@ -61,3 +62,5 @@ export function inject({ name, getProperties }: InjectConfig) {
 		})(target);
 	});
 }
+
+export default inject;

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -9,7 +9,8 @@ import i18n, {
 } from '@dojo/i18n/i18n';
 import { VNodeProperties } from '@dojo/interfaces/vdom';
 import { Constructor, DNode, WidgetProperties } from './../interfaces';
-import { afterRender, WidgetBase } from './../WidgetBase';
+import { WidgetBase } from './../WidgetBase';
+import { afterRender } from './../decorators/afterRender';
 import { isHNode } from './../d';
 
 export interface I18nProperties extends WidgetProperties {

--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -5,7 +5,9 @@ import { ClassesFunction, Constructor, WidgetProperties } from './../interfaces'
 import { Registry } from './../Registry';
 import { Injector } from './../Injector';
 import { inject } from './../decorators/inject';
-import { diffProperty, WidgetBase, handleDecorator } from './../WidgetBase';
+import { WidgetBase } from './../WidgetBase';
+import { handleDecorator } from './../decorators/handleDecorator';
+import { diffProperty } from './../decorators/diffProperty';
 import { shallow } from './../diff';
 
 /**

--- a/tests/unit/Container.ts
+++ b/tests/unit/Container.ts
@@ -1,7 +1,8 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { v , w } from '../../src/d';
-import { diffProperty, WidgetBase } from '../../src/WidgetBase';
+import { WidgetBase } from '../../src/WidgetBase';
+import { diffProperty } from './../../src/decorators/diffProperty';
 import { always } from '../../src/diff';
 import { Container } from './../../src/Container';
 import { Registry } from './../../src/Registry';

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -1,31 +1,25 @@
-import { VNode } from '@dojo/interfaces/vdom';
-import Promise from '@dojo/shim/Promise';
+
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { stub, spy, SinonStub } from 'sinon';
 import { v, w } from '../../src/d';
-import { Constructor, DNode, PropertyChangeRecord, Render } from '../../src/interfaces';
-import {
-	WidgetBase,
-	diffProperty,
-	afterRender,
-	beforeRender
-} from '../../src/WidgetBase';
-import { ignore, always, auto } from '../../src/diff';
+import { VNode } from '@dojo/interfaces/vdom';
+import { Constructor, DNode } from '../../src/interfaces';
+import { WidgetBase } from '../../src/WidgetBase';
 import Registry, { WIDGET_BASE_TYPE } from './../../src/Registry';
-import createTestWidget from './../support/createTestWidget';
 
-interface TestProperties {
-	id?: string;
-	foo: string;
-	bar?: null | string;
-	baz?: number;
-	qux?: boolean;
-}
+import { handleDecorator } from './../../src/decorators/handleDecorator';
+import createTestWidget from './../support/createTestWidget';
 
 let consoleStub: SinonStub;
 
 const registry = new Registry();
+
+function testDecorator(func?: Function) {
+	return handleDecorator((target, propertyKey) => {
+		target.addDecorator('test-decorator', func);
+	});
+}
 
 registerSuite({
 	name: 'WidgetBase',
@@ -97,12 +91,8 @@ registerSuite({
 			let invalidateCalled = false;
 			let renderCount = 0;
 			class Foo extends WidgetBase<{ bar: string }> {
-				@diffProperty('bar', auto)
-				barDiff() {
-					this.invalidate();
-					return {
-						changed: false
-					};
+				invalidate() {
+					super.invalidate();
 				}
 				render() {
 					renderCount++;
@@ -116,7 +106,9 @@ registerSuite({
 			});
 			foo.__render__();
 			assert.equal(renderCount, 1);
-			foo.__setProperties__({ bar: 'qux' });
+			foo.__setCoreProperties__({ bind: foo, baseRegistry: registry });
+			foo.invalidate();
+			foo.__setProperties__({ bar: '' });
 			foo.__render__();
 			assert.equal(renderCount, 2);
 			assert.isFalse(invalidateCalled);
@@ -147,281 +139,6 @@ registerSuite({
 			const widget = new WidgetBase();
 			const renderedWidget = <VNode> (<any> widget).__render__();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'div');
-	},
-	diffProperty: {
-		'decorator': {
-			'diff with no reaction'() {
-				let callCount = 0;
-				function diffFoo(previousProperty: any, newProperty: any) {
-					callCount++;
-					assert.equal(newProperty, 'bar');
-					return {
-						changed: true,
-						value: newProperty
-					};
-				}
-
-				@diffProperty('foo', diffFoo)
-				@diffProperty('bar', diffFoo)
-				class TestWidget extends WidgetBase<TestProperties> {}
-
-				const testWidget = new TestWidget();
-
-				testWidget.__setProperties__({ id: '', foo: 'bar' });
-				assert.equal(callCount, 1);
-			},
-			'diff with reaction': {
-				'reaction does not execute if no registered properties are changed'() {
-					let callCount = 0;
-					function customDiff(previousProperty: any, newProperty: any) {
-						callCount++;
-						return {
-							changed: false,
-							value: newProperty
-						};
-					}
-
-					class TestWidget extends WidgetBase<TestProperties> {
-
-						reactionCalled = false;
-
-						@diffProperty('foo', customDiff)
-						@diffProperty('id', customDiff)
-						protected onFooOrBarChanged(): void {
-							this.reactionCalled = true;
-						}
-					}
-					const testWidget = new TestWidget();
-					testWidget.__setProperties__({ id: '', foo: 'bar' });
-					assert.strictEqual(callCount, 2);
-					assert.isFalse(testWidget.reactionCalled);
-				},
-				'reaction executed when at least one registered properties is changed'() {
-					let callCount = 0;
-					function customDiff(previousProperty: any, newProperty: any) {
-						callCount++;
-						return {
-							changed: newProperty === 'bar' ? true : false,
-							value: newProperty
-						};
-					}
-
-					class TestWidget extends WidgetBase<TestProperties> {
-
-						reactionCalled = false;
-
-						@diffProperty('foo', customDiff)
-						@diffProperty('id', customDiff)
-						protected onFooOrBarChanged(): void {
-							this.reactionCalled = true;
-						}
-					}
-					const testWidget = new TestWidget();
-					testWidget.__setProperties__({ id: '', foo: 'bar' });
-					assert.strictEqual(callCount, 2);
-					assert.isTrue(testWidget.reactionCalled);
-				}
-			}
-		},
-		'non decorator': {
-			'diff with no reaction'() {
-				let callCount = 0;
-
-				function diffPropertyFoo(previousProperty: string, newProperty: string): PropertyChangeRecord {
-					callCount++;
-					assert.equal(newProperty, 'bar');
-					return {
-						changed: false,
-						value: newProperty
-					};
-				}
-
-				class TestWidget extends WidgetBase<TestProperties> {
-					constructor() {
-						super();
-						diffProperty('foo', diffPropertyFoo)(this);
-					}
-				}
-
-				const testWidget = new TestWidget();
-				testWidget.__setProperties__({ id: '', foo: 'bar' });
-				assert.equal(callCount, 1);
-			},
-			'diff with reaction': {
-				'reaction does not execute if no registered properties are changed'() {
-					let callCount = 0;
-
-					function diffPropertyFoo(previousProperty: string, newProperty: string): PropertyChangeRecord {
-						callCount++;
-						assert.equal(newProperty, 'bar');
-						return {
-							changed: false,
-							value: newProperty
-						};
-					}
-
-					class TestWidget extends WidgetBase<TestProperties> {
-						reactionCalled = false;
-						constructor() {
-							super();
-							diffProperty('foo', diffPropertyFoo, this.onFooPropertyChanged)(this);
-						}
-
-						onFooPropertyChanged(previousProperties: any, newProperties: any): void {
-							this.reactionCalled = true;
-						}
-					}
-
-					const testWidget = new TestWidget();
-					testWidget.__setProperties__({ id: '', foo: 'bar' });
-					assert.equal(callCount, 1);
-					assert.isFalse(testWidget.reactionCalled);
-				},
-				'reaction executed when at least one registered properties is changed'() {
-					let callCount = 0;
-
-					function customDiffProperty(previousProperty: string, newProperty: string): PropertyChangeRecord {
-						callCount++;
-						return {
-							changed: newProperty === 'bar' ? true : false,
-							value: newProperty
-						};
-					}
-
-					class TestWidget extends WidgetBase<TestProperties> {
-						reactionCalled = false;
-						constructor() {
-							super();
-							diffProperty('foo', customDiffProperty, this.onPropertyChanged)(this);
-							diffProperty('id', customDiffProperty, this.onPropertyChanged)(this);
-						}
-
-						onPropertyChanged(previousProperties: any, newProperties: any): void {
-							this.reactionCalled = true;
-						}
-					}
-
-					const testWidget = new TestWidget();
-					testWidget.__setProperties__({ id: '', foo: 'bar' });
-					assert.equal(callCount, 2);
-					assert.isTrue(testWidget.reactionCalled);
-				}
-			}
-		},
-		'decorators can be applied at instance level'() {
-			let renderCallCount = 0;
-
-			class TestWidget extends WidgetBase<any> {
-				constructor() {
-					super();
-
-					afterRender((node: DNode) => {
-						renderCallCount++;
-						return node;
-					})(this);
-				}
-
-				render() {
-					return v('div');
-				}
-			}
-
-			new TestWidget();
-			const widget2 = new TestWidget();
-			widget2.__render__();
-
-			assert.equal(renderCallCount, 1);
-		},
-		'multiple default decorators on the same method cause the first matching decorator to win'() {
-			@diffProperty('foo', ignore)
-			class TestWidget extends WidgetBase<TestProperties> { }
-
-			@diffProperty('foo', always)
-			class SubWidget extends TestWidget { }
-
-			const widget = new SubWidget();
-			const vnode = widget.__render__();
-
-			widget.__setProperties__({
-				foo: 'bar'
-			});
-
-			assert.notStrictEqual(vnode, widget.__render__());
-		},
-		'multiple custom decorators on the same method cause the first matching decorator to win'() {
-			const calls: string[] = [];
-
-			function diff1(prevProp: any, newProp: any): PropertyChangeRecord {
-				calls.push('diff1');
-				return {
-					changed: false,
-					value: newProp
-				};
-			}
-
-			function diff2(prevProp: any, newProp: any): PropertyChangeRecord {
-				calls.push('diff2');
-				return {
-					changed: false,
-					value: newProp
-				};
-			}
-
-			@diffProperty('foo', diff1)
-			class TestWidget extends WidgetBase<TestProperties> { }
-
-			@diffProperty('foo', diff2)
-			class SubWidget extends TestWidget { }
-
-			const widget = new SubWidget();
-			widget.__setProperties__({
-				id: '',
-				foo: 'bar'
-			});
-
-			assert.deepEqual(calls, ['diff1', 'diff2']);
-			assert.strictEqual(calls[0], 'diff1');
-			assert.strictEqual(calls[1], 'diff2');
-		},
-
-		'diffProperty properties are excluded from catch-all'() {
-			function customDiff() {
-				return {
-					changed: false,
-					value: ''
-				};
-			}
-			@diffProperty('foo', customDiff)
-			@diffProperty('id', customDiff)
-			class TestWidget extends WidgetBase<TestProperties> { }
-
-			const widget = new TestWidget();
-			const vnode = widget.__render__();
-
-			widget.__setProperties__({
-				foo: '',
-				id: ''
-			});
-			assert.strictEqual(vnode, widget.__render__());
-		},
-
-		'properties that are deleted dont get returned'() {
-			const widget = new WidgetBase<any>();
-			widget.__setProperties__({
-				a: 1,
-				b: 2,
-				c: 3
-			});
-
-			assert.deepEqual(widget.properties, { a: 1, b: 2, c: 3 });
-
-			widget.__setProperties__({
-				a: 4,
-				c: 5
-			});
-
-			assert.deepEqual(widget.properties, { a: 4, c: 5 });
-		}
 	},
 	setProperties: {
 		'widgets function properties are bound to the parent by default'() {
@@ -520,212 +237,11 @@ registerSuite({
 			assert.isTrue(testWidget.properties.functionIsBound);
 		}
 	},
-	beforeRender: {
-		decorator() {
-			let beforeRenderCount = 1;
-			type RenderFunction = () => DNode;
-			class TestWidget extends WidgetBase<any> {
-				@beforeRender()
-				firstAfterRender(renderFunction: RenderFunction, properties: any, children: DNode[]): RenderFunction {
-					assert.strictEqual(beforeRenderCount++, 1);
-					return () => {
-						const rendered = renderFunction();
-						const clonedProperties = { ...properties };
-						return v('bar', clonedProperties, [ rendered, ...children ]);
-					};
-				}
-
-				@beforeRender()
-				secondAfterRender(renderFunction: RenderFunction, properties: any, children: DNode[]): RenderFunction {
-					assert.strictEqual(beforeRenderCount++, 2);
-					return () => {
-						const rendered = renderFunction();
-						properties.bar = 'foo';
-						return v('qux', properties, [ rendered ]);
-					};
-				}
-			}
-
-			class ExtendedTestWidget extends TestWidget {
-				@beforeRender()
-				thirdAfterRender(renderFunction: RenderFunction, properties: any, children: DNode[]): RenderFunction {
-					assert.strictEqual(beforeRenderCount, 3);
-					return renderFunction;
-				}
-
-				render() {
-					return v('foo', this.children);
-				}
-			}
-
-			const widget = new ExtendedTestWidget();
-			widget.__setChildren__([v('baz', { baz: 'qux' })]);
-			widget.__setProperties__({ foo: 'bar' });
-			const qux: any = widget.__render__();
-			assert.equal(qux.vnodeSelector, 'qux');
-			assert.deepEqual(qux.properties.bind, widget);
-			assert.equal(qux.properties.bar, 'foo');
-			assert.equal(qux.properties.foo, 'bar');
-			assert.lengthOf(qux.children, 1);
-			const bar = qux.children[0];
-			assert.equal(bar.vnodeSelector, 'bar');
-			assert.deepEqual(bar.properties.bind, widget);
-			assert.deepEqual(bar.properties.foo, 'bar');
-			assert.lengthOf(bar.children, 2);
-			const foo = bar.children[0];
-			assert.equal(foo.vnodeSelector, 'foo');
-			assert.deepEqual(foo.properties.bind, widget);
-			assert.lengthOf(foo.children, 1);
-			const baz1 = foo.children[0];
-			assert.equal(baz1.vnodeSelector, 'baz');
-			assert.deepEqual(baz1.properties.bind, widget);
-			assert.deepEqual(baz1.properties.baz, 'qux');
-			assert.lengthOf(baz1.children, 0);
-			const baz2 = bar.children[1];
-			assert.equal(baz2.vnodeSelector, 'baz');
-			assert.deepEqual(baz2.properties.bind, widget);
-			assert.deepEqual(baz2.properties.baz, 'qux');
-			assert.lengthOf(baz2.children, 0);
-		},
-		'class level decorator'() {
-			let beforeRenderCount = 0;
-
-			@beforeRender(function (renderFunc: Render) {
-				beforeRenderCount++;
-				return renderFunc;
-			})
-			class TestWidget extends WidgetBase<any> {
-			}
-
-			const widget = new TestWidget();
-			widget.__render__();
-			assert.strictEqual(beforeRenderCount, 1);
-		},
-		'Use previous render function when a beforeRender does not return a function'() {
-			class TestWidget extends WidgetBase {
-				@beforeRender()
-				protected firstBeforeRender(renderFunc: Render) {
-					return () => 'first render';
-				}
-
-				@beforeRender()
-				protected secondBeforeRender(renderFunc: Render) { }
-			}
-
-			const widget = new TestWidget();
-			const vNode = <VNode> widget.__render__();
-			assert.strictEqual(vNode, 'first render');
-			assert.isTrue(consoleStub.calledOnce);
-			assert.isTrue(consoleStub.calledWith('Render function not returned from beforeRender, using previous render'));
-		}
-	},
-	afterRender: {
-		decorator() {
-			let afterRenderCount = 1;
-			class TestWidget extends WidgetBase<any> {
-				@afterRender()
-				firstAfterRender(result: DNode): DNode {
-					assert.strictEqual(afterRenderCount++, 1);
-					return result;
-				}
-
-				@afterRender()
-				secondAfterRender(result: DNode): DNode {
-					assert.strictEqual(afterRenderCount++, 2);
-					return result;
-				}
-			}
-
-			class ExtendedTestWidget extends TestWidget {
-				@afterRender()
-				thirdAfterRender(result: DNode): DNode {
-					assert.strictEqual(afterRenderCount, 3);
-					return result;
-				}
-			}
-
-			const widget = new ExtendedTestWidget();
-			widget.__render__();
-			assert.strictEqual(afterRenderCount, 3);
-		},
-		'non decorator'() {
-			let afterRenderCount = 1;
-			class TestWidget extends WidgetBase<any> {
-
-				constructor() {
-					super();
-					afterRender()(this, 'firstAfterRender');
-					afterRender()(this, 'secondAfterRender');
-				}
-
-				firstAfterRender(result: DNode): DNode {
-					assert.strictEqual(afterRenderCount++, 1);
-					return result;
-				}
-
-				secondAfterRender(result: DNode): DNode {
-					assert.strictEqual(afterRenderCount++, 2);
-					return result;
-				}
-			}
-
-			class ExtendedTestWidget extends TestWidget {
-
-				constructor() {
-					super();
-					afterRender(this.thirdAfterRender)(this);
-				}
-
-				thirdAfterRender(result: DNode): DNode {
-					assert.strictEqual(afterRenderCount, 3);
-					return result;
-				}
-			}
-
-			const widget = new ExtendedTestWidget();
-			widget.__render__();
-			assert.strictEqual(afterRenderCount, 3);
-		},
-		'class level decorator'() {
-			let afterRenderCount = 0;
-
-			@afterRender(function (node: any) {
-				afterRenderCount++;
-				return node;
-			})
-			class TestWidget extends WidgetBase<any> {
-			}
-
-			const widget = new TestWidget();
-			widget.__render__();
-			assert.strictEqual(afterRenderCount, 1);
-		},
-		'class level without decorator'() {
-			let afterRenderCount = 0;
-
-			function afterRenderFn(node: any) {
-				afterRenderCount++;
-
-				return node;
-			}
-
-			class TestWidget extends WidgetBase<any> {
-				constructor() {
-					super();
-					afterRender(afterRenderFn)(this);
-				}
-			}
-
-			const widget = new TestWidget();
-			widget.__render__();
-			assert.strictEqual(afterRenderCount, 1);
-		}
-	},
 	'extendable'() {
 		let called = false;
 
 		function PropertyLogger() {
-			return afterRender(function(dNode: any) {
+			return testDecorator(function(dNode: any) {
 				called = true;
 				return dNode;
 			});
@@ -733,11 +249,14 @@ registerSuite({
 
 		@PropertyLogger()
 		class TestWidget extends WidgetBase {
+			public log() {
+				const testDecorators = this.getDecorator('test-decorator');
+				testDecorators[0]();
+			}
 		}
 
 		const widget = new TestWidget();
-		widget.__render__();
-
+		widget.log();
 		assert.strictEqual(called, true);
 	},
 	render: {
@@ -1352,12 +871,8 @@ registerSuite({
 		assert.equal(foo, 1);
 	},
 	'decorators are cached'() {
+		@testDecorator()
 		class TestWidget extends WidgetBase<any> {
-			@afterRender()
-			running(result: DNode): DNode {
-				return result;
-			}
-
 			render() {
 				return v('div');
 			}
@@ -1370,40 +885,31 @@ registerSuite({
 		const widget = new TestWidget();
 		const decoratorSpy = spy(widget, '_buildDecoratorList');
 
-		widget.callGetDecorator('afterRender');
+		widget.callGetDecorator('test-decorator');
 
 		// first call calls the method
 		assert.equal(decoratorSpy.callCount, 1);
-
-		widget.callGetDecorator('afterRender');
+		widget.callGetDecorator('test-decorator');
 
 		// second call is cached
 		assert.equal(decoratorSpy.callCount, 1);
 	},
 	'decorators applied to subclasses are not applied to base classes'() {
-		class TestWidget extends WidgetBase<any> {
-			@afterRender()
-			firstRender(result: DNode): DNode {
-				return result;
-			}
-
-			getAfterRenders(): Function[] {
-				return this.getDecorator('afterRender');
+		@testDecorator()
+		class TestWidget extends WidgetBase {
+			getTestDecorators(): Function[] {
+				return this.getDecorator('test-decorator');
 			}
 		}
 
-		class TestWidget2 extends TestWidget {
-			@afterRender()
-			secondRender(result: DNode): DNode {
-				return result;
-			}
-		}
+		@testDecorator()
+		class TestWidget2 extends TestWidget { }
 
 		const testWidget = new TestWidget();
 		const testWidget2 = new TestWidget2();
 
-		assert.equal(testWidget.getAfterRenders().length, 1);
-		assert.equal(testWidget2.getAfterRenders().length, 2);
+		assert.equal(testWidget.getTestDecorators().length, 1);
+		assert.equal(testWidget2.getTestDecorators().length, 2);
 	},
 	'decorator cache is populated when addDecorator is called after instantiation'() {
 		class TestWidget extends WidgetBase<any> {

--- a/tests/unit/decorators/afterRender.ts
+++ b/tests/unit/decorators/afterRender.ts
@@ -1,0 +1,110 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+import { DNode } from './../../../src/interfaces';
+import { afterRender } from './../../../src/decorators/afterRender';
+import { WidgetBase } from './../../../src/WidgetBase';
+
+registerSuite({
+	name: 'decorators/afterRender',
+	decorator() {
+		let afterRenderCount = 1;
+		class TestWidget extends WidgetBase<any> {
+			@afterRender()
+			firstAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount++, 1);
+				return result;
+			}
+
+			@afterRender()
+			secondAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount++, 2);
+				return result;
+			}
+		}
+
+		class ExtendedTestWidget extends TestWidget {
+			@afterRender()
+			thirdAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount, 3);
+				return result;
+			}
+		}
+
+		const widget = new ExtendedTestWidget();
+		widget.__render__();
+		assert.strictEqual(afterRenderCount, 3);
+	},
+	'non decorator'() {
+		let afterRenderCount = 1;
+		class TestWidget extends WidgetBase<any> {
+
+			constructor() {
+				super();
+				afterRender()(this, 'firstAfterRender');
+				afterRender()(this, 'secondAfterRender');
+			}
+
+			firstAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount++, 1);
+				return result;
+			}
+
+			secondAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount++, 2);
+				return result;
+			}
+		}
+
+		class ExtendedTestWidget extends TestWidget {
+
+			constructor() {
+				super();
+				afterRender(this.thirdAfterRender)(this);
+			}
+
+			thirdAfterRender(result: DNode): DNode {
+				assert.strictEqual(afterRenderCount, 3);
+				return result;
+			}
+		}
+
+		const widget = new ExtendedTestWidget();
+		widget.__render__();
+		assert.strictEqual(afterRenderCount, 3);
+	},
+	'class level decorator'() {
+		let afterRenderCount = 0;
+
+		@afterRender(function (node: any) {
+			afterRenderCount++;
+			return node;
+		})
+		class TestWidget extends WidgetBase<any> {
+		}
+
+		const widget = new TestWidget();
+		widget.__render__();
+		assert.strictEqual(afterRenderCount, 1);
+	},
+	'class level without decorator'() {
+		let afterRenderCount = 0;
+
+		function afterRenderFn(node: any) {
+			afterRenderCount++;
+
+			return node;
+		}
+
+		class TestWidget extends WidgetBase<any> {
+			constructor() {
+				super();
+				afterRender(afterRenderFn)(this);
+			}
+		}
+
+		const widget = new TestWidget();
+		widget.__render__();
+		assert.strictEqual(afterRenderCount, 1);
+	}
+});

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -1,2 +1,5 @@
+import './afterRender';
 import './beforeProperties';
+import './beforeRender';
+import './diffProperty';
 import './inject';

--- a/tests/unit/decorators/beforeRender.ts
+++ b/tests/unit/decorators/beforeRender.ts
@@ -1,0 +1,117 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { stub, SinonStub } from 'sinon';
+
+import { v } from './../../../src/d';
+import { DNode, Render } from './../../../src/interfaces';
+import { beforeRender } from './../../../src/decorators/beforeRender';
+import { WidgetBase } from './../../../src/WidgetBase';
+
+let consoleStub: SinonStub;
+
+registerSuite({
+	name: 'decorators/beforeRender',
+	beforeEach() {
+		consoleStub = stub(console, 'warn');
+	},
+	afterEach() {
+		consoleStub.restore();
+	},
+	decorator() {
+		let beforeRenderCount = 1;
+		type RenderFunction = () => DNode;
+		class TestWidget extends WidgetBase<any> {
+			@beforeRender()
+			firstAfterRender(renderFunction: RenderFunction, properties: any, children: DNode[]): RenderFunction {
+				assert.strictEqual(beforeRenderCount++, 1);
+				return () => {
+					const rendered = renderFunction();
+					const clonedProperties = { ...properties };
+					return v('bar', clonedProperties, [ rendered, ...children ]);
+				};
+			}
+
+			@beforeRender()
+			secondAfterRender(renderFunction: RenderFunction, properties: any, children: DNode[]): RenderFunction {
+				assert.strictEqual(beforeRenderCount++, 2);
+				return () => {
+					const rendered = renderFunction();
+					properties.bar = 'foo';
+					return v('qux', properties, [ rendered ]);
+				};
+			}
+		}
+
+		class ExtendedTestWidget extends TestWidget {
+			@beforeRender()
+			thirdAfterRender(renderFunction: RenderFunction, properties: any, children: DNode[]): RenderFunction {
+				assert.strictEqual(beforeRenderCount, 3);
+				return renderFunction;
+			}
+
+			render() {
+				return v('foo', this.children);
+			}
+		}
+
+		const widget = new ExtendedTestWidget();
+		widget.__setChildren__([v('baz', { baz: 'qux' })]);
+		widget.__setProperties__({ foo: 'bar' });
+		const qux: any = widget.__render__();
+		assert.equal(qux.vnodeSelector, 'qux');
+		assert.deepEqual(qux.properties.bind, widget);
+		assert.equal(qux.properties.bar, 'foo');
+		assert.equal(qux.properties.foo, 'bar');
+		assert.lengthOf(qux.children, 1);
+		const bar = qux.children[0];
+		assert.equal(bar.vnodeSelector, 'bar');
+		assert.deepEqual(bar.properties.bind, widget);
+		assert.deepEqual(bar.properties.foo, 'bar');
+		assert.lengthOf(bar.children, 2);
+		const foo = bar.children[0];
+		assert.equal(foo.vnodeSelector, 'foo');
+		assert.deepEqual(foo.properties.bind, widget);
+		assert.lengthOf(foo.children, 1);
+		const baz1 = foo.children[0];
+		assert.equal(baz1.vnodeSelector, 'baz');
+		assert.deepEqual(baz1.properties.bind, widget);
+		assert.deepEqual(baz1.properties.baz, 'qux');
+		assert.lengthOf(baz1.children, 0);
+		const baz2 = bar.children[1];
+		assert.equal(baz2.vnodeSelector, 'baz');
+		assert.deepEqual(baz2.properties.bind, widget);
+		assert.deepEqual(baz2.properties.baz, 'qux');
+		assert.lengthOf(baz2.children, 0);
+	},
+	'class level decorator'() {
+		let beforeRenderCount = 0;
+
+		@beforeRender(function (renderFunc: Render) {
+			beforeRenderCount++;
+			return renderFunc;
+		})
+		class TestWidget extends WidgetBase<any> {
+		}
+
+		const widget = new TestWidget();
+		widget.__render__();
+		assert.strictEqual(beforeRenderCount, 1);
+	},
+	'Use previous render function when a beforeRender does not return a function'() {
+		class TestWidget extends WidgetBase {
+			@beforeRender()
+			protected firstBeforeRender(renderFunc: Render) {
+				return () => 'first render';
+			}
+
+			@beforeRender()
+			protected secondBeforeRender(renderFunc: Render) { }
+		}
+
+		const widget = new TestWidget();
+		const vNode = widget.__render__();
+		assert.strictEqual(vNode, 'first render');
+		assert.isTrue(consoleStub.calledOnce);
+		assert.isTrue(consoleStub.calledWith('Render function not returned from beforeRender, using previous render'));
+	}
+});

--- a/tests/unit/decorators/diffProperty.ts
+++ b/tests/unit/decorators/diffProperty.ts
@@ -1,0 +1,265 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+import { PropertyChangeRecord } from './../../../src/interfaces';
+import { always, ignore } from './../../../src/diff';
+import { diffProperty } from './../../../src/decorators/diffProperty';
+import { WidgetBase } from './../../../src/WidgetBase';
+
+interface TestProperties {
+	id?: string;
+	foo: string;
+}
+
+registerSuite({
+	name: 'decorators/diffProperty',
+	'decorator': {
+		'diff with no reaction'() {
+			let callCount = 0;
+			function diffFoo(previousProperty: any, newProperty: any) {
+				callCount++;
+				assert.equal(newProperty, 'bar');
+				return {
+					changed: true,
+					value: newProperty
+				};
+			}
+
+			@diffProperty('foo', diffFoo)
+			@diffProperty('bar', diffFoo)
+			class TestWidget extends WidgetBase<TestProperties> {}
+
+			const testWidget = new TestWidget();
+
+			testWidget.__setProperties__({ id: '', foo: 'bar' });
+			assert.equal(callCount, 1);
+		},
+		'diff with reaction': {
+			'reaction does not execute if no registered properties are changed'() {
+				let callCount = 0;
+				function customDiff(previousProperty: any, newProperty: any) {
+					callCount++;
+					return {
+						changed: false,
+						value: newProperty
+					};
+				}
+
+				class TestWidget extends WidgetBase<TestProperties> {
+
+					reactionCalled = false;
+
+					@diffProperty('foo', customDiff)
+					@diffProperty('id', customDiff)
+					protected onFooOrBarChanged(): void {
+						this.reactionCalled = true;
+					}
+				}
+				const testWidget = new TestWidget();
+				testWidget.__setProperties__({ id: '', foo: 'bar' });
+				assert.strictEqual(callCount, 2);
+				assert.isFalse(testWidget.reactionCalled);
+			},
+			'reaction executed when at least one registered properties is changed'() {
+				let callCount = 0;
+				function customDiff(previousProperty: any, newProperty: any) {
+					callCount++;
+					return {
+						changed: newProperty === 'bar' ? true : false,
+						value: newProperty
+					};
+				}
+
+				class TestWidget extends WidgetBase<TestProperties> {
+
+					reactionCalled = false;
+
+					@diffProperty('foo', customDiff)
+					@diffProperty('id', customDiff)
+					protected onFooOrBarChanged(): void {
+						this.reactionCalled = true;
+					}
+				}
+				const testWidget = new TestWidget();
+				testWidget.__setProperties__({ id: '', foo: 'bar' });
+				assert.strictEqual(callCount, 2);
+				assert.isTrue(testWidget.reactionCalled);
+			}
+		}
+	},
+	'non decorator': {
+		'diff with no reaction'() {
+			let callCount = 0;
+
+			function diffPropertyFoo(previousProperty: string, newProperty: string): PropertyChangeRecord {
+				callCount++;
+				assert.equal(newProperty, 'bar');
+				return {
+					changed: false,
+					value: newProperty
+				};
+			}
+
+			class TestWidget extends WidgetBase<TestProperties> {
+				constructor() {
+					super();
+					diffProperty('foo', diffPropertyFoo)(this);
+				}
+			}
+
+			const testWidget = new TestWidget();
+			testWidget.__setProperties__({ id: '', foo: 'bar' });
+			assert.equal(callCount, 1);
+		},
+		'diff with reaction': {
+			'reaction does not execute if no registered properties are changed'() {
+				let callCount = 0;
+
+				function diffPropertyFoo(previousProperty: string, newProperty: string): PropertyChangeRecord {
+					callCount++;
+					assert.equal(newProperty, 'bar');
+					return {
+						changed: false,
+						value: newProperty
+					};
+				}
+
+				class TestWidget extends WidgetBase<TestProperties> {
+					reactionCalled = false;
+					constructor() {
+						super();
+						diffProperty('foo', diffPropertyFoo, this.onFooPropertyChanged)(this);
+					}
+
+					onFooPropertyChanged(previousProperties: any, newProperties: any): void {
+						this.reactionCalled = true;
+					}
+				}
+
+				const testWidget = new TestWidget();
+				testWidget.__setProperties__({ id: '', foo: 'bar' });
+				assert.equal(callCount, 1);
+				assert.isFalse(testWidget.reactionCalled);
+			},
+			'reaction executed when at least one registered properties is changed'() {
+				let callCount = 0;
+
+				function customDiffProperty(previousProperty: string, newProperty: string): PropertyChangeRecord {
+					callCount++;
+					return {
+						changed: newProperty === 'bar' ? true : false,
+						value: newProperty
+					};
+				}
+
+				class TestWidget extends WidgetBase<TestProperties> {
+					reactionCalled = false;
+					constructor() {
+						super();
+						diffProperty('foo', customDiffProperty, this.onPropertyChanged)(this);
+						diffProperty('id', customDiffProperty, this.onPropertyChanged)(this);
+					}
+
+					onPropertyChanged(previousProperties: any, newProperties: any): void {
+						this.reactionCalled = true;
+					}
+				}
+
+				const testWidget = new TestWidget();
+				testWidget.__setProperties__({ id: '', foo: 'bar' });
+				assert.equal(callCount, 2);
+				assert.isTrue(testWidget.reactionCalled);
+			}
+		}
+	},
+	'multiple default decorators on the same method cause the first matching decorator to win'() {
+		@diffProperty('foo', ignore)
+		class TestWidget extends WidgetBase<TestProperties> { }
+
+		@diffProperty('foo', always)
+		class SubWidget extends TestWidget { }
+
+		const widget = new SubWidget();
+		const vnode = widget.__render__();
+
+		widget.__setProperties__({
+			foo: 'bar'
+		});
+
+		assert.notStrictEqual(vnode, widget.__render__());
+	},
+	'multiple custom decorators on the same method cause the first matching decorator to win'() {
+		const calls: string[] = [];
+
+		function diff1(prevProp: any, newProp: any): PropertyChangeRecord {
+			calls.push('diff1');
+			return {
+				changed: false,
+				value: newProp
+			};
+		}
+
+		function diff2(prevProp: any, newProp: any): PropertyChangeRecord {
+			calls.push('diff2');
+			return {
+				changed: false,
+				value: newProp
+			};
+		}
+
+		@diffProperty('foo', diff1)
+		class TestWidget extends WidgetBase<TestProperties> { }
+
+		@diffProperty('foo', diff2)
+		class SubWidget extends TestWidget { }
+
+		const widget = new SubWidget();
+		widget.__setProperties__({
+			id: '',
+			foo: 'bar'
+		});
+
+		assert.deepEqual(calls, ['diff1', 'diff2']);
+		assert.strictEqual(calls[0], 'diff1');
+		assert.strictEqual(calls[1], 'diff2');
+	},
+
+	'diffProperty properties are excluded from catch-all'() {
+		function customDiff() {
+			return {
+				changed: false,
+				value: ''
+			};
+		}
+		@diffProperty('foo', customDiff)
+		@diffProperty('id', customDiff)
+		class TestWidget extends WidgetBase<TestProperties> { }
+
+		const widget = new TestWidget();
+		const vnode = widget.__render__();
+
+		widget.__setProperties__({
+			foo: '',
+			id: ''
+		});
+		assert.strictEqual(vnode, widget.__render__());
+	},
+
+	'properties that are deleted dont get returned'() {
+		const widget = new WidgetBase<any>();
+		widget.__setProperties__({
+			a: 1,
+			b: 2,
+			c: 3
+		});
+
+		assert.deepEqual(widget.properties, { a: 1, b: 2, c: 3 });
+
+		widget.__setProperties__({
+			a: 4,
+			c: 5
+		});
+
+		assert.deepEqual(widget.properties, { a: 4, c: 5 });
+	}
+});

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -6,7 +6,8 @@ import * as assert from 'intern/chai!assert';
 import { spy, stub, SinonStub } from 'sinon';
 import { v } from '../../../src/d';
 import { ProjectorMixin, ProjectorAttachState } from '../../../src/mixins/Projector';
-import { beforeRender, WidgetBase } from '../../../src/WidgetBase';
+import { WidgetBase } from '../../../src/WidgetBase';
+import { beforeRender } from './../../../src/decorators/beforeRender';
 import { Registry } from './../../../src/Registry';
 
 const Event = global.window.Event;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Move all decorators into their own modules in the `decorators` directory.

Resolves #683
