### PR TITLE
Do not call schedule render every invalidate, only on setting properties and children

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -1,7 +1,7 @@
 import { assign } from '@dojo/core/lang';
 import { from as arrayFrom } from '@dojo/shim/array';
 import global from '@dojo/shim/global';
-import { Constructor, DNode, WidgetBaseInterface, WidgetProperties } from './interfaces';
+import { Constructor, DNode, WidgetProperties } from './interfaces';
 import { WidgetBase } from './WidgetBase';
 import { w } from './d';
 import { ProjectorMixin } from './mixins/Projector';
@@ -117,8 +117,8 @@ export interface CustomElementDescriptor {
 export interface CustomElement extends HTMLElement {
 	getWidgetConstructor(): Constructor<WidgetBase<WidgetProperties>>;
 	getDescriptor(): CustomElementDescriptor;
-	getWidgetInstance(): WidgetBaseInterface<any>;
-	setWidgetInstance(instance: WidgetBaseInterface<any>): void;
+	getWidgetInstance(): ProjectorMixin<any>;
+	setWidgetInstance(instance: ProjectorMixin<any>): void;
 }
 
 function getWidgetPropertyFromAttribute(attributeName: string, attributeValue: string | null, descriptor: CustomElementAttributeDescriptor): [ string, any ] {
@@ -176,7 +176,7 @@ export function initializeElement(element: CustomElement) {
 			},
 			set(value: any) {
 				const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attribute.attributeName, value, attribute);
-				element.getWidgetInstance().__setProperties__(assign({}, element.getWidgetInstance().properties, {
+				element.getWidgetInstance().setProperties(assign({}, element.getWidgetInstance().properties, {
 					[propertyName]: propertyValue
 				}));
 			}
@@ -196,7 +196,7 @@ export function initializeElement(element: CustomElement) {
 			},
 
 			set(value: any) {
-				element.getWidgetInstance().__setProperties__(assign(
+				element.getWidgetInstance().setProperties(assign(
 					{},
 					element.getWidgetInstance().properties,
 					{ [widgetPropertyName]: setValue ? setValue(value) : value }
@@ -265,7 +265,7 @@ export function handleAttributeChanged(element: CustomElement, name: string, new
 	attributes.forEach((attribute) => {
 		if (attribute.attributeName === name) {
 			const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(name, newValue, attribute);
-			element.getWidgetInstance().__setProperties__(assign(
+			element.getWidgetInstance().setProperties(assign(
 				{},
 				element.getWidgetInstance().properties,
 				{ [propertyName]: propertyValue }

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -181,7 +181,9 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this._boundDoRender = this._doRender.bind(this);
 			this._boundRender = this.__render__.bind(this);
-			this.own(this.on('invalidated', this.scheduleRender));
+			this.own(this.on('invalidated', () => {
+				this.scheduleRender();
+			}));
 
 			this.root = document.body;
 			this.projectorState = ProjectorAttachState.Detached;
@@ -281,6 +283,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		public setChildren(children: DNode[]): void {
 			this._projectorChildren = [ ...children ];
 			super.__setChildren__(children);
+			this.emit({ type: 'invalidated' });
 		}
 
 		public setProperties(properties: this['properties']): void {
@@ -295,6 +298,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			this._projectorProperties = assign({}, properties);
 			super.__setCoreProperties__({ bind: this, baseRegistry: properties.registry });
 			super.__setProperties__(properties);
+			this.emit({ type: 'invalidated' });
 		}
 
 		public toHtml(): string {
@@ -333,11 +337,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 				}
 			}
 			return result;
-		}
-
-		protected invalidate(): void {
-			super.invalidate();
-			this.scheduleRender();
 		}
 
 		private _doRender() {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -129,6 +129,11 @@ export interface ProjectorMixin<P> {
 	 * The status of the projector
 	 */
 	readonly projectorState: ProjectorAttachState;
+
+	/**
+	 * Exposes invalidate for projector instances
+	 */
+	invalidate(): void;
 }
 
 /**
@@ -337,6 +342,10 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 				}
 			}
 			return result;
+		}
+
+		public invalidate() {
+			super.invalidate();
 		}
 
 		private _doRender() {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -344,7 +344,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			return result;
 		}
 
-		public invalidate() {
+		public invalidate(): void {
 			super.invalidate();
 		}
 

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -5,6 +5,7 @@ import {
 } from './customElements';
 import { Constructor, WidgetProperties } from './interfaces';
 import { WidgetBase } from './WidgetBase';
+import { ProjectorMixin } from './mixins/Projector';
 
 declare namespace customElements {
 	function define(name: string, constructor: any): void;
@@ -30,7 +31,7 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 	customElements.define(descriptor.tagName, class extends HTMLElement {
 		private _isAppended = false;
 		private _appender: Function;
-		private _widgetInstance: WidgetBase;
+		private _widgetInstance: ProjectorMixin<any>;
 
 		constructor() {
 			super();
@@ -49,11 +50,11 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 			handleAttributeChanged(this, name, newValue, oldValue);
 		}
 
-		public getWidgetInstance(): WidgetBase<any> {
+		public getWidgetInstance(): ProjectorMixin<any> {
 			return this._widgetInstance;
 		}
 
-		public setWidgetInstance(widget: WidgetBase<any>): void {
+		public setWidgetInstance(widget: ProjectorMixin<any>): void {
 			this._widgetInstance = widget;
 		}
 

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -11,11 +11,7 @@ import { Registry } from './../../../src/Registry';
 
 const Event = global.window.Event;
 
-class BaseTestWidget extends ProjectorMixin(WidgetBase) {
-	public callInvalidate() {
-		this.invalidate();
-	}
-}
+class BaseTestWidget extends ProjectorMixin(WidgetBase) {}
 
 let result: any;
 
@@ -92,7 +88,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
@@ -111,7 +107,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = 'other text';
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'div');
 				assert.equal(vnode.text, 'other text');
@@ -128,7 +124,7 @@ registerSuite({
 				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
@@ -148,7 +144,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = null;
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
@@ -165,7 +161,7 @@ registerSuite({
 				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
@@ -185,7 +181,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = undefined;
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
@@ -233,7 +229,7 @@ registerSuite({
 				projector.sandbox();
 				assert.strictEqual(count, 1, 'render should have been called once');
 				assert.strictEqual(projector.root.firstChild!.textContent, '1', 'should have rendered "1"');
-				projector.callInvalidate();
+				projector.invalidate();
 				assert.strictEqual(count, 2, 'render should have been called synchronously');
 				assert.strictEqual(projector.root.firstChild!.textContent, '2', 'should have rendered "2"');
 				projector.destroy();
@@ -278,7 +274,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
@@ -299,7 +295,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = 'other text';
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'div');
 				assert.equal(vnode.text, 'other text');
@@ -318,7 +314,7 @@ registerSuite({
 				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
@@ -340,7 +336,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = null;
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
@@ -359,7 +355,7 @@ registerSuite({
 				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'span');
 				assert.isUndefined(vnode.text);
@@ -381,7 +377,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = undefined;
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'h2');
 				assert.isUndefined(vnode.text);
@@ -430,7 +426,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.equal(vnode.text, 'other text');
@@ -448,7 +444,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = 'other text';
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.equal(vnode.text, 'other text');
@@ -467,7 +463,7 @@ registerSuite({
 				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.equal(vnode.text, 'other text');
@@ -486,7 +482,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = null;
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.isUndefined(vnode.text);
@@ -505,7 +501,7 @@ registerSuite({
 				assert.lengthOf(vnode.children, 0);
 
 				result = v('div', [ 'other text' ]);
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.equal(vnode.text, 'other text');
@@ -524,7 +520,7 @@ registerSuite({
 				assert.isUndefined(vnode.children);
 
 				result = undefined;
-				projector.callInvalidate();
+				projector.invalidate();
 				vnode = projector.__render__() as VNode;
 				assert.equal(vnode.vnodeSelector, 'my-app');
 				assert.isUndefined(vnode.text);
@@ -770,6 +766,12 @@ registerSuite({
 		projector.setProperties({ key: 'hello' });
 		assert.isTrue(scheduleRender.called);
 	},
+	'scheduleRender not called on invalidate'() {
+		const projector = new BaseTestWidget();
+		const scheduleRender = spy(projector, 'scheduleRender');
+		projector.invalidate();
+		assert.isTrue(scheduleRender.called);
+	},
 	'properties are reset to original state on render'() {
 		const testProperties = {
 			key: 'bar'
@@ -790,7 +792,7 @@ registerSuite({
 		projector.setProperties(testProperties);
 		projector.setChildren(testChildren);
 		projector.__render__();
-		projector.callInvalidate();
+		projector.invalidate();
 		projector.__render__();
 	},
 	'invalidate on setting children'() {
@@ -897,7 +899,7 @@ registerSuite({
 			exitAnimation: 'fade-out'
 		}));
 
-		projector.callInvalidate();
+		projector.invalidate();
 
 		const domNode = document.getElementById('test-element')!;
 		assert.isNotNull(domNode);
@@ -908,7 +910,7 @@ registerSuite({
 		sendAnimationEndEvents(domNode!);
 
 		children = [];
-		projector.callInvalidate();
+		projector.invalidate();
 
 		assert.isTrue(domNode.classList.contains('fade-out'));
 		assert.isTrue(domNode.classList.contains('fade-out-active'));
@@ -942,7 +944,7 @@ registerSuite({
 			exitAnimationActive: 'active-fade-out'
 		}));
 
-		projector.callInvalidate();
+		projector.invalidate();
 
 		const domNode = document.getElementById('test-element')!;
 		assert.isNotNull(domNode);
@@ -953,7 +955,7 @@ registerSuite({
 		sendAnimationEndEvents(domNode);
 
 		children = [];
-		projector.callInvalidate();
+		projector.invalidate();
 
 		assert.isTrue(domNode.classList.contains('fade-out'));
 		assert.isTrue(domNode.classList.contains('active-fade-out'));
@@ -990,7 +992,7 @@ registerSuite({
 		assert.isNotNull(domNode);
 
 		children = [];
-		projector.callInvalidate();
+		projector.invalidate();
 
 		assert.isTrue(domNode.classList.contains('fade-out'));
 		assert.isTrue(domNode.classList.contains('fade-out-active'));

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -769,8 +769,9 @@ registerSuite({
 	'scheduleRender not called on invalidate'() {
 		const projector = new BaseTestWidget();
 		const scheduleRender = spy(projector, 'scheduleRender');
+		projector.__setProperties__({});
 		projector.invalidate();
-		assert.isTrue(scheduleRender.called);
+		assert.isTrue(scheduleRender.notCalled);
 	},
 	'properties are reset to original state on render'() {
 		const testProperties = {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Calling `scheduleRender` every time  `invalidate` is called is problematic in certain scenarios when a widget is wrapped by the `ProjectorMixin`.  

1) When the `widget` has a property registered with a custom diff that always returns changed as true i.e. `diffProperty('my-prop', always)`
2) Uses the new `@alwaysRender` decorator (such as the `Container` HOC). 

Currently this causes `projector` instances to continuously schedule a render, as `this.invalidate()` will be called for all `__setProperties__` calls.

Overriding `invalidate` in this way should not be needed, as a listener that calls `scheduleRender` is attached to `projector` instances' `invalidated` event. 

Instead this `invalidated` event can be explicitly emitted at the end of `setProperties` and `setChildren`, the public API for projector instances.

Other mechanisms such as `injectors` of external state that need to schedule a render, also emit an `invalidated` event and therefore will be sure `scheduleRender` is fired.