### PR TITLE
Fix behavior for multiple nodes with the same root in intersection meta

### DIFF
--- a/src/meta/Intersection.ts
+++ b/src/meta/Intersection.ts
@@ -53,11 +53,8 @@ export class Intersection extends Base {
 			return defaultIntersection;
 		}
 
-		let details = this._getDetails(options);
-		if (!details || !details.entries.get(node)) {
-			if (!details) {
-				details = this._createDetails(options, rootNode);
-			}
+		let details = this._getDetails(options) || this._createDetails(options, rootNode);
+		if (!details.entries.get(node)) {
 			details.entries.set(node, defaultIntersection);
 			details.observer.observe(node);
 		}

--- a/src/meta/Intersection.ts
+++ b/src/meta/Intersection.ts
@@ -54,8 +54,11 @@ export class Intersection extends Base {
 		}
 
 		let details = this._getDetails(options);
-		if (!details) {
-			details = this._createDetails(options, rootNode);
+		if (!details || !details.entries.get(node)) {
+			if (!details) {
+				details = this._createDetails(options, rootNode);
+			}
+			details.entries.set(node, defaultIntersection);
 			details.observer.observe(node);
 		}
 

--- a/tests/unit/meta/Intersection.ts
+++ b/tests/unit/meta/Intersection.ts
@@ -271,11 +271,11 @@ registerSuite('meta - Intersection', {
 				assert.equal(observeStub.callCount, 2, 'Should have observed node with different options');
 				assert.lengthOf(observers, 2);
 				intersection.get('bar');
-				assert.equal(observeStub.callCount, 3, 'Should have observed node with a different key');
+				assert.equal(observeStub.callCount, 3, 'Should have observed new node');
 				assert.lengthOf(observers, 2);
 				intersection.get('bar', { root: 'root'});
 				assert.lengthOf(observers, 2);
-				assert.equal(observeStub.callCount, 4, 'Should have observed node with a different key and options');
+				assert.equal(observeStub.callCount, 4, 'Should have observed new node with different options');
 
 				intersection.get('bar', { root: 'root'});
 				intersection.get('bar');

--- a/tests/unit/meta/Intersection.ts
+++ b/tests/unit/meta/Intersection.ts
@@ -238,6 +238,42 @@ registerSuite('meta - Intersection', {
 				assert.lengthOf(observers, 2);
 				intersection.get('foo', { root: 'root'});
 				assert.lengthOf(observers, 2);
+			},
+			'observing multiple elements with the same root'() {
+				const nodeHandler = new NodeHandler();
+				const observeStub = stub();
+				const intersection = new Intersection({
+					invalidate: () => {},
+					nodeHandler
+				});
+				const root = document.createElement('div');
+				const bar = document.createElement('div');
+
+				intersectionObserver.restore();
+				intersectionObserver = stub(global, 'IntersectionObserver', function (callback: any) {
+					const observer = {
+						observe: observeStub,
+						takeRecords: stub().returns([])
+					};
+					observers.push([ observer, callback ]);
+					return observer;
+				});
+
+				nodeHandler.add(bar, 'bar');
+				nodeHandler.add(root, 'foo');
+				nodeHandler.add(root, 'root');
+				intersection.get('foo');
+				assert.lengthOf(observers, 1);
+				assert.equal(observeStub.callCount, 1, 'Should have observed node');
+				intersection.get('foo', { root: 'root'});
+				assert.equal(observeStub.callCount, 2, 'Should have observed node with different options');
+				assert.lengthOf(observers, 2);
+				intersection.get('bar');
+				assert.equal(observeStub.callCount, 3, 'Should have observed node with a different key');
+				assert.lengthOf(observers, 2);
+				intersection.get('bar', { root: 'root'});
+				assert.lengthOf(observers, 2);
+				assert.equal(observeStub.callCount, 4, 'Should have observed node with a different key and options');
 			}
 		}
 	}

--- a/tests/unit/meta/Intersection.ts
+++ b/tests/unit/meta/Intersection.ts
@@ -259,9 +259,11 @@ registerSuite('meta - Intersection', {
 					return observer;
 				});
 
-				nodeHandler.add(bar, 'bar');
 				nodeHandler.add(root, 'foo');
+				nodeHandler.add(bar, 'bar');
+				nodeHandler.add(root, 'baz');
 				nodeHandler.add(root, 'root');
+
 				intersection.get('foo');
 				assert.lengthOf(observers, 1);
 				assert.equal(observeStub.callCount, 1, 'Should have observed node');
@@ -274,6 +276,49 @@ registerSuite('meta - Intersection', {
 				intersection.get('bar', { root: 'root'});
 				assert.lengthOf(observers, 2);
 				assert.equal(observeStub.callCount, 4, 'Should have observed node with a different key and options');
+
+				intersection.get('bar', { root: 'root'});
+				intersection.get('bar');
+				intersection.get('foo');
+				intersection.get('foo', { root: 'root'});
+				assert.lengthOf(observers, 2);
+				assert.equal(observeStub.callCount, 4, 'Should not have observed the same nodes again');
+			},
+			'observation should be based on node, not key'() {
+				const nodeHandler = new NodeHandler();
+				const observeStub = stub();
+				const intersection = new Intersection({
+					invalidate: () => {},
+					nodeHandler
+				});
+				const root = document.createElement('div');
+
+				intersectionObserver.restore();
+				intersectionObserver = stub(global, 'IntersectionObserver', function (callback: any) {
+					const observer = {
+						observe: observeStub,
+						takeRecords: stub().returns([])
+					};
+					observers.push([ observer, callback ]);
+					return observer;
+				});
+
+				nodeHandler.add(root, 'foo');
+				nodeHandler.add(root, 'baz');
+				nodeHandler.add(root, 'root');
+
+				intersection.get('foo');
+				assert.lengthOf(observers, 1);
+				assert.equal(observeStub.callCount, 1, 'Should have observed node');
+				intersection.get('foo', { root: 'root'});
+				assert.equal(observeStub.callCount, 2, 'Should have observed node with different options');
+				assert.lengthOf(observers, 2);
+				intersection.get('baz');
+				assert.equal(observeStub.callCount, 2, 'Should not have observed with the same node and options');
+				assert.lengthOf(observers, 2);
+				intersection.get('baz', { root: 'root'});
+				assert.equal(observeStub.callCount, 2, 'Should not have observed with the same node and options');
+				assert.lengthOf(observers, 2);
 			}
 		}
 	}

--- a/tests/unit/meta/Intersection.ts
+++ b/tests/unit/meta/Intersection.ts
@@ -244,7 +244,8 @@ registerSuite('meta - Intersection', {
 				const observeStub = stub();
 				const intersection = new Intersection({
 					invalidate: () => {},
-					nodeHandler
+					nodeHandler,
+					bind: bindInstance
 				});
 				const root = document.createElement('div');
 				const bar = document.createElement('div');
@@ -289,7 +290,8 @@ registerSuite('meta - Intersection', {
 				const observeStub = stub();
 				const intersection = new Intersection({
 					invalidate: () => {},
-					nodeHandler
+					nodeHandler,
+					bind: bindInstance
 				});
 				const root = document.createElement('div');
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
The intersection meta would not observe any nodes after the first called for a given `options` + `root` combination. This updates the logic so that `details` is only created once for each `options` + `root` combination but each new node requested is observed. A default value for details is provided for each node to avoid observing that node more than once.

Resolves #727 
