### PR TITLE
Move logic in custom element initialization

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -226,8 +226,11 @@ export function initializeElement(element: CustomElement) {
 	}
 
 	const projector = ProjectorMixin(element.getWidgetConstructor());
-
 	const widgetInstance = new projector();
+
+	widgetInstance.setProperties(initialProperties);
+	element.setWidgetInstance(widgetInstance);
+
 	return function() {
 		// find children
 		let children: DNode[] = [];
@@ -242,9 +245,7 @@ export function initializeElement(element: CustomElement) {
 			element.removeChild(childNode);
 		});
 
-		widgetInstance.setProperties(initialProperties);
 		widgetInstance.setChildren(children);
-		element.setWidgetInstance(widgetInstance);
 		widgetInstance.append(element);
 	};
 }

--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -221,32 +221,30 @@ export function initializeElement(element: CustomElement) {
 		};
 	});
 
-	// find children
-	let children: DNode[] = [];
-
-	arrayFrom(element.children).forEach((childNode: HTMLElement, index: number) => {
-		const DomElement = DomWrapper(childNode);
-		children.push(w(DomElement, {
-			key: `child-${index}`
-		}));
-	});
-
 	if (initialization) {
 		initialization.call(element, initialProperties);
 	}
 
-	arrayFrom(element.children).forEach((childNode: HTMLElement) => {
-		element.removeChild(childNode);
-	});
-
 	const projector = ProjectorMixin(element.getWidgetConstructor());
 
 	const widgetInstance = new projector();
-	widgetInstance.setProperties(initialProperties);
-	widgetInstance.setChildren(children);
-	element.setWidgetInstance(widgetInstance);
-
 	return function() {
+		// find children
+		let children: DNode[] = [];
+		let elementChildren = arrayFrom(element.children);
+		elementChildren.forEach((childNode: HTMLElement, index: number) => {
+			const DomElement = DomWrapper(childNode);
+			children.push(w(DomElement, {
+				key: `child-${index}`
+			}));
+		});
+		elementChildren.forEach((childNode: HTMLElement) => {
+			element.removeChild(childNode);
+		});
+
+		widgetInstance.setProperties(initialProperties);
+		widgetInstance.setChildren(children);
+		element.setWidgetInstance(widgetInstance);
 		widgetInstance.append(element);
 	};
 }

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -129,7 +129,7 @@ registerSuite('registerCustomElement', {
 			return this.remote
 				.get((<any> require).toUrl('./support/registerCustomElement.html'))
 				.setFindTimeout(1000)
-				.findByCssSelector('#parent-element > div > child-wrapper#nestedParent > div > div')
+				.findByCssSelector('#parent-element > div > child-wrapper#nested-parent > div > div')
 				.then((element: any) => {
 					return element.getVisibleText();
 				})
@@ -157,7 +157,7 @@ registerSuite('registerCustomElement', {
 					return element.getVisibleText();
 				})
 				.then((text: string) => {
-					assert.strictEqual(text, 'nested child');
+					assert.strictEqual(text, 'programmatic nested child');
 				})
 				.end()
 				.findByCssSelector('#dynamic-parent-element > div > div')
@@ -165,7 +165,7 @@ registerSuite('registerCustomElement', {
 					return element.getVisibleText();
 				})
 				.then((text: string) => {
-					assert.strictEqual(text, 'top level child');
+					assert.strictEqual(text, 'programmatic top level child');
 				});
 		}
 	}

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -121,6 +121,52 @@ registerSuite('registerCustomElement', {
 				.then(pollUntil(function () {
 					return (<any> document).querySelector('#reinitButton > button').innerHTML === 'test';
 				}, undefined, 1000), undefined);
+		},
+		'declarative children should be wrapped as widgets'() {
+			if (skip) {
+				this.skip('not compatible with iOS 9.1 or Safari 9.1');
+			}
+			return this.remote
+				.get((<any> require).toUrl('./support/registerCustomElement.html'))
+				.setFindTimeout(1000)
+				.findByCssSelector('#parent-element > div > child-wrapper#nestedParent > div > div')
+				.then((element: any) => {
+					return element.getVisibleText();
+				})
+				.then((text: string) => {
+					assert.strictEqual(text, 'nested child');
+				})
+				.end()
+				.findByCssSelector('#parent-element > div > div')
+				.then((element: any) => {
+					return element.getVisibleText();
+				})
+				.then((text: string) => {
+					assert.strictEqual(text, 'top level child');
+				});
+		},
+		'programmatically added children should be wrapped as widgets'() {
+			if (skip) {
+				this.skip('not compatible with iOS 9.1 or Safari 9.1');
+			}
+			return this.remote
+				.get((<any> require).toUrl('./support/registerCustomElement.html'))
+				.setFindTimeout(1000)
+				.findByCssSelector('#dynamic-parent-element > div > child-wrapper > div > div')
+				.then((element: any) => {
+					return element.getVisibleText();
+				})
+				.then((text: string) => {
+					assert.strictEqual(text, 'nested child');
+				})
+				.end()
+				.findByCssSelector('#dynamic-parent-element > div > div')
+				.then((element: any) => {
+					return element.getVisibleText();
+				})
+				.then((text: string) => {
+					assert.strictEqual(text, 'top level child');
+				});
 		}
 	}
 });

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -10,6 +10,12 @@
 <test-button id="testButton" label="hello" label-suffix="world"></test-button>
 
 <no-attributes id="noAttributes" label="hello" label-suffix="world"></no-attributes>
+<child-wrapper id="parent-element">
+	<child-wrapper id="nested-parent">
+		<div>nested child</div>
+	</child-wrapper>,
+	<div>top level child</div>
+</child-wrapper>
 
 <script>
 	window.buttonClicked = false;
@@ -40,9 +46,23 @@
 		var reinitButton = document.createElement("test-button");
 		reinitButton.id = "reinitButton";
 		reinitButton.label = "test";
+		reinitButton.appendChild(document.createElement('div'));
 		document.body.appendChild(reinitButton);
 		document.body.removeChild(reinitButton);
 		document.body.appendChild(reinitButton);
+
+		var dynamicChildren = document.createElement('child-wrapper');
+		var nestedParent = document.createElement('child-wrapper');
+		var topLevelChild = document.createElement('div');
+		var nestedChild = document.createElement('div');
+		nestedParent.appendChild(nestedChild);
+		dynamicChildren.appendChild(nestedParent);
+		dynamicChildren.appendChild(topLevelChild);
+		topLevelChild.textContent = 'Programmatic top level child';
+		nestedChild.textContent = 'Programmatic nested child';
+		document.body.appendChild(dynamicChildren);
+		document.body.removeChild(dynamicChildren);
+		document.body.appendChild(dynamicChildren);
 	});
 </script>
 </body>

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -55,6 +55,7 @@
 		var nestedParent = document.createElement('child-wrapper');
 		var topLevelChild = document.createElement('div');
 		var nestedChild = document.createElement('div');
+		dynamicChildren.id = 'dynamic-parent-element';
 		nestedParent.appendChild(nestedChild);
 		dynamicChildren.appendChild(nestedParent);
 		dynamicChildren.appendChild(topLevelChild);

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -13,7 +13,7 @@
 <child-wrapper id="parent-element">
 	<child-wrapper id="nested-parent">
 		<div>nested child</div>
-	</child-wrapper>,
+	</child-wrapper>
 	<div>top level child</div>
 </child-wrapper>
 
@@ -59,8 +59,8 @@
 		nestedParent.appendChild(nestedChild);
 		dynamicChildren.appendChild(nestedParent);
 		dynamicChildren.appendChild(topLevelChild);
-		topLevelChild.textContent = 'Programmatic top level child';
-		nestedChild.textContent = 'Programmatic nested child';
+		topLevelChild.textContent = 'programmatic top level child';
+		nestedChild.textContent = 'programmatic nested child';
 		document.body.appendChild(dynamicChildren);
 		document.body.removeChild(dynamicChildren);
 		document.body.appendChild(dynamicChildren);

--- a/tests/functional/support/registerCustomElement.ts
+++ b/tests/functional/support/registerCustomElement.ts
@@ -26,6 +26,12 @@ class TestButton extends WidgetBase<TestButtonProperties> {
 	}
 }
 
+class ChildWrapper extends WidgetBase {
+	render() {
+		return v('div', {}, this.children);
+	}
+}
+
 registerCustomElement(function () {
 	return {
 		tagName: 'test-button',
@@ -64,5 +70,12 @@ registerCustomElement(function () {
 				eventName: 'button-click'
 			}
 		]
+	};
+});
+
+registerCustomElement(function () {
+	return {
+		tagName: 'child-wrapper',
+		widgetConstructor: ChildWrapper
 	};
 });

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -75,7 +75,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 
 			const result = element.getWidgetInstance().properties;
 			assert.strictEqual(result.a, '1');
@@ -101,7 +101,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 
 			assert.strictEqual(element.a, '1');
 			assert.strictEqual(element.b, '2');
@@ -125,7 +125,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 
 			element.a = 4;
 
@@ -143,7 +143,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 
 			handleAttributeChanged(element, 'a', 'test', null);
 			handleAttributeChanged(element, 'b', 'test', null);
@@ -158,7 +158,7 @@ registerSuite('customElements', {
 				tagName: 'test'
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 
 			handleAttributeChanged(element, 'b', 'test', null);
 
@@ -177,7 +177,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 			element.getWidgetInstance().__setProperties__({
 				a: 'test'
 			});
@@ -199,7 +199,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 			element.getWidgetInstance().__setProperties__({
 				test: 'test'
 			});
@@ -220,7 +220,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 			element.getWidgetInstance().__setProperties__({
 				a: 4
 			});
@@ -241,7 +241,7 @@ registerSuite('customElements', {
 				]
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 			element.a = 4;
 
 			assert.deepEqual(element.getWidgetInstance().properties.a, 8);
@@ -273,7 +273,7 @@ registerSuite('customElements', {
 					]
 				});
 
-				initializeElement(element);
+				initializeElement(element)();
 
 				assert.isFunction(element.getWidgetInstance().properties.onTest);
 				element.getWidgetInstance().properties.onTest('detail here');
@@ -296,7 +296,7 @@ registerSuite('customElements', {
 				parentNode: element
 			} ];
 
-			initializeElement(element);
+			initializeElement(element)();
 
 			assert.lengthOf(element.removedChildren(), 1);
 			assert.lengthOf(element.getWidgetInstance().children, 1);
@@ -313,7 +313,7 @@ registerSuite('customElements', {
 				}
 			});
 
-			initializeElement(element);
+			initializeElement(element)();
 
 			assert.strictEqual(element.getWidgetInstance().properties.prop1, 'test');
 		}

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -20,7 +20,11 @@ function createFakeElement(attributes: any, descriptor: CustomElementDescriptor)
 		setWidgetInstance(instance: WidgetBase<any>) {
 			widgetInstance = instance;
 		},
-		getWidgetConstructor: () => WidgetBase,
+		getWidgetConstructor: () => class extends WidgetBase<any> {
+			render() {
+				return v('div');
+			}
+		},
 		getDescriptor: () => descriptor,
 		children: [],
 		getAttribute(name: string) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
If I'm understanding the code correctly, the widget won't render until it's attached to the projector. That happens [here](https://github.com/dojo/widget-core/blob/master/src/customElements.ts#L250), in the callback that gets called when the custom element is attached to the DOM. So until that point we don't need to worry about a `MutationObserver`, because we can just capture the state of the element when it's attached and set the appropriate children at that time. This has the added benefit of letting things like `replaceChild` and `insertBefore` work as expected, without a lot of additional logic.

If we want to be able to add children after the element is attached then we will probably need to track the elements we've seen and use a `MutationObserver` to detect new children and create widgets for them. That should probably be a separate PR though.

Resolves #531 
