### PR TITLE
remove deprecated warnings

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -211,7 +211,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		this._boundInvalidate = this.invalidate.bind(this);
 
 		this.own(this._registry.on('invalidate', this._boundInvalidate));
-		this._checkOnElementUsage();
 	}
 
 	protected meta<T extends WidgetMetaBase>(MetaType: WidgetMetaConstructor<T>): T {
@@ -736,16 +735,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			}
 			this._cachedChildrenMap.set(key, filteredCacheChildren);
 		});
-	}
-
-	private _checkOnElementUsage() {
-		const name = (<any> this).constructor.name || 'unknown';
-		if (this.onElementCreated !== WidgetBase.prototype.onElementCreated) {
-			console.warn(`Usage of 'onElementCreated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`);
-		}
-		if (this.onElementUpdated !== WidgetBase.prototype.onElementUpdated) {
-			console.warn(`Usage of 'onElementUpdated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`);
-		}
 	}
 }
 

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -40,24 +40,6 @@ registerSuite({
 		assert(widgetBase);
 		assert.isFunction(widgetBase.__render__);
 	},
-	'deprecated api warning'() {
-		class TestWidgetOne extends WidgetBase<any> {
-			onElementUpdated(element: Element, key: string) {
-
-			}
-			onElementCreated(element: Element, key: string) {
-
-			}
-		}
-		class TestWidgetTwo extends WidgetBase<any> {}
-
-		const name = (<any> TestWidgetOne).name || 'unknown';
-		new TestWidgetOne();
-		new TestWidgetTwo();
-		assert.isTrue(consoleStub.calledTwice);
-		assert.isTrue(consoleStub.firstCall.calledWith(`Usage of 'onElementCreated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`));
-		assert.isTrue(consoleStub.secondCall.calledWith(`Usage of 'onElementUpdated' has been deprecated and will be removed in a future version, see https://github.com/dojo/widget-core/issues/559 for details (${name})`));
-	},
 	children() {
 		const expectedChild = v('div');
 		const widget = new WidgetBase();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removing the warnings for using onElement* protected functions, this will be re-addressed when we can support removing the hooks.
