### PR TITLE
Only schedule a Projector render when properties or children are set explicitly

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -251,10 +251,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		return this._properties;
 	}
 
-	protected get isDirty(): boolean {
-		return this._dirty;
-	}
-
 	public get changedPropertyKeys(): string[] {
 		return [ ...this._changedPropertyKeys ];
 	}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -251,6 +251,10 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		return this._properties;
 	}
 
+	protected get isDirty(): boolean {
+		return this._dirty;
+	}
+
 	public get changedPropertyKeys(): string[] {
 		return [ ...this._changedPropertyKeys ];
 	}

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -361,9 +361,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 		public invalidate(): void {
 			super.invalidate();
-			if (this.isDirty) {
-				this.scheduleRender();
-			}
+			this.scheduleRender();
 		}
 
 		private _doRender() {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -169,8 +169,10 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		private _paused: boolean;
 		private _boundDoRender: () => void;
 		private _boundRender: Function;
-		private _projectorChildren: DNode[];
-		private _projectorProperties: this['properties'];
+		private _projectorChildren: DNode[] = [];
+		private _resetChildren = true;
+		private _projectorProperties: this['properties'] = {} as this['properties'];
+		private _resetProperties = true;
 		private _rootTagName: string;
 		private _attachType: AttachType;
 
@@ -288,12 +290,13 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		}
 
 		public setChildren(children: DNode[]): void {
+			this._resetChildren = false;
 			this._projectorChildren = [ ...children ];
-			super.__setChildren__(children);
-			this.emit({ type: 'invalidated' });
+			super.__setChildren__([ ...children ]);
 		}
 
 		public setProperties(properties: this['properties']): void {
+			this._resetProperties = false;
 			if (this._projectorProperties && this._projectorProperties.registry !== properties.registry) {
 				if (this._projectorProperties.registry) {
 					this._projectorProperties.registry.destroy();
@@ -305,7 +308,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			this._projectorProperties = assign({}, properties);
 			super.__setCoreProperties__({ bind: this, baseRegistry: properties.registry });
 			super.__setProperties__(properties);
-			this.emit({ type: 'invalidated' });
 		}
 
 		public toHtml(): string {
@@ -346,17 +348,22 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		}
 
 		public __render__(): VNode {
-			if (this._projectorChildren) {
+			if (this._resetChildren) {
 				this.setChildren(this._projectorChildren);
 			}
-			if (this._projectorProperties) {
+			if (this._resetProperties) {
 				this.setProperties(this._projectorProperties);
 			}
+			this._resetChildren = true;
+			this._resetProperties = true;
 			return super.__render__() as VNode;
 		}
 
 		public invalidate(): void {
 			super.invalidate();
+			if (this.isDirty) {
+				this.scheduleRender();
+			}
 		}
 
 		private _doRender() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -761,18 +761,14 @@ registerSuite({
 		projector.destroy();
 		assert.strictEqual(registryDestroyedCount, 3);
 	},
-	'scheduleRender on setting properties'() {
+	'scheduleRender on called on invalidate when projector is dirty'() {
 		const projector = new BaseTestWidget();
 		const scheduleRender = spy(projector, 'scheduleRender');
+		projector.append();
 		projector.setProperties({ key: 'hello' });
-		assert.isTrue(scheduleRender.called);
-	},
-	'scheduleRender not called on invalidate'() {
-		const projector = new BaseTestWidget();
-		const scheduleRender = spy(projector, 'scheduleRender');
-		projector.__setProperties__({});
-		projector.invalidate();
-		assert.isTrue(scheduleRender.notCalled);
+		assert.isTrue(scheduleRender.calledOnce);
+		projector.setProperties({ key: 'hello' });
+		assert.isTrue(scheduleRender.calledOnce);
 	},
 	'properties are reset to original state on render'() {
 		const testProperties = {
@@ -800,9 +796,15 @@ registerSuite({
 	'invalidate on setting children'() {
 		const projector = new BaseTestWidget();
 		const scheduleRender = spy(projector, 'scheduleRender');
-
+		projector.append();
+		projector.setChildren([]);
+		assert.isTrue(scheduleRender.notCalled);
 		projector.setChildren([ v('div') ]);
-		assert.isTrue(scheduleRender.called);
+		assert.isTrue(scheduleRender.calledOnce);
+		projector.setChildren([]);
+		assert.isTrue(scheduleRender.calledTwice);
+		projector.setChildren([]);
+		assert.isTrue(scheduleRender.calledTwice);
 	},
 	'invalidate before attached'() {
 		const projector: any = new BaseTestWidget();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Calling `setProperties` or `setChildren` cause a render to occur on every RAF, this change adds flags to skip resetting the projector properties/children on the render after they have been set explicitly using the projector API `setProperties` and `setChildren`

Resolves #704
