### PR TITLE
Support deferred properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2383,9 +2383,9 @@
       }
     },
     "generic-names": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.2.tgz",
-      "integrity": "sha1-4lt/7OtbWo8o9flyp8z+V+Virc0=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
+      "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
       "dev": true,
       "requires": {
         "loader-utils": "0.2.17"
@@ -2703,9 +2703,9 @@
       }
     },
     "grunt-dojo2": {
-      "version": "2.0.0-beta2.9",
-      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.9.tgz",
-      "integrity": "sha512-uiYNSMJluURE2q6fh6xROMvfHPuf+Ij/1a5pSgoyzcuj7udGOCP63V+k9hTp75h6WvuQgLpyz5p4ZkIKdmKwjQ==",
+      "version": "2.0.0-beta2.10",
+      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.10.tgz",
+      "integrity": "sha512-kV6qK4Kll+WxRQgIi330VAl9ImEmSpatlzsRf5kR+yX47pD1bjKImfrGEE9nIPeDiHt42nKi/Ec8GhOoT9fX5Q==",
       "dev": true,
       "requires": {
         "codecov.io": "0.1.6",
@@ -5567,7 +5567,7 @@
       "dev": true,
       "requires": {
         "css-modules-loader-core": "1.1.0",
-        "generic-names": "1.0.2",
+        "generic-names": "1.0.3",
         "postcss": "5.2.18",
         "string-hash": "1.1.3"
       }

--- a/src/d.ts
+++ b/src/d.ts
@@ -2,6 +2,7 @@ import Symbol from '@dojo/shim/Symbol';
 import {
 	Constructor,
 	DefaultWidgetBaseInterface,
+	DeferredVirtualProperties,
 	DNode,
 	HNode,
 	RegistryLabel,
@@ -77,19 +78,26 @@ export function w<W extends WidgetBaseInterface>(widgetConstructor: Constructor<
 /**
  * Wrapper function for calls to create HNodes.
  */
-export function v(tag: string, properties: VirtualDomProperties, children?: DNode[]): HNode;
+export function v(tag: string, properties: VirtualDomProperties | DeferredVirtualProperties, children?: DNode[]): HNode;
 export function v(tag: string, children: undefined | DNode[]): HNode;
 export function v(tag: string): HNode;
-export function v(tag: string, propertiesOrChildren: VirtualDomProperties | DNode[] = {}, children: undefined | DNode[] = undefined): HNode {
-		let properties: VirtualDomProperties = propertiesOrChildren;
+export function v(tag: string, propertiesOrChildren: VirtualDomProperties | DeferredVirtualProperties | DNode[] = {}, children: undefined | DNode[] = undefined): HNode {
+		let properties: VirtualDomProperties | DeferredVirtualProperties = propertiesOrChildren;
+		let deferredPropertiesCallback;
 
 		if (Array.isArray(propertiesOrChildren)) {
 			children = propertiesOrChildren;
 			properties = {};
 		}
 
+		if (typeof properties === 'function') {
+			deferredPropertiesCallback = properties;
+			properties = {};
+		}
+
 		return {
 			tag,
+			deferredPropertiesCallback,
 			children,
 			properties,
 			type: HNODE

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -79,7 +79,7 @@ export interface Projection {
 	update(updatedDNode: DNode): void;
 }
 
-export type DeferredVirtualProperties = (updated: boolean) => VirtualDomProperties;
+export type DeferredVirtualProperties = (inserted: boolean) => VirtualDomProperties;
 
 export interface VirtualDomProperties {
 	/**

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -69,6 +69,7 @@ export interface ProjectorOptions {
 export interface ProjectionOptions extends ProjectorOptions {
 	readonly namespace?: string;
 	eventHandlerInterceptor?: (propertyName: string, eventHandler: Function, domNode: Node, properties: VirtualDomProperties) => Function | undefined;
+	deferredRenderCallbacks: Function [];
 	afterRenderCallbacks: Function[];
 	merge: boolean;
 }
@@ -77,6 +78,8 @@ export interface Projection {
 	readonly domNode: Element;
 	update(updatedDNode: DNode): void;
 }
+
+export type DeferredVirtualProperties = (updated: boolean) => VirtualDomProperties;
 
 export interface VirtualDomProperties {
 	/**
@@ -257,6 +260,11 @@ export interface HNode {
 	 * HNode properties
 	 */
 	properties: VirtualDomProperties;
+
+	/**
+	 * Deferred callback for HNode properties
+	 */
+	deferredPropertiesCallback?: DeferredVirtualProperties;
 
 	/**
 	 * The tag of the HNode

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -138,6 +138,15 @@ registerSuite('d', {
 			assert.equal(hNode.type, HNODE);
 			assert.isTrue(isHNode(hNode));
 			assert.isFalse(isWNode(hNode));
+		},
+		'create HNode wrapper with deferred properties'() {
+			const props = () => {
+				return { a: 'a' };
+			};
+			const hNode = v('div', props);
+
+			assert.deepEqual(hNode.properties, {});
+			assert.strictEqual(hNode.deferredPropertiesCallback, props);
 		}
 	},
 	decorator: {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

`v()` now supports a function as the second parameter (rather than just `VirtualDomProperties`). If a callback is passed, the callback will be called on render as per usual, and then again on the next `requestAnimationFrame`. This allows you to for example measure and apply changes to a property without having to trigger a full re-render, or change a style property to trigger a css transition. 

Example usage:

```typescript
v('div', (inserted /** the dom node has been inserted **/ ) => {
    return {
        opacity: inserted ? '1' : '0',
        classes: [ 'fadeIn' ]
    };
});
```

There are a few caveats which will likely be resolved in future:
* in lieu of a bonafide scheduler, there is nothing fancy here - it will simply queue a deferred property callback to the next `rAF` even if a main render is scheduled for the next `rAF`. In the future it will be more desirable to remove deferred property callbacks from the queue if they are going to be updated as part of a main render anyway. 

* there will currently be an issue with using `this.meta` in a deferred property callback on render due to us scheduling nodes to be added to the node handler (which meta uses for dom node existing) on a `rIC` rather than a `rAF`. the node handler also clears out nodes after each `__render__`, which is problematic for anything deferred after it, so we will need a better way of handling dom nodes generally in the node handler.

I will raise a PR with a readme update separately as their is an outstanding PR open.

Resolves https://github.com/dojo/widget-core/issues/714