### PR TITLE
Only break early by node equality in `updateDom` for HNodes

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -706,9 +706,6 @@ function createDom(
 }
 
 function updateDom(previous: any, dnode: InternalDNode, projectionOptions: ProjectionOptions, parentNode: Element, parentInstance: WidgetBase) {
-	if (previous === dnode) {
-		return false;
-	}
 	if (isWNode(dnode)) {
 		const { instance, rendered: previousRendered } = previous;
 		if (instance && previousRendered) {
@@ -730,6 +727,9 @@ function updateDom(previous: any, dnode: InternalDNode, projectionOptions: Proje
 		}
 	}
 	else {
+		if (previous === dnode) {
+			return false;
+		}
 		const domNode = previous.domNode!;
 		let textUpdated = false;
 		let updated = false;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Only break early for matching `HNode`, not matching `WNode`s.

Resolves #742 
