### PR TITLE
Expose changed property keys from WidgetBase

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -149,10 +149,18 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	 */
 	private _properties: P & WidgetProperties & { [index: string]: any };
 
+	/**
+	 * Array of property keys considered changed from the previous set properties
+	 */
+	private _changedPropertyKeys: string[] = [];
+
+	/**
+	 * Core properties widget base sets for all widget
+	 */
 	private _coreProperties: CoreProperties = {} as CoreProperties;
 
 	/**
-	 * cached chldren map for instance management
+	 * cached children map for instance management
 	 */
 	private _cachedChildrenMap: Map<string | number | Promise<WidgetBaseConstructor> | WidgetBaseConstructor, WidgetCacheWrapper[]>;
 
@@ -305,6 +313,10 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		return this._properties;
 	}
 
+	public get changedPropertyKeys(): string[] {
+		return [ ...this._changedPropertyKeys ];
+	}
+
 	public __setCoreProperties__(coreProperties: CoreProperties): void {
 		this._renderState = WidgetRenderState.PROPERTIES;
 		const { baseRegistry } = coreProperties;
@@ -368,6 +380,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		}
 
 		this._properties = diffPropertyResults;
+		this._changedPropertyKeys = changedPropertyKeys;
 
 		if (changedPropertyKeys.length > 0) {
 			this.invalidate();

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -740,6 +740,20 @@ registerSuite({
 
 		assert.strictEqual(called, true);
 	},
+	changedPropertyKeys() {
+		class TestWidget extends WidgetBase<any> {}
+		const widget = new TestWidget();
+		widget.__setProperties__({ foo: true });
+		assert.deepEqual(widget.changedPropertyKeys, [ 'foo' ]);
+		widget.__setProperties__({ foo: true });
+		assert.deepEqual(widget.changedPropertyKeys, []);
+		widget.__setProperties__({ foo: true });
+		widget.__setProperties__({ foo: true, bar: true });
+		assert.deepEqual(widget.changedPropertyKeys, [ 'bar' ]);
+		const changedPropertyKeys = widget.changedPropertyKeys;
+		changedPropertyKeys.push('bad key');
+		assert.notDeepEqual(changedPropertyKeys, widget.changedPropertyKeys);
+	},
 	render: {
 		'render with non widget children'() {
 			class TestWidget extends WidgetBase<any> {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Expose `changedPropertyKeys` from `WidgetBase`. Set with the keys identified as changed during the diff process.

Resolves #670 
