### PR TITLE
Add start position information for a drag event

### DIFF
--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -154,9 +154,7 @@ class DragController {
 			this._dragging = target;
 			state.last = state.start = getPositionMatrix(e);
 			state.dragResults.delta = createPosition();
-			if (!state.dragResults.start) {
-				state.dragResults.start = deepAssign({}, state.start);
-			}
+			state.dragResults.start = deepAssign({}, state.start);
 			state.dragResults.isDragging = true;
 			state.invalidate();
 		} // else, we are ignoring the event

--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -14,26 +14,59 @@ export interface DragResults {
 	 * Is the DOM node currently in a drag state
 	 */
 	isDragging: boolean;
+
+	/**
+	 * A matrix of posistions that represent the start position for the current drag interaction
+	 */
+	start?: PositionMatrix;
 }
 
 interface NodeData {
 	dragResults: DragResults;
 	invalidate: () => void;
-	last: Position;
-	start: Position;
+	last: PositionMatrix;
+	start: PositionMatrix;
 }
 
+/**
+ * An x/y position structure
+ */
 export interface Position {
 	x: number;
 	y: number;
+}
+
+/**
+ * A matrix of x/y positions
+ */
+export interface PositionMatrix {
+	/**
+	 * Client x/y position
+	 */
+	client: Position;
+
+	/**
+	 * Offset x/y position
+	 */
+	offset: Position;
+
+	/**
+	 * Page x/y position
+	 */
+	page: Position;
+
+	/**
+	 * Screen x/y position
+	 */
+	screen: Position;
 }
 
 function createNodeData(invalidate: () => void): NodeData {
 	return {
 		dragResults: deepAssign({}, emptyResults),
 		invalidate,
-		last: createPosition(),
-		start: createPosition()
+		last: createPositionMatrix(),
+		start: createPositionMatrix()
 	};
 }
 
@@ -45,6 +78,18 @@ function createPosition(): Position {
 }
 
 /**
+ * Create an empty position matrix
+ */
+function createPositionMatrix(): PositionMatrix {
+	return {
+		client: { x: 0, y: 0 },
+		offset: { x: 0, y: 0 },
+		page: { x: 0, y: 0 },
+		screen: { x: 0, y: 0 }
+	};
+}
+
+/**
  * A frozen empty result object, frozen to ensure that no one downstream modifies it
  */
 const emptyResults = Object.freeze({
@@ -53,13 +98,27 @@ const emptyResults = Object.freeze({
 });
 
 /**
- * Return the x/y position for an event
+ * Return the x/y position matrix for an event
  * @param event The pointer event
  */
-function getPosition(event: PointerEvent): Position {
+function getPositionMatrix(event: PointerEvent): PositionMatrix {
 	return {
-		x: event.pageX,
-		y: event.pageY
+		client: {
+			x: event.clientX,
+			y: event.clientY
+		},
+		offset: {
+			x: event.offsetX,
+			y: event.offsetY
+		},
+		page: {
+			x: event.pageX,
+			y: event.pageY
+		},
+		screen: {
+			x: event.screenX,
+			y: event.screenY
+		}
 	};
 }
 
@@ -68,10 +127,10 @@ function getPosition(event: PointerEvent): Position {
  * @param start The first position
  * @param current The second position
  */
-function getDelta(start: Position, current: Position): Position {
+function getDelta(start: PositionMatrix, current: PositionMatrix): Position {
 	return {
-		x: current.x - start.x,
-		y: current.y - start.y
+		x: current.client.x - start.client.x,
+		y: current.client.y - start.client.y
 	};
 }
 
@@ -93,9 +152,12 @@ class DragController {
 		if (data) {
 			const { state, target } = data;
 			this._dragging = target;
-			state.dragResults.isDragging = true;
-			state.last = state.start = getPosition(e);
+			state.last = state.start = getPositionMatrix(e);
 			state.dragResults.delta = createPosition();
+			if (!state.dragResults.start) {
+				state.dragResults.start = deepAssign({}, state.start);
+			}
+			state.dragResults.isDragging = true;
 			state.invalidate();
 		} // else, we are ignoring the event
 	}
@@ -107,8 +169,11 @@ class DragController {
 		}
 		// state cannot be unset, using ! operator
 		const state = this._nodeMap.get(_dragging)!;
-		state.last = getPosition(e);
+		state.last = getPositionMatrix(e);
 		state.dragResults.delta = getDelta(state.start, state.last);
+		if (!state.dragResults.start) {
+			state.dragResults.start = deepAssign({}, state.start);
+		}
 		state.invalidate();
 	}
 
@@ -119,11 +184,12 @@ class DragController {
 		}
 		// state cannot be unset, using ! operator
 		const state = this._nodeMap.get(_dragging)!;
-		state.last = getPosition(e);
-		state.dragResults = {
-			delta: getDelta(state.start, state.last),
-			isDragging: false
-		};
+		state.last = getPositionMatrix(e);
+		state.dragResults.delta = getDelta(state.start, state.last);
+		if (!state.dragResults.start) {
+			state.dragResults.start = deepAssign({}, state.start);
+		}
+		state.dragResults.isDragging = false;
 		state.invalidate();
 		this._dragging = undefined;
 	}
@@ -145,11 +211,13 @@ class DragController {
 		}
 
 		const state = _nodeMap.get(node)!;
+		// shallow "clone" the results, so no downstream manipulation can occur
+		const dragResults = assign({}, state.dragResults);
 		// we are offering up an accurate delta, so we need to take the last event position and move it to the start so
 		// that our deltas are calculated from the last time they are read
 		state.start = state.last;
-		// shallow "clone" the results, so no downstream manipulation can occur
-		const dragResults = assign({}, state.dragResults);
+		// clear the start state
+		delete state.dragResults.start;
 
 		// reset the delta after we have read any last delta while not dragging
 		if (!dragResults.isDragging && dragResults.delta.x !== 0 && dragResults.delta.y !== 0) {

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -91,8 +91,14 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 100,
-				pageY: 50
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -101,8 +107,14 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointermove', {
 			eventInit: {
 				bubbles: true,
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 110,
-				pageY: 55
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -111,8 +123,14 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerup', {
 			eventInit: {
 				bubbles: true,
+				clientX: 105,
+				clientY: 45,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 105,
-				pageY: 45
+				pageY: 45,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -123,13 +141,16 @@ registerSuite({
 			emptyResults,
 			{
 				delta: { x: 0, y: 0 },
-				isDragging: true
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
 			}, {
 				delta: { x: 10, y: 5 },
-				isDragging: true
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
 			}, {
 				delta: { x: -5, y: -10 },
-				isDragging: false
+				isDragging: false,
+				start: { client: { x: 110, y: 55 }, offset: { x: 10, y: 5 }, page: { x: 110, y: 55 }, screen: { x: 1100, y: 1050 } }
 			}
 		], 'the stack of should represent a drag state');
 
@@ -166,8 +187,14 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 100,
-				pageY: 50
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -176,24 +203,42 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointermove', {
 			eventInit: {
 				bubbles: true,
+				clientX: 105,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 105,
-				pageY: 55
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
 		sendEvent(div.firstChild as Element, 'pointermove', {
 			eventInit: {
 				bubbles: true,
+				clientX: 110,
+				clientY: 60,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 110,
-				pageY: 60
+				pageY: 60,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
 		sendEvent(div.firstChild as Element, 'pointermove', {
 			eventInit: {
 				bubbles: true,
+				clientX: 115,
+				clientY: 65,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 115,
-				pageY: 65
+				pageY: 65,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -202,8 +247,14 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerup', {
 			eventInit: {
 				bubbles: true,
+				clientX: 120,
+				clientY: 70,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 120,
-				pageY: 70
+				pageY: 70,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -214,13 +265,16 @@ registerSuite({
 			emptyResults,
 			{
 				delta: { x: 0, y: 0 },
-				isDragging: true
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
 			}, {
 				delta: { x: 15, y: 15 },
-				isDragging: true
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
 			}, {
 				delta: { x: 5, y: 5 },
-				isDragging: false
+				isDragging: false,
+				start: { client: { x: 115, y: 65 }, offset: { x: 10, y: 5 }, page: { x: 115, y: 65 }, screen: { x: 1100, y: 1050 } }
 			}
 		], 'the stack of should represent a drag state');
 
@@ -257,8 +311,14 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointermove', {
 			eventInit: {
 				bubbles: true,
+				clientX: 115,
+				clientY: 65,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 115,
-				pageY: 65
+				pageY: 65,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -267,8 +327,14 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerup', {
 			eventInit: {
 				bubbles: true,
+				clientX: 120,
+				clientY: 65,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 120,
-				pageY: 70
+				pageY: 70,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -316,8 +382,14 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 100,
-				pageY: 50
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -326,8 +398,14 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointermove', {
 			eventInit: {
 				bubbles: true,
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 110,
-				pageY: 55
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -336,8 +414,14 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointerup', {
 			eventInit: {
 				bubbles: true,
+				clientX: 105,
+				clientY: 45,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 105,
-				pageY: 45
+				pageY: 45,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -348,13 +432,16 @@ registerSuite({
 			emptyResults,
 			{
 				delta: { x: 0, y: 0 },
-				isDragging: true
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
 			}, {
 				delta: { x: 10, y: 5 },
-				isDragging: true
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
 			}, {
 				delta: { x: -5, y: -10 },
-				isDragging: false
+				isDragging: false,
+				start: { client: { x: 110, y: 55 }, offset: { x: 10, y: 5 }, page: { x: 110, y: 55 }, screen: { x: 1100, y: 1050 } }
 			}
 		], 'dragging should be attributed to parent node');
 
@@ -399,8 +486,14 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 100,
-				pageY: 50
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -409,8 +502,14 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointermove', {
 			eventInit: {
 				bubbles: true,
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 110,
-				pageY: 55
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 
@@ -419,8 +518,14 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointerup', {
 			eventInit: {
 				bubbles: true,
+				clientX: 105,
+				clientY: 45,
+				offsetX: 10,
+				offsetY: 5,
 				pageX: 105,
-				pageY: 45
+				pageY: 45,
+				screenX: 1100,
+				screenY: 1050
 			}
 		});
 

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -282,6 +282,124 @@ registerSuite({
 		document.body.removeChild(div);
 	},
 
+	'render not done between drag and pointer up should be culmative'() {
+		const dragResults: DragResults[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				dragResults.push(this.meta(Drag).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root',
+					styles: {
+						width: '100px',
+						height: '100px'
+					}
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerdown', {
+			eventInit: {
+				bubbles: true,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 100,
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointermove', {
+			eventInit: {
+				bubbles: true,
+				clientX: 105,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 105,
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		sendEvent(div.firstChild as Element, 'pointermove', {
+			eventInit: {
+				bubbles: true,
+				clientX: 110,
+				clientY: 60,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 110,
+				pageY: 60,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		sendEvent(div.firstChild as Element, 'pointermove', {
+			eventInit: {
+				bubbles: true,
+				clientX: 115,
+				clientY: 65,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 115,
+				pageY: 65,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		sendEvent(div.firstChild as Element, 'pointerup', {
+			eventInit: {
+				bubbles: true,
+				clientX: 120,
+				clientY: 70,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 120,
+				pageY: 70,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		assert.deepEqual(dragResults, [
+			emptyResults,
+			emptyResults,
+			{
+				delta: { x: 0, y: 0 },
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
+			}, {
+				delta: { x: 20, y: 20 },
+				isDragging: false,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
+			}
+		], 'the stack of should represent a drag state');
+
+		widget.destroy();
+		document.body.removeChild(div);
+	},
+
 	'movement ignored when start event missing'() {
 		const dragResults: DragResults[] = [];
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR enhances the Drag meta provider by providing a `start` property on drag results.  This start property is a matrix of positional information from the pointer event.  It therefore makes it possible to determine where the pointer location is by taking one of the properties of the `start` property and adding the `delta` property.

This is useful in cases where a render function needs to instantiate something at a particular location of where the pointer event is occurring.

Resolves #715 
