### PR TITLE
Add 'connected' event for custom elements

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -131,7 +131,7 @@ function getWidgetPropertyFromAttribute(attributeName: string, attributeValue: s
 	return [ propertyName, value ];
 }
 
-let customEventClass = global.CustomEvent;
+export let customEventClass = global.CustomEvent;
 
 if (typeof customEventClass !== 'function') {
 	const customEvent = function (event: string, params: any) {

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -1,4 +1,5 @@
 import {
+	customEventClass,
 	CustomElementDescriptor,
 	handleAttributeChanged,
 	initializeElement
@@ -43,6 +44,9 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 			if (!this._isAppended) {
 				this._appender();
 				this._isAppended = true;
+				this.dispatchEvent(new customEventClass('connected', {
+					bubbles: false
+				}));
 			}
 		}
 

--- a/tests/functional/registerCustomElement.ts
+++ b/tests/functional/registerCustomElement.ts
@@ -53,6 +53,21 @@ registerSuite('registerCustomElement', {
 					assert.isTrue(buttonClicked);
 				});
 		},
+		'custom elements emit event on connection'() {
+			if (skip) {
+				this.skip('not compatible with iOS 9.1 or Safari 9.1');
+			}
+			return this.remote
+				.get((<any> require).toUrl('./support/registerCustomElement.html'))
+				.setFindTimeout(1000)
+				.findByCssSelector('#testButton > button')
+				.click()
+				.end()
+				.execute('return window.connectedEvent')
+				.then((connectedEvent: boolean) => {
+					assert.isTrue(connectedEvent);
+				});
+		},
 		'updates the correct instance when multiple or the same custom elements are used'() {
 			if (skip) {
 				this.skip('not compatible with iOS 9.1 or Safari 9.1');

--- a/tests/functional/support/registerCustomElement.html
+++ b/tests/functional/support/registerCustomElement.html
@@ -20,12 +20,17 @@
 <script>
 	window.buttonClicked = false;
 	window.ready = false;
+	window.connectedEvent = false;
 
 	require.config({
 		packages: [
 			{ name: '@dojo', location: '../../../../node_modules/@dojo' },
 			{ name: 'pepjs', location: '../../../../node_modules/pepjs/dist', main: 'pep' }
 		]
+	});
+
+	document.getElementById('testButton').addEventListener('connected', function() {
+		window.connectedEvent = true;
 	});
 
 	require(['./registerCustomElement'], function() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds an event `connected` that is emitted once a custom element has connected.

```js
myCustomElement.addEventListener('connected', function() {
    // do things once the element has connected
});

```

Resolves #754 
