### PR TITLE
Exclude tsx test files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,10 @@
 module.exports = function (grunt) {
 	require('grunt-dojo2').initConfig(grunt, {
+		ts: {
+			dist: {
+				exclude: [ 'tests/**/*.tsx', 'tests/**/*.ts' ]
+			}
+		},
 		typedoc: {
 			options: {
 				ignoreCompilerErrors: true // Remove this once compile errors are resolved


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Since including the `tsxIntegration` test the `dist/umd` output is not flat and includes both `src` and `test` directories. It should be just contents of the `src` directory.

Would be resolved by https://github.com/dojo/grunt-dojo2/issues/137

Is there any reason why all files in the `test` directory can't be excluded by default?

```ts
exclude: [ 'tests/**/*' ]
```


