### PR TITLE
Remove the stacked theme order reversal to support widget extension with new theme

### DIFF
--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -313,7 +313,7 @@ export function ThemeableMixin<E, T extends Constructor<WidgetBase<ThemeableProp
 		private _recalculateThemeClasses() {
 			const { properties: { injectedTheme = {}, theme = injectedTheme } } = this;
 			if (!this._registeredBaseThemes) {
-				this._registeredBaseThemes = [ ...this.getDecorator('baseThemeClasses') ].reverse();
+				this._registeredBaseThemes = [ ...this.getDecorator('baseThemeClasses') ];
 				this._checkForDuplicates();
 			}
 			const registeredBaseThemeKeys = this._registeredBaseThemes.map((registeredBaseThemeClasses) => {

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -40,15 +40,15 @@ class SubClassTestWidget extends TestWidget { }
 @theme(baseThemeClasses2)
 class StackedTestWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> { }
 
-@theme(baseThemeClasses3)
 @theme(baseThemeClasses1)
+@theme(baseThemeClasses3)
 class DuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> { }
 
 class NonDecoratorDuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<ThemeableProperties> {
 	constructor() {
 		super();
-		theme(baseThemeClasses1)(this);
 		theme(baseThemeClasses3)(this);
+		theme(baseThemeClasses1)(this);
 	}
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #702 
