### PR TITLE
Meta providers accept number or string keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.1.2",
+  "version": "0.1.2-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6959,9 +6959,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
     },
     "typings-core": {
@@ -6999,7 +6999,7 @@
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
-        "typescript": "2.4.2",
+        "typescript": "2.5.3",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
       },
@@ -7012,6 +7012,12 @@
           "requires": {
             "glob": "7.1.2"
           }
+        },
+        "typescript": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+          "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+          "dev": true
         }
       }
     },

--- a/src/meta/Base.ts
+++ b/src/meta/Base.ts
@@ -20,17 +20,18 @@ export class Base extends Destroyable implements WidgetMetaBase {
 	}
 
 	protected getNode(key: string | number): HTMLElement | undefined {
-		const node = this.nodeHandler.get(key);
+		const stringKey = `${key}`;
+		const node = this.nodeHandler.get(stringKey);
 
-		if (!node && !this._requestedNodeKeys.has(key)) {
-			const handle = this.nodeHandler.on(`${key}`, () => {
+		if (!node && !this._requestedNodeKeys.has(stringKey)) {
+			const handle = this.nodeHandler.on(stringKey, () => {
 				handle.destroy();
-				this._requestedNodeKeys.delete(key);
+				this._requestedNodeKeys.delete(stringKey);
 				this.invalidate();
 			});
 
 			this.own(handle);
-			this._requestedNodeKeys.add(key);
+			this._requestedNodeKeys.add(stringKey);
 		}
 
 		return node;

--- a/src/meta/Dimensions.ts
+++ b/src/meta/Dimensions.ts
@@ -50,7 +50,7 @@ const defaultDimensions = {
 
 export class Dimensions extends Base {
 
-	public get(key: string): Readonly<DimensionResults> {
+	public get(key: string | number): Readonly<DimensionResults> {
 		const node = this.getNode(key);
 
 		if (!node) {

--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -232,7 +232,7 @@ const controller = new DragController();
 export class Drag extends Base {
 	private _boundInvalidate: () => void = this.invalidate.bind(this);
 
-	public get(key: string): Readonly<DragResults> {
+	public get(key: string | number): Readonly<DragResults> {
 		const node = this.getNode(key);
 
 		// if we don't have a reference to the node yet, return an empty set of results

--- a/src/meta/Intersection.ts
+++ b/src/meta/Intersection.ts
@@ -40,7 +40,7 @@ export class Intersection extends Base {
 	 * @param key The key to return the intersection meta for
 	 * @param options The options for the request
 	 */
-	public get(key: string, options: IntersectionGetOptions = {}): IntersectionResult {
+	public get(key: string | number, options: IntersectionGetOptions = {}): IntersectionResult {
 		let rootNode: HTMLElement | undefined;
 		if (options.root) {
 			rootNode = this.getNode(options.root);

--- a/src/meta/Matches.ts
+++ b/src/meta/Matches.ts
@@ -6,7 +6,7 @@ export default class Matches extends Base {
 	 * @param key The virtual DOM key
 	 * @param event The event object
 	 */
-	public get(key: string, event: Event): boolean {
+	public get(key: string | number, event: Event): boolean {
 		return this.getNode(key) === event.target;
 	}
 }

--- a/tests/unit/meta/Dimensions.ts
+++ b/tests/unit/meta/Dimensions.ts
@@ -59,6 +59,16 @@ registerSuite({
 
 		assert.deepEqual(dimensions.get('foo'), defaultDimensions);
 	},
+	'Will accept a number key'() {
+		const nodeHandler = new NodeHandler();
+
+		const dimensions = new Dimensions({
+			invalidate: () => {},
+			nodeHandler
+		});
+
+		assert.deepEqual(dimensions.get(1234), defaultDimensions);
+	},
 	'Will create event listener for node if not yet loaded'() {
 		const nodeHandler = new NodeHandler();
 		const onSpy = spy(nodeHandler, 'on');

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -62,6 +62,34 @@ registerSuite({
 		document.body.removeChild(div);
 	},
 
+	'standard rendering with a number key'() {
+		const dragResults: DragResults[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			render() {
+				dragResults.push(this.meta(Drag).get(1234));
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 1234
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		assert.deepEqual(dragResults, [ emptyResults, emptyResults ], 'should have been called twice, both empty results');
+
+		widget.destroy();
+		document.body.removeChild(div);
+	},
+
 	'pointer dragging a node'() {
 		const dragResults: DragResults[] = [];
 

--- a/tests/unit/meta/Intersection.ts
+++ b/tests/unit/meta/Intersection.ts
@@ -97,7 +97,7 @@ registerSuite({
 
 			intersection.get(1234);
 			assert.isTrue(onSpy.calledOnce);
-			assert.isTrue(onSpy.firstCall.calledWith(1234));
+			assert.isTrue(onSpy.firstCall.calledWith('1234'));
 		},
 		'intersection calls invalidate when node available'() {
 			const nodeHandler = new NodeHandler();

--- a/tests/unit/meta/Intersection.ts
+++ b/tests/unit/meta/Intersection.ts
@@ -86,6 +86,19 @@ registerSuite({
 			assert.isTrue(onSpy.calledOnce);
 			assert.isTrue(onSpy.firstCall.calledWith('root'));
 		},
+		'intersections with number key'() {
+			const nodeHandler = new NodeHandler();
+			const onSpy = spy(nodeHandler, 'on');
+
+			const intersection = new Intersection({
+				invalidate: () => {},
+				nodeHandler
+			});
+
+			intersection.get(1234);
+			assert.isTrue(onSpy.calledOnce);
+			assert.isTrue(onSpy.firstCall.calledWith(1234));
+		},
 		'intersection calls invalidate when node available'() {
 			const nodeHandler = new NodeHandler();
 			const onSpy = spy(nodeHandler, 'on');

--- a/tests/unit/meta/Matches.ts
+++ b/tests/unit/meta/Matches.ts
@@ -65,6 +65,40 @@ registerSuite({
 		document.body.removeChild(div);
 	},
 
+	'node matches with number key'() {
+		const results: boolean[] = [];
+
+		class TestWidget extends ProjectorMixin(ThemeableMixin(WidgetBase)) {
+			private _onclick(evt: MouseEvent) {
+				results.push(this.meta(Matches).get(1234, evt));
+			}
+
+			render() {
+				return v('div', {
+					innerHTML: 'hello world',
+					key: 1234,
+					onclick: this._onclick
+				});
+			}
+		}
+
+		const div = document.createElement('div');
+
+		document.body.appendChild(div);
+
+		const widget = new TestWidget();
+		widget.append(div);
+
+		resolveRAF();
+
+		sendEvent(div.firstChild as Element, 'click');
+
+		assert.deepEqual(results, [ true ], 'should have been called and the target matched');
+
+		widget.destroy();
+		document.body.removeChild(div);
+	},
+
 	'node does not match'() {
 		const results: boolean[] = [];
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This fixes all the meta providers so their `.get()` methods accepts `string | number` for keys.

Resolves #720
