### PR TITLE
`alwaysRender` Decorator

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -2,6 +2,7 @@ import { WidgetBase } from './WidgetBase';
 import { inject, GetProperties } from './decorators/inject';
 import { Constructor, DNode, RegistryLabel } from './interfaces';
 import { w } from './d';
+import { alwaysRender } from './decorators/alwaysRender';
 
 export type Container<T extends WidgetBase> = Constructor<WidgetBase<Partial<T['properties']>>>;
 
@@ -11,11 +12,8 @@ export function Container<W extends WidgetBase> (
 	{ getProperties }: { getProperties: GetProperties }
 ): Container<W> {
 	@inject({ name, getProperties })
+	@alwaysRender()
 	class WidgetContainer extends WidgetBase<Partial<W['properties']>> {
-		public __setProperties__(properties: Partial<W['properties']>): void {
-			super.__setProperties__(properties as any);
-			this.invalidate();
-		}
 		protected render(): DNode {
 			return w(component, this.properties, this.children);
 		}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -152,7 +152,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	private _coreProperties: CoreProperties = {} as CoreProperties;
 
 	/**
-	 * cached chldren map for instance management
+	 * cached children map for instance management
 	 */
 	private _cachedChildrenMap: Map<string | number | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
 
@@ -318,28 +318,48 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 
 	public __setProperties__(originalProperties: this['properties']): void {
 		const properties = this._runBeforeProperties(originalProperties);
-		const changedPropertyKeys: string[] = [];
-		const allProperties = [ ...Object.keys(properties), ...Object.keys(this._properties) ];
-		const checkedProperties: string[] = [];
-		const diffPropertyResults: any = {};
+		const alwaysRender = this.getDecorator('alwaysRender').length > 0;
 		const registeredDiffPropertyNames = this.getDecorator('registeredDiffProperty');
-		let runReactions = false;
 
+		let changedPropertyKeys: string[] = [];
+		let diffPropertyResults: any = {};
 		this._renderState = WidgetRenderState.PROPERTIES;
 
-		for (let i = 0; i < allProperties.length; i++) {
-			const propertyName = allProperties[i];
-			if (checkedProperties.indexOf(propertyName) > 0) {
-				continue;
+		if (alwaysRender) {
+			if (registeredDiffPropertyNames.length > 0) {
+				throw new Error('Widget marked as `alwayRender` but has custom diffs registered');
 			}
-			checkedProperties.push(propertyName);
-			const previousProperty = this._properties[propertyName];
-			const newProperty = this._bindFunctionProperty(properties[propertyName], this._coreProperties.bind);
-			if (registeredDiffPropertyNames.indexOf(propertyName) !== -1) {
-				runReactions = true;
-				const diffFunctions = this.getDecorator(`diffProperty:${propertyName}`);
-				for (let i = 0; i < diffFunctions.length; i++) {
-					const result = diffFunctions[i](previousProperty, newProperty);
+			changedPropertyKeys = Object.keys(properties);
+			diffPropertyResults = { ...properties };
+		}
+		else {
+			const allProperties = [ ...Object.keys(properties), ...Object.keys(this._properties) ];
+			const checkedProperties: string[] = [];
+			let runReactions = false;
+
+			for (let i = 0; i < allProperties.length; i++) {
+				const propertyName = allProperties[i];
+				if (checkedProperties.indexOf(propertyName) > 0) {
+					continue;
+				}
+				checkedProperties.push(propertyName);
+				const previousProperty = this._properties[propertyName];
+				const newProperty = this._bindFunctionProperty(properties[propertyName], this._coreProperties.bind);
+				if (registeredDiffPropertyNames.indexOf(propertyName) !== -1) {
+					runReactions = true;
+					const diffFunctions = this.getDecorator(`diffProperty:${propertyName}`);
+					for (let i = 0; i < diffFunctions.length; i++) {
+						const result = diffFunctions[i](previousProperty, newProperty);
+						if (result.changed && changedPropertyKeys.indexOf(propertyName) === -1) {
+							changedPropertyKeys.push(propertyName);
+						}
+						if (propertyName in properties) {
+							diffPropertyResults[propertyName] = result.value;
+						}
+					}
+				}
+				else {
+					const result = boundAuto(previousProperty, newProperty);
 					if (result.changed && changedPropertyKeys.indexOf(propertyName) === -1) {
 						changedPropertyKeys.push(propertyName);
 					}
@@ -348,28 +368,19 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 					}
 				}
 			}
-			else {
-				const result = boundAuto(previousProperty, newProperty);
-				if (result.changed && changedPropertyKeys.indexOf(propertyName) === -1) {
-					changedPropertyKeys.push(propertyName);
-				}
-				if (propertyName in properties) {
-					diffPropertyResults[propertyName] = result.value;
-				}
-			}
-		}
 
-		if (runReactions) {
-			this._mapDiffPropertyReactions(properties, changedPropertyKeys).forEach((args, reaction) => {
-				if (args.changed) {
-					reaction.call(this, args.previousProperties, args.newProperties);
-				}
-			});
+			if (runReactions) {
+				this._mapDiffPropertyReactions(properties, changedPropertyKeys).forEach((args, reaction) => {
+					if (args.changed) {
+						reaction.call(this, args.previousProperties, args.newProperties);
+					}
+				});
+			}
 		}
 
 		this._properties = diffPropertyResults;
 
-		if (changedPropertyKeys.length > 0) {
+		if (changedPropertyKeys.length > 0 || alwaysRender) {
 			this.invalidate();
 		}
 	}

--- a/src/decorators/alwaysRender.ts
+++ b/src/decorators/alwaysRender.ts
@@ -1,0 +1,9 @@
+import { handleDecorator } from './../WidgetBase';
+
+export function alwaysRender() {
+	return handleDecorator((target, propertyKey) => {
+		target.addDecorator('alwaysRender');
+	});
+}
+
+export default alwaysRender;

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -404,7 +404,6 @@ registerSuite({
 			});
 			assert.strictEqual(vnode, widget.__render__());
 		},
-
 		'properties that are deleted dont get returned'() {
 			const widget = new WidgetBase<any>();
 			widget.__setProperties__({
@@ -420,6 +419,33 @@ registerSuite({
 				c: 5
 			});
 
+			assert.deepEqual(widget.properties, { a: 4, c: 5 });
+		},
+		'properties implicitly removed cause an invalidate but are not set on properties'() {
+			@diffProperty('b', always)
+			class TestWidget extends WidgetBase<any> {
+				public invalidateCount = 0;
+				invalidate() {
+					this.invalidateCount++;
+					super.invalidate();
+				}
+			}
+			const widget = new TestWidget();
+			widget.__setProperties__({
+				a: 1,
+				b: 2,
+				c: 3
+			});
+
+			assert.strictEqual(widget.invalidateCount, 1);
+			assert.deepEqual(widget.properties, { a: 1, b: 2, c: 3 });
+
+			widget.__setProperties__({
+				a: 4,
+				c: 5
+			});
+
+			assert.strictEqual(widget.invalidateCount, 2);
 			assert.deepEqual(widget.properties, { a: 4, c: 5 });
 		}
 	},

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -1,2 +1,3 @@
+import './alwaysRender';
 import './beforeProperties';
 import './inject';

--- a/tests/unit/decorators/alwaysRender.ts
+++ b/tests/unit/decorators/alwaysRender.ts
@@ -1,0 +1,44 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+import { diffProperty, WidgetBase } from './../../../src/WidgetBase';
+import { alwaysRender } from './../../../src/decorators/alwaysRender';
+import { auto } from './../../../src/diff';
+
+registerSuite({
+	name: 'decorators/alwaysRender',
+	alwaysRender() {
+		let renderCount = 0;
+
+		@alwaysRender()
+		class AlwaysRender extends WidgetBase {
+			render() {
+				renderCount++;
+				return super.render();
+			}
+		}
+
+		const widget = new AlwaysRender();
+		widget.__render__();
+		widget.__setProperties__({});
+		widget.__render__();
+		assert.strictEqual(renderCount, 2);
+	},
+	'alwaysRender on widgets with custom diff (`diffProperty`) throw an error'() {
+		let renderCount = 0;
+
+		@diffProperty('property', auto)
+		@alwaysRender()
+		class AlwaysRender extends WidgetBase {
+			render() {
+				renderCount++;
+				return super.render();
+			}
+		}
+
+		const widget = new AlwaysRender();
+		assert.throws(() => {
+			widget.__setProperties__({});
+		}, Error, 'Widget marked as `alwayRender` but has custom diffs registered');
+	}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

`alwaysRender` decorator that skip the entire diff properties process (as detailed in associated issue) and calls `invalidate`.  

Throws an error if the widget has registered custom diffs using the `diffProperty` decorator.

Resolves #676 
