### PR TITLE
Add warning if a Themeable widget hasn't registered base CSS

### DIFF
--- a/src/mixins/Themeable.ts
+++ b/src/mixins/Themeable.ts
@@ -314,7 +314,12 @@ export function ThemeableMixin<E, T extends Constructor<WidgetBase<ThemeableProp
 			const { properties: { injectedTheme = {}, theme = injectedTheme } } = this;
 			if (!this._registeredBaseThemes) {
 				this._registeredBaseThemes = [ ...this.getDecorator('baseThemeClasses') ];
-				this._checkForDuplicates();
+				if (this._registeredBaseThemes.length > 0) {
+					this._checkForDuplicates();
+				}
+				else {
+					console.warn('Base CSS has not been registered using `@theme` for themeable widget.');
+				}
 			}
 			const registeredBaseThemeKeys = this._registeredBaseThemes.map((registeredBaseThemeClasses) => {
 				return registeredBaseThemeClasses[THEME_KEY];

--- a/tests/unit/mixins/Themeable.ts
+++ b/tests/unit/mixins/Themeable.ts
@@ -52,6 +52,8 @@ class NonDecoratorDuplicateThemeClassWidget extends ThemeableMixin(WidgetBase)<T
 	}
 }
 
+class ThemeableWidgetNoCssTheme extends ThemeableMixin(WidgetBase) {}
+
 let consoleStub: SinonStub;
 
 registerSuite({
@@ -376,6 +378,13 @@ registerSuite({
 				assert.strictEqual(consoleStub.firstCall.args[0], `Duplicate base theme class key 'class1' detected, this could cause unexpected results`);
 			}
 		}
+	},
+	'Themeable warns if no css has been configured using `@theme`'() {
+		const widget = new ThemeableWidgetNoCssTheme();
+		widget.classes();
+		assert.isTrue(consoleStub.calledOnce);
+		assert.strictEqual(consoleStub.firstCall.args[0], 'Base CSS has not been registered using `@theme` for themeable widget.');
+
 	},
 	'injecting a theme': {
 		'theme can be injected by defining a ThemeInjector with registry'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a warning if a Themeable widget is used to get classes but a base CSS file has not been registered.

Resolves #649 
