### PR TITLE
Fix Drag meta to properly model non-primary button or pointers

### DIFF
--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -240,14 +240,10 @@ class DragController {
 		// we are offering up an accurate delta, so we need to take the last event position and move it to the start so
 		// that our deltas are calculated from the last time they are read
 		state.start = state.last;
+		// reset the delta after we have read, as any future reads should have an empty delta
+		state.dragResults.delta = createPosition();
 		// clear the start state
 		delete state.dragResults.start;
-
-		// reset the delta after we have read, as any future reads should have an empty delta
-		if (dragResults.delta.x !== 0 && dragResults.delta.y !== 0) {
-			// future reads of the delta will be blank
-			state.dragResults.delta = createPosition();
-		}
 
 		return dragResults;
 	}

--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -147,12 +147,26 @@ class DragController {
 		}
 	}
 
-	private _onDragStart = (e: PointerEvent) => {
-		const data = this._getData(e.target as HTMLElement);
+	private _onDragStart = (event: PointerEvent) => {
+		const { _dragging } = this;
+		if (!event.isPrimary && _dragging) {
+			// we have a second touch going on here, while we are dragging, so we aren't really dragging, so we
+			// will close this down
+			const state = this._nodeMap.get(_dragging)!;
+			state.dragResults.isDragging = false;
+			state.invalidate();
+			this._dragging = undefined;
+			return;
+		}
+		if (event.button !== 0) {
+			// it isn't the primary button that is being clicked, so we will ignore this
+			return;
+		}
+		const data = this._getData(event.target as HTMLElement);
 		if (data) {
 			const { state, target } = data;
 			this._dragging = target;
-			state.last = state.start = getPositionMatrix(e);
+			state.last = state.start = getPositionMatrix(event);
 			state.dragResults.delta = createPosition();
 			state.dragResults.start = deepAssign({}, state.start);
 			state.dragResults.isDragging = true;
@@ -160,14 +174,14 @@ class DragController {
 		} // else, we are ignoring the event
 	}
 
-	private _onDrag = (e: PointerEvent) => {
+	private _onDrag = (event: PointerEvent) => {
 		const { _dragging } = this;
 		if (!_dragging) {
 			return;
 		}
 		// state cannot be unset, using ! operator
 		const state = this._nodeMap.get(_dragging)!;
-		state.last = getPositionMatrix(e);
+		state.last = getPositionMatrix(event);
 		state.dragResults.delta = getDelta(state.start, state.last);
 		if (!state.dragResults.start) {
 			state.dragResults.start = deepAssign({}, state.start);
@@ -175,14 +189,14 @@ class DragController {
 		state.invalidate();
 	}
 
-	private _onDragStop = (e: PointerEvent) => {
+	private _onDragStop = (event: PointerEvent) => {
 		const { _dragging } = this;
 		if (!_dragging) {
 			return;
 		}
 		// state cannot be unset, using ! operator
 		const state = this._nodeMap.get(_dragging)!;
-		state.last = getPositionMatrix(e);
+		state.last = getPositionMatrix(event);
 		state.dragResults.delta = getDelta(state.start, state.last);
 		if (!state.dragResults.start) {
 			state.dragResults.start = deepAssign({}, state.start);

--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -134,6 +134,17 @@ function getDelta(start: PositionMatrix, current: PositionMatrix): Position {
 	};
 }
 
+/**
+ * Sets the `touch-action` on nodes so that PointerEvents are always emitted for the node
+ * @param node The node to init
+ */
+function initNode(node: HTMLElement): void {
+	// Ensure that the node has `touch-action` none
+	node.style.touchAction = 'none';
+	// PEP requires an attribute of `touch-action` to be set on the element
+	node.setAttribute('touch-action', 'none');
+}
+
 class DragController {
 	private _nodeMap = new WeakMap<HTMLElement, NodeData>();
 	private _dragging: HTMLElement | undefined = undefined;
@@ -216,9 +227,10 @@ class DragController {
 
 	public get(node: HTMLElement, invalidate: () => void): DragResults {
 		const { _nodeMap } = this;
-		// first time we see a node, we will initialize its state
+		// first time we see a node, we will initialize its state and properties
 		if (!_nodeMap.has(node)) {
 			_nodeMap.set(node, createNodeData(invalidate));
+			initNode(node);
 			return emptyResults;
 		}
 

--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -231,8 +231,8 @@ class DragController {
 		// clear the start state
 		delete state.dragResults.start;
 
-		// reset the delta after we have read any last delta while not dragging
-		if (!dragResults.isDragging && dragResults.delta.x !== 0 && dragResults.delta.y !== 0) {
+		// reset the delta after we have read, as any future reads should have an empty delta
+		if (dragResults.delta.x !== 0 && dragResults.delta.y !== 0) {
 			// future reads of the delta will be blank
 			state.dragResults.delta = createPosition();
 		}

--- a/tests/functional/Drag.ts
+++ b/tests/functional/Drag.ts
@@ -1,0 +1,69 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+// import pollUntil = require('intern/dojo/node!leadfoot/helpers/pollUntil');
+import { DragResults } from '../../src/meta/Drag';
+
+registerSuite({
+	name: 'Drag',
+
+	'touch drag'(this: any) {
+		if (!this.remote.session.capabilities.touchEnabled) {
+			this.skip('Not touch enabled device');
+		}
+		return this.remote
+			.get((<any> require).toUrl('./meta/Drag.html'))
+			.setFindTimeout(1000)
+			.findById('results')
+			.pressFinger(50, 50)
+			.sleep(100)
+			.moveFinger(100, 100)
+			.sleep(100)
+			.findById('results')
+			.getVisibleText()
+			.then((text: string) => {
+				const result: DragResults = JSON.parse(text);
+				assert.isTrue(result.isDragging, 'should be in a drag state');
+				assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
+			})
+			.releaseFinger()
+			.sleep(50)
+			.findById('results')
+			.getVisibleText()
+			.then((text: string) => {
+				const result: DragResults = JSON.parse(text);
+				assert.isFalse(result.isDragging, 'should be no longer dragging');
+				assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should not have moved further');
+			});
+	},
+
+	'mouse drag'(this: any) {
+		if (!this.remote.session.capabilities.mouseEnabled) {
+			this.skip('Not mouse enabled device');
+		}
+		return this.remote
+			.get((<any> require).toUrl('./meta/Drag.html'))
+			.setFindTimeout(1000)
+			.findById('results')
+			.moveMouseTo(50, 50)
+			.pressMouseButton()
+			.sleep(100)
+			.moveMouseTo(100, 100)
+			.sleep(100)
+			.findById('results')
+			.getVisibleText()
+			.then((text: string) => {
+				const result: DragResults = JSON.parse(text);
+				assert.isTrue(result.isDragging, 'should be in a drag state');
+				assert.deepEqual(result.delta, { x: 50, y: 50 }, 'should have dragged expected distance');
+			})
+			.releaseMouseButton()
+			.sleep(50)
+			.findById('results')
+			.getVisibleText()
+			.then((text: string) => {
+				const result: DragResults = JSON.parse(text);
+				assert.isFalse(result.isDragging, 'should be no longer dragging');
+				assert.deepEqual(result.delta, { x: 0, y: 0 }, 'should have dragged expected distance');
+			});
+	}
+});

--- a/tests/functional/Drag.ts
+++ b/tests/functional/Drag.ts
@@ -12,7 +12,7 @@ registerSuite({
 		}
 		return this.remote
 			.get((<any> require).toUrl('./meta/Drag.html'))
-			.setFindTimeout(10000)
+			.setFindTimeout(5000)
 			.findById('results')
 			.pressFinger(50, 50)
 			.sleep(100)
@@ -37,13 +37,16 @@ registerSuite({
 	},
 
 	'mouse drag'(this: any) {
-		const { browser, mouseEnabled } = this.remote.session.capabilities;
+		const { browser, browserName, mouseEnabled } = this.remote.session.capabilities;
 		if (!mouseEnabled || browser === 'iPhone' || browser === 'iPad') {
 			this.skip('Not mouse enabled device');
 		}
+		if (browserName === 'MicrosoftEdge') {
+			this.skip('For some reason, findById not working on Edge ATM.');
+		}
 		return this.remote
 			.get((<any> require).toUrl('./meta/Drag.html'))
-			.setFindTimeout(10000)
+			.setFindTimeout(5000)
 			.findById('results')
 			.moveMouseTo(50, 50)
 			.pressMouseButton()

--- a/tests/functional/Drag.ts
+++ b/tests/functional/Drag.ts
@@ -37,7 +37,8 @@ registerSuite({
 	},
 
 	'mouse drag'(this: any) {
-		if (!this.remote.session.capabilities.mouseEnabled) {
+		const { browser, mouseEnabled } = this.remote.session.capabilities;
+		if (!mouseEnabled || browser === 'iPhone' || browser === 'iPad') {
 			this.skip('Not mouse enabled device');
 		}
 		return this.remote

--- a/tests/functional/Drag.ts
+++ b/tests/functional/Drag.ts
@@ -12,7 +12,7 @@ registerSuite({
 		}
 		return this.remote
 			.get((<any> require).toUrl('./meta/Drag.html'))
-			.setFindTimeout(1000)
+			.setFindTimeout(10000)
 			.findById('results')
 			.pressFinger(50, 50)
 			.sleep(100)
@@ -42,7 +42,7 @@ registerSuite({
 		}
 		return this.remote
 			.get((<any> require).toUrl('./meta/Drag.html'))
-			.setFindTimeout(1000)
+			.setFindTimeout(10000)
 			.findById('results')
 			.moveMouseTo(50, 50)
 			.pressMouseButton()

--- a/tests/functional/all.ts
+++ b/tests/functional/all.ts
@@ -1,1 +1,2 @@
+import './Drag';
 import './registerCustomElement';

--- a/tests/functional/meta/Drag.html
+++ b/tests/functional/meta/Drag.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Drag Test</title>
+</head>
+<body>
+	<script src="../../../../node_modules/@dojo/loader/loader.js"></script>
+	<script>
+		require.config({
+			packages: [
+				{ name: '@dojo', location: '../../../../node_modules/@dojo' },
+				{ name: 'maquette', location: '../../../../node_modules/maquette/dist', main: 'maquette' },
+				{ name: 'pepjs', location: '../../../../node_modules/pepjs/dist', main: 'pep' }
+			]
+		});
+
+		require([ './Drag' ], function () {});
+	</script>
+</body>
+</html>

--- a/tests/functional/meta/Drag.ts
+++ b/tests/functional/meta/Drag.ts
@@ -1,0 +1,25 @@
+import { v } from '../../../src/d';
+import WidgetBase from '../../../src/WidgetBase';
+import Projector from '../../../src/mixins/Projector';
+import Drag from '../../../src/meta/Drag';
+
+class DragExample extends WidgetBase {
+	render() {
+		const dragResults = this.meta(Drag).get('root');
+		return v('div', {
+			key: 'root',
+			styles: {
+				'background-color': dragResults.isDragging ? 'green' : 'white',
+				border: '1px solid black',
+				color: dragResults.isDragging ? 'white' : 'black',
+				height: '400px',
+				'user-select': 'none',
+				width: '200px'
+			}
+		}, [ v('pre#results', {}, [ JSON.stringify(dragResults, null, '  ') ]) ]);
+	}
+}
+
+const projector = new (Projector(DragExample))();
+
+projector.append();

--- a/tests/functional/meta/Drag.ts
+++ b/tests/functional/meta/Drag.ts
@@ -16,7 +16,7 @@ class DragExample extends WidgetBase {
 				'user-select': 'none',
 				width: '200px'
 			}
-		}, [ v('pre#results', {}, [ JSON.stringify(dragResults, null, '  ') ]) ]);
+		}, [ v('pre', { id: 'results' }, [ JSON.stringify(dragResults, null, '  ') ]) ]);
 	}
 }
 

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -119,6 +119,8 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				isPrimary: true,
+				button: 0,
 				clientX: 100,
 				clientY: 50,
 				offsetX: 10,
@@ -215,6 +217,8 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				isPrimary: true,
+				button: 0,
 				clientX: 100,
 				clientY: 50,
 				offsetX: 10,
@@ -339,6 +343,8 @@ registerSuite({
 		sendEvent(div.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				isPrimary: true,
+				button: 0,
 				clientX: 100,
 				clientY: 50,
 				offsetX: 10,
@@ -528,6 +534,8 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				isPrimary: true,
+				button: 0,
 				clientX: 100,
 				clientY: 50,
 				offsetX: 10,
@@ -632,6 +640,8 @@ registerSuite({
 		sendEvent(div.firstChild!.firstChild as Element, 'pointerdown', {
 			eventInit: {
 				bubbles: true,
+				isPrimary: true,
+				button: 0,
 				clientX: 100,
 				clientY: 50,
 				offsetX: 10,
@@ -681,6 +691,202 @@ registerSuite({
 			emptyResults,
 			emptyResults
 		], 'there should be no drag results');
+
+		widget.destroy();
+		document.body.removeChild(div);
+	},
+
+	'non-primary button node dragging should be ignored'() {
+		const dragResults: DragResults[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				dragResults.push(this.meta(Drag).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root',
+					styles: {
+						width: '100px',
+						height: '100px'
+					}
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerdown', {
+			eventInit: {
+				bubbles: true,
+				isPrimary: true,
+				button: 1,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 100,
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointermove', {
+			eventInit: {
+				bubbles: true,
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 110,
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerup', {
+			eventInit: {
+				bubbles: true,
+				clientX: 105,
+				clientY: 45,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 105,
+				pageY: 45,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		assert.deepEqual(dragResults, [
+			emptyResults,
+			emptyResults
+		], 'the stack of should represent a drag state');
+
+		widget.destroy();
+		document.body.removeChild(div);
+	},
+
+	'two finger touch should stop dragging'() {
+		const dragResults: DragResults[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				dragResults.push(this.meta(Drag).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root',
+					styles: {
+						width: '100px',
+						height: '100px'
+					}
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerdown', {
+			eventInit: {
+				bubbles: true,
+				isPrimary: true,
+				button: 0,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 100,
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerdown', {
+			eventInit: {
+				bubbles: true,
+				isPrimary: false,
+				button: 0,
+				clientX: 150,
+				clientY: 100,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 150,
+				pageY: 100,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointermove', {
+			eventInit: {
+				bubbles: true,
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 110,
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerup', {
+			eventInit: {
+				bubbles: true,
+				clientX: 105,
+				clientY: 45,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 105,
+				pageY: 45,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		assert.deepEqual(dragResults, [
+			emptyResults,
+			emptyResults,
+			{
+				delta: { x: 0, y: 0 },
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
+			}, {
+				delta: { x: 0, y: 0 },
+				isDragging: false
+			}
+		], 'the stack of should represent a drag state');
 
 		widget.destroy();
 		document.body.removeChild(div);

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -890,5 +890,110 @@ registerSuite({
 
 		widget.destroy();
 		document.body.removeChild(div);
+	},
+
+	'other invalidation properly reports empty delta'() {
+		const dragResults: DragResults[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				dragResults.push(this.meta(Drag).get('root'));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 'root',
+					styles: {
+						width: '100px',
+						height: '100px'
+					}
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerdown', {
+			eventInit: {
+				bubbles: true,
+				isPrimary: true,
+				button: 0,
+				clientX: 100,
+				clientY: 50,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 100,
+				pageY: 50,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointermove', {
+			eventInit: {
+				bubbles: true,
+				clientX: 110,
+				clientY: 55,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 110,
+				pageY: 55,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		widget.invalidate();
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'pointerup', {
+			eventInit: {
+				bubbles: true,
+				clientX: 105,
+				clientY: 45,
+				offsetX: 10,
+				offsetY: 5,
+				pageX: 105,
+				pageY: 45,
+				screenX: 1100,
+				screenY: 1050
+			}
+		});
+
+		resolveRAF();
+
+		assert.deepEqual(dragResults, [
+			emptyResults,
+			emptyResults,
+			{
+				delta: { x: 0, y: 0 },
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
+			}, {
+				delta: { x: 10, y: 5 },
+				isDragging: true,
+				start: { client: { x: 100, y: 50 }, offset: { x: 10, y: 5 }, page: { x: 100, y: 50 }, screen: { x: 1100, y: 1050 } }
+			}, {
+				delta: { x: 0, y: 0 },
+				isDragging: true
+			}, {
+				delta: { x: -5, y: -10 },
+				isDragging: false,
+				start: { client: { x: 110, y: 55 }, offset: { x: 10, y: 5 }, page: { x: 110, y: 55 }, screen: { x: 1100, y: 1050 } }
+			}
+		], 'the stack of should represent a drag state');
+
+		widget.destroy();
+		document.body.removeChild(div);
 	}
 });

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -58,6 +58,9 @@ registerSuite({
 
 		assert.deepEqual(dragResults, [ emptyResults, emptyResults ], 'should have been called twice, both empty results');
 
+		assert.strictEqual((div.firstChild as HTMLElement).getAttribute('touch-action'), 'none', 'Should have set touch-action attribute to none');
+		assert.strictEqual((div.firstChild as HTMLElement).style.touchAction, 'none', 'Should have set touch-action type to none');
+
 		widget.destroy();
 		document.body.removeChild(div);
 	},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR fixes issues with the Drag meta provider, where secondary button clicks (right clicks) would put the node into a drag state.  In addition it handles situations where a non primary pointer (e.g. two finger touch) occurs, which cancels the current drag state.

Resolves #717
