### PR TITLE
Use external API for setting properties and children

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -242,8 +242,8 @@ export function initializeElement(element: CustomElement) {
 	const projector = ProjectorMixin(element.getWidgetConstructor());
 
 	const widgetInstance = new projector();
-	widgetInstance.__setProperties__(initialProperties);
-	widgetInstance.__setChildren__(children);
+	widgetInstance.setProperties(initialProperties);
+	widgetInstance.setChildren(children);
 	element.setWidgetInstance(widgetInstance);
 
 	return function() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Need to use the external projector API to set properties and children in custom elements.

Resolves #709
