### PR TITLE
Do not own child widgets to ensure instances can be GC'd once they are no longer required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,46 +35,71 @@
       "dev": true
     },
     "@theintern/digdug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.0.tgz",
-      "integrity": "sha512-PDcflahjSPdnJnChtWhej3l5jknGDdDl15p1+7rNxjOpb2gpgnhoWzXCfkUFJvUL/q1DuAowRQNNh2hdUk5MGw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.1.tgz",
+      "integrity": "sha512-MCF9jwQWAbBhy6NTQiaLeOrPOOtijYX9/LfyDyJJqnq6c0icBL4XfV58eudIXNiZtTYFiVwFh104dlCgL7+Auw==",
       "dev": true,
       "requires": {
-        "@dojo/core": "2.0.0-beta2.4",
-        "@dojo/has": "2.0.0-beta2.3",
-        "@dojo/interfaces": "2.0.0-beta2.4",
-        "@dojo/shim": "2.0.0-beta2.4",
+        "@dojo/core": "0.1.0",
+        "@dojo/has": "0.1.0",
+        "@dojo/interfaces": "0.1.0",
+        "@dojo/shim": "0.1.0",
         "decompress": "4.2.0",
-        "semver": "5.4.1"
+        "semver": "5.4.1",
+        "tslib": "1.8.0"
       },
       "dependencies": {
-        "@dojo/interfaces": {
-          "version": "2.0.0-beta2.4",
-          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-2.0.0-beta2.4.tgz",
-          "integrity": "sha1-OGXj9EQJMuCNJNJPgj5UFwaiKNM=",
+        "@dojo/core": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.1.0.tgz",
+          "integrity": "sha512-boiwQHfV7idOZfZnDzgLrofS2LA7ELGKjd6tl0/hLBunJ3psozAd4CpNcT7XC00/OPYFIxVHFEpI+FZNlpUgfw==",
+          "dev": true
+        },
+        "@dojo/has": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.0.tgz",
+          "integrity": "sha512-orYLbYVTcqNpZBmPNRlidUyCn/WuV4jV4JvTAy4Je/zQq9m9Nb8gK+8X7/iOUjSJbP1+vv1ld9Q3932IGC1IyA==",
+          "dev": true
+        },
+        "@dojo/shim": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.1.0.tgz",
+          "integrity": "sha512-008RP8DB175ib26dde7wQWFiYIbSACFaArLdLHYdY/cQLN9s3yVj2Gtp5C/9YoY3Ziy9wA241myOjy6QcVHcWw==",
           "dev": true
         }
       }
     },
     "@theintern/leadfoot": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.0.tgz",
-      "integrity": "sha512-kcC/tpbdaO8DplWdZ1BeOXwII5HCwiVk3Dck0dnmm/vdqtzRE4yApY5um062PAJh8TqzT1cdR/zy4k4HWo8dBQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.1.tgz",
+      "integrity": "sha512-6aWQP7Qf5pvh8iEvDS+5gCbazqmb40PXADsGLBOZmKorC3WLELpP4Dw0GkeWKf4UYJ/4xKPwUX4gNTbYlF74kA==",
       "dev": true,
       "requires": {
-        "@dojo/core": "2.0.0-beta2.4",
-        "@dojo/has": "2.0.0-beta2.3",
-        "@dojo/interfaces": "2.0.0-beta2.4",
-        "@dojo/shim": "2.0.0-beta2.4",
+        "@dojo/core": "0.1.0",
+        "@dojo/has": "0.1.0",
+        "@dojo/interfaces": "0.1.0",
+        "@dojo/shim": "0.1.0",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.4",
-        "tslib": "1.7.1"
+        "tslib": "1.8.0"
       },
       "dependencies": {
-        "@dojo/interfaces": {
-          "version": "2.0.0-beta2.4",
-          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-2.0.0-beta2.4.tgz",
-          "integrity": "sha1-OGXj9EQJMuCNJNJPgj5UFwaiKNM=",
+        "@dojo/core": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.1.0.tgz",
+          "integrity": "sha512-boiwQHfV7idOZfZnDzgLrofS2LA7ELGKjd6tl0/hLBunJ3psozAd4CpNcT7XC00/OPYFIxVHFEpI+FZNlpUgfw==",
+          "dev": true
+        },
+        "@dojo/has": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.0.tgz",
+          "integrity": "sha512-orYLbYVTcqNpZBmPNRlidUyCn/WuV4jV4JvTAy4Je/zQq9m9Nb8gK+8X7/iOUjSJbP1+vv1ld9Q3932IGC1IyA==",
+          "dev": true
+        },
+        "@dojo/shim": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.1.0.tgz",
+          "integrity": "sha512-008RP8DB175ib26dde7wQWFiYIbSACFaArLdLHYdY/cQLN9s3yVj2Gtp5C/9YoY3Ziy9wA241myOjy6QcVHcWw==",
           "dev": true
         }
       }
@@ -263,9 +288,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.80",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.80.tgz",
-      "integrity": "sha512-FumgRtCaxilKUcgMnZCzH6K3gntIwLiLLIaR+UBGNZpT/N3ne2dKrDSGoGIxSHYpAjnq6kIVV0r51U+kLXX59A==",
+      "version": "4.14.82",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.82.tgz",
+      "integrity": "sha512-fhoasvjS6qO4nPEfCD0fonL+BHS3b9ge0LpHxumuDtOuKMvs85OmQldDQzmlGEOZIfyYeo5/sas07+hWWzSJlw==",
       "dev": true
     },
     "@types/marked": {
@@ -642,7 +667,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000756",
+        "caniuse-db": "1.0.30000758",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1010,7 +1035,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000756",
+        "caniuse-db": "1.0.30000758",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -1074,15 +1099,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000756",
+        "caniuse-db": "1.0.30000758",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000756",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000756.tgz",
-      "integrity": "sha1-6TimuZFjDzDSJj3TRYvrZdNiJos=",
+      "version": "1.0.30000758",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000758.tgz",
+      "integrity": "sha1-ojViexki6Hi2MWSULJkbhN6SyBA=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3251,8 +3276,8 @@
         "@dojo/has": "2.0.0-beta2.3",
         "@dojo/interfaces": "2.0.0-beta2.4",
         "@dojo/shim": "2.0.0-beta2.4",
-        "@theintern/digdug": "2.0.0",
-        "@theintern/leadfoot": "2.0.0",
+        "@theintern/digdug": "2.0.1",
+        "@theintern/leadfoot": "2.0.1",
         "@types/benchmark": "1.0.30",
         "@types/chai": "4.0.4",
         "@types/charm": "1.0.1",
@@ -3265,7 +3290,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.80",
+        "@types/lodash": "4.14.82",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -5457,7 +5482,7 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.13",
+        "postcss": "6.0.14",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
@@ -5488,9 +5513,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -5578,7 +5603,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5608,9 +5633,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -5642,7 +5667,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5672,9 +5697,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -5706,7 +5731,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5736,9 +5761,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -5770,7 +5795,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5800,9 +5825,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7096,9 +7121,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
+      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
       "dev": true
     },
     "tslint": {
@@ -7116,8 +7141,8 @@
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
-        "tslib": "1.7.1",
-        "tsutils": "2.12.1"
+        "tslib": "1.8.0",
+        "tsutils": "2.12.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7177,12 +7202,12 @@
           }
         },
         "tsutils": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
-          "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.2.tgz",
+          "integrity": "sha1-rVikhl0X7D3bZjG2ylO+FKVlb/M=",
           "dev": true,
           "requires": {
-            "tslib": "1.7.1"
+            "tslib": "1.8.0"
           }
         }
       }
@@ -7257,7 +7282,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.1.10",
-        "@types/lodash": "4.14.80",
+        "@types/lodash": "4.14.82",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -363,7 +363,7 @@ export function filterAndDecorateChildren(children: undefined | DNode | DNode[],
 	}
 	children = Array.isArray(children) ? children : [ children ];
 
-	for (let i = 0; i < children.length;) {
+	for (let i = 0; i < children.length; ) {
 		const child = children[i] as InternalDNode;
 		if (child === undefined || child === null) {
 			children.splice(i, 1);
@@ -637,7 +637,6 @@ function createDom(
 			widgetConstructor = item;
 		}
 		const instance = new widgetConstructor();
-		parentInstance.own(instance);
 		instance.own(instance.on('invalidated', () => {
 			parentInstance.invalidate();
 		}));


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

As per the investigation in #745, when a parent owns its widget children it creates a handle reference that is never severed and therefore the widgets are never available for garbage collection.

Removing the automatic `own` on child widgets enables children to be GC'd correctly once they are no longer in use.

Related to #745 
