### PR TITLE
Remove `Evented` and `Destroyable` from `WidgetBase`

### DIFF
--- a/src/NodeHandler.ts
+++ b/src/NodeHandler.ts
@@ -29,7 +29,7 @@ export class NodeHandler extends Evented implements NodeHandlerInterface {
 		this.emit({ type: key });
 	}
 
-	public addRoot(element: HTMLElement, key?: string): void {
+	public addRoot(): void {
 		this.emit({ type: NodeEventType.Widget });
 	}
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -108,14 +108,14 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 	public readonly nodeHandler: NodeHandler = new NodeHandler();
 
-	private _parentInvalidate: Function;
+	protected parentInvalidate: Function;
 
 	/**
 	 * @constructor
 	 */
 	constructor(invalidate?: Function) {
 		if (invalidate) {
-			this._parentInvalidate = invalidate;
+			this.parentInvalidate = invalidate;
 		}
 
 		this._children = [];
@@ -274,8 +274,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	public invalidate(): void {
 		if (this._renderState === WidgetRenderState.IDLE) {
 			this._dirty = true;
-			if (this._parentInvalidate) {
-				this._parentInvalidate();
+			if (this.parentInvalidate) {
+				this.parentInvalidate();
 			}
 		}
 		else if (this._renderState === WidgetRenderState.PROPERTIES) {

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -1,5 +1,4 @@
 import { EventTypedObject } from '@dojo/interfaces/core';
-import { Evented } from '@dojo/core/Evented';
 import Map from '@dojo/shim/Map';
 import WeakMap from '@dojo/shim/WeakMap';
 import { v } from './d';
@@ -53,7 +52,7 @@ const boundAuto = auto.bind(null);
 /**
  * Main widget base for all widgets to extend
  */
-export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends Evented implements WidgetBaseInterface<P, C> {
+export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implements WidgetBaseInterface<P, C> {
 
 	/**
 	 * static identifier
@@ -88,11 +87,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	private _cachedDNode: DNode | DNode[];
 
 	/**
-	 * map of specific property diff functions
-	 */
-	private _diffPropertyFunctionMap: Map<string, string>;
-
-	/**
 	 * map of decorators that are applied to this widget
 	 */
 	private _decoratorCache: Map<string, any[]>;
@@ -112,42 +106,27 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 
 	private _boundInvalidate: () => void;
 
-	private _nodeHandler: NodeHandler;
+	public readonly nodeHandler: NodeHandler = new NodeHandler();
+
+	private _parentInvalidate: Function;
 
 	/**
 	 * @constructor
 	 */
-	constructor() {
-		super({});
+	constructor(invalidate?: Function) {
+		if (invalidate) {
+			this._parentInvalidate = invalidate;
+		}
 
 		this._children = [];
 		this._decoratorCache = new Map<string, any[]>();
 		this._properties = <P> {};
-		this._diffPropertyFunctionMap = new Map<string, string>();
+		this.nodeHandler = new NodeHandler();
 		this._bindFunctionPropertyMap = new WeakMap<(...args: any[]) => any, { boundFunc: (...args: any[]) => any, scope: any }>();
 		this._registry = new RegistryHandler();
-		this._nodeHandler = new NodeHandler();
-		this.own(this._registry);
-		this.own(this._nodeHandler);
 		this._boundRenderFunc = this.render.bind(this);
 		this._boundInvalidate = this.invalidate.bind(this);
-		this.own(this.on({
-			'element-created': ({ key, element }: WidgetAndElementEvent) => {
-				this._nodeHandler.add(element, `${key}`);
-				this.onElementCreated(element, key);
-			},
-			'element-updated': ({ key, element }: WidgetAndElementEvent) => {
-				this._nodeHandler.add(element, `${key}`);
-				this.onElementUpdated(element, key);
-			},
-			'widget-created': ({ element }: WidgetAndElementEvent) => {
-				this._nodeHandler.addRoot(element, undefined);
-			},
-			'widget-updated': ({ element }: WidgetAndElementEvent) => {
-				this._nodeHandler.addRoot(element, undefined);
-			}
-		}));
-		this.own(this._registry.on('invalidate', this._boundInvalidate));
+		this._registry.on('invalidate', this._boundInvalidate);
 	}
 
 	protected meta<T extends WidgetMetaBase>(MetaType: WidgetMetaConstructor<T>): T {
@@ -155,11 +134,11 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 		if (!cached) {
 			cached = new MetaType({
 				invalidate: this._boundInvalidate,
-				nodeHandler: this._nodeHandler,
+				nodeHandler: this.nodeHandler,
 				bind: this
 			});
 			this._metaMap.set(MetaType, cached);
-			this.own(cached);
+			cached;
 		}
 
 		return cached as T;
@@ -171,7 +150,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	 * @param element The dom node represented by the vdom node.
 	 * @param key The vdom node's key.
 	 */
-	protected onElementCreated(element: Element, key: string): void {
+	public onElementCreated(element: Element, key: string): void {
 		// Do nothing by default.
 	}
 
@@ -181,7 +160,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	 * @param element The dom node represented by the vdom node.
 	 * @param key The vdom node's key.
 	 */
-	protected onElementUpdated(element: Element, key: string): void {
+	public onElementUpdated(element: Element, key: string): void {
 		// Do nothing by default.
 	}
 
@@ -286,7 +265,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			const render = this._runBeforeRenders();
 			let dNode = render();
 			this._cachedDNode = this.runAfterRenders(dNode);
-			this._nodeHandler.clear();
+			this.nodeHandler.clear();
 		}
 		this._renderState = WidgetRenderState.IDLE;
 		return this._cachedDNode;
@@ -295,10 +274,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 	public invalidate(): void {
 		if (this._renderState === WidgetRenderState.IDLE) {
 			this._dirty = true;
-			this.emit({
-				type: 'invalidated',
-				target: this
-			});
+			if (this._parentInvalidate) {
+				this._parentInvalidate();
+			}
 		}
 		else if (this._renderState === WidgetRenderState.PROPERTIES) {
 			this._dirty = true;
@@ -476,7 +454,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> extends E
 			}, dNode);
 		}
 
-		this._metaMap.forEach(meta => {
+		this._metaMap.forEach((meta) => {
 			meta.afterRender();
 		});
 

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -53,7 +53,7 @@ export function inject({ name, getProperties }: InjectConfig) {
 				}
 				if (registeredInjectors.indexOf(injector) === -1) {
 					injector.on('invalidate', () => {
-						this.emit({ type: 'invalidated', target: this });
+						this.invalidate();
 					});
 					registeredInjectors.push(injector);
 				}

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -397,7 +397,7 @@ export interface DefaultWidgetBaseInterface extends WidgetBaseInterface<WidgetPr
  */
 export interface WidgetBaseInterface<
 	P = WidgetProperties,
-	C extends DNode = DNode> extends Evented {
+	C extends DNode = DNode> {
 
 	/**
 	 * Widget properties

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -79,16 +79,11 @@ export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & 
 
 		constructor(...args: any[]) {
 			super(...args);
-			const subscription = observeLocale({
+			observeLocale({
 				next: () => {
 					if (!this.properties.locale) {
 						this.invalidate();
 					}
-				}
-			});
-			this.own({
-				destroy() {
-					subscription.unsubscribe();
 				}
 			});
 		}

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -163,6 +163,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		constructor(...args: any[]) {
 			super(...args);
 
+			this.parentInvalidate = this.scheduleRender.bind(this);
 			this._projectionOptions = {
 				transitions: cssTransitions
 			};
@@ -171,11 +172,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			this._boundRender = this.__render__.bind(this);
 			this.root = document.body;
 			this.projectorState = ProjectorAttachState.Detached;
-		}
-
-		public invalidate() {
-			super.invalidate();
-			this.scheduleRender();
 		}
 
 		public append(root?: Element): Handle  {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -2,7 +2,6 @@ import { assign } from '@dojo/core/lang';
 import global from '@dojo/shim/global';
 import { createHandle } from '@dojo/core/lang';
 import { Handle } from '@dojo/interfaces/core';
-import { Evented } from '@dojo/core/Evented';
 import 'pepjs';
 import cssTransitions from '../animations/cssTransitions';
 import { Constructor, DNode, Projection, ProjectionOptions } from './../interfaces';
@@ -87,7 +86,7 @@ export interface ProjectorMixin<P> {
 	 * The `Projector` creates a `DocumentFragment` which replaces any other `root` that has been set.
 	 * @param doc The `Document` to use, which defaults to the global `document`.
 	 */
-	sandbox(doc?: Document): Handle;
+	sandbox(doc?: Document): void;
 
 	/**
 	 * Schedule a render.
@@ -133,6 +132,11 @@ export interface ProjectorMixin<P> {
 	 * Exposes invalidate for projector instances
 	 */
 	invalidate(): void;
+
+	/**
+	 * Runs registered destroy handles
+	 */
+	destroy(): void;
 }
 
 export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T): T & Constructor<ProjectorMixin<P>> {
@@ -154,12 +158,10 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		private _projectorProperties: this['properties'] = {} as this['properties'];
 		private _rootTagName: string;
 		private _attachType: AttachType;
+		private _handles: Function[] = [];
 
 		constructor(...args: any[]) {
 			super(...args);
-
-			const nodeEvent = new Evented();
-			this.own(nodeEvent);
 
 			this._projectionOptions = {
 				transitions: cssTransitions
@@ -167,15 +169,16 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this._boundDoRender = this._doRender.bind(this);
 			this._boundRender = this.__render__.bind(this);
-			this.own(this.on('invalidated', () => {
-				this.scheduleRender();
-			}));
-
 			this.root = document.body;
 			this.projectorState = ProjectorAttachState.Detached;
 		}
 
-		public append(root?: Element) {
+		public invalidate() {
+			super.invalidate();
+			this.scheduleRender();
+		}
+
+		public append(root?: Element): Handle  {
 			const options = {
 				type: AttachType.Append,
 				root
@@ -184,7 +187,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			return this._attach(options);
 		}
 
-		public merge(root?: Element) {
+		public merge(root?: Element): Handle {
 			const options = {
 				type: AttachType.Merge,
 				root
@@ -193,7 +196,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			return this._attach(options);
 		}
 
-		public replace(root?: Element) {
+		public replace(root?: Element): Handle  {
 			const options = {
 				type: AttachType.Replace,
 				root
@@ -252,7 +255,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			this._async = async;
 		}
 
-		public sandbox(doc: Document = document): Handle {
+		public sandbox(doc: Document = document): void {
 			if (this.projectorState === ProjectorAttachState.Attached) {
 				throw new Error('Projector already attached, cannot create sandbox');
 			}
@@ -260,10 +263,11 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			const previousRoot = this.root;
 
 			/* free up the document fragment for GC */
-			this.own(createHandle(() => {
+			this.own(() => {
 				this._root = previousRoot;
-			}));
-			return this._attach({
+			});
+
+			this._attach({
 				/* DocumentFragment is not assignable to Element, but provides everything needed to work */
 				root: doc.createDocumentFragment() as any,
 				type: AttachType.Append
@@ -289,9 +293,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			if (this._projectorProperties && this._projectorProperties.registry !== properties.registry) {
 				if (this._projectorProperties.registry) {
 					this._projectorProperties.registry.destroy();
-				}
-				if (properties.registry) {
-					this.own(properties.registry);
 				}
 			}
 			this._projectorProperties = assign({}, properties);
@@ -324,6 +325,19 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			}
 		}
 
+		private own(handle: Function): void {
+			this._handles.push(handle);
+		}
+
+		public destroy() {
+			while (this._handles.length > 0) {
+				const handle = this._handles.pop();
+				if (handle) {
+					handle();
+				}
+			}
+		}
+
 		private _attach({ type, root }: AttachOptions): Handle {
 			this._attachType = type;
 			if (root) {
@@ -336,16 +350,16 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this.projectorState = ProjectorAttachState.Attached;
 
-			this._attachHandle = this.own({
-				destroy: () => {
-					if (this.projectorState === ProjectorAttachState.Attached) {
-						this.pause();
-						this._projection = undefined;
-						this.projectorState = ProjectorAttachState.Detached;
-					}
-					this._attachHandle = { destroy() { } };
+			const handle = () => {
+				if (this.projectorState === ProjectorAttachState.Attached) {
+					this.pause();
+					this._projection = undefined;
+					this.projectorState = ProjectorAttachState.Detached;
 				}
-			});
+			};
+
+			this.own(handle);
+			this._attachHandle = createHandle(handle);
 
 			this._projectionOptions = { ...this._projectionOptions, ...{ sync: !this._async } };
 

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -20,7 +20,7 @@ export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): D
 			return hNode;
 		}
 
-		protected onElementCreated(element: Element, key: string) {
+		public onElementCreated(element: Element, key: string) {
 			options.onAttached && options.onAttached();
 		}
 

--- a/tests/unit/NodeHandler.ts
+++ b/tests/unit/NodeHandler.ts
@@ -53,13 +53,13 @@ registerSuite('NodeHandler', {
 					assert.isTrue(projectorStub.notCalled);
 				},
 				'add root emits Widget'() {
-					nodeHandler.addRoot(element, 'foo');
+					nodeHandler.addRoot();
 
 					assert.isTrue(widgetStub.calledOnce);
 					assert.isTrue(projectorStub.notCalled);
 				},
 				'add root without a key emits Widget event only'() {
-					nodeHandler.addRoot(element);
+					nodeHandler.addRoot();
 
 					assert.isTrue(widgetStub.calledOnce);
 					assert.isTrue(elementStub.notCalled);

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -277,21 +277,21 @@ describe('WidgetBase', () => {
 		});
 
 		it('elements are added to node handler on create', () => {
-			const element = {};
+			const element = {} as any;
 			const key = '1';
 			const widget = new BaseTestWidget();
 			const meta = widget.meta(TestMeta);
-			widget.emit({ type: 'element-created', element, key });
+			widget.nodeHandler.add(element, key);
 			assert.isTrue(meta.has(key));
 			assert.strictEqual(meta.get(key), element);
 		});
 
 		it('elements are added to node handler on update', () => {
-			const element = {};
+			const element = {} as any;
 			const key = '1';
 			const widget = new BaseTestWidget();
 			const meta = widget.meta(TestMeta);
-			widget.emit({ type: 'element-updated', element, key });
+			widget.nodeHandler.add(element, key);
 			assert.isTrue(meta.has(key));
 			assert.strictEqual(meta.get(key), element);
 		});
@@ -300,7 +300,7 @@ describe('WidgetBase', () => {
 			const widget = new BaseTestWidget();
 			const meta = widget.meta(TestMeta);
 
-			widget.emit({ type: 'widget-created' });
+			widget.nodeHandler.addRoot();
 			assert.isTrue(meta.widgetEvent);
 		});
 
@@ -308,31 +308,9 @@ describe('WidgetBase', () => {
 			const widget = new BaseTestWidget();
 			const meta = widget.meta(TestMeta);
 
-			widget.emit({ type: 'widget-updated' });
+			widget.nodeHandler.addRoot();
 			assert.isTrue(meta.widgetEvent);
 		});
-	});
-
-	describe('onElementCreated called on `element-created` event', () => {
-		class TestWidget extends BaseTestWidget {
-			onElementCreated(element: any, key: any) {
-				assert.strictEqual(element, 'element');
-				assert.strictEqual(key, 'key');
-			}
-		}
-		const widget = new TestWidget();
-		widget.emit({ type: 'element-created', key: 'key', element: 'element' });
-	});
-
-	describe('onElementUpdated called on `element-updated` event', () => {
-		class TestWidget extends BaseTestWidget {
-			onElementUpdated(element: any, key: any) {
-				assert.strictEqual(element, 'element');
-				assert.strictEqual(key, 'key');
-			}
-		}
-		const widget = new TestWidget();
-		widget.emit({ type: 'element-updated', key: 'key', element: 'element' });
 	});
 
 	describe('decorators', () => {

--- a/tests/unit/decorators/inject.ts
+++ b/tests/unit/decorators/inject.ts
@@ -51,23 +51,6 @@ registerSuite('decorators/inject', {
 			assert.strictEqual(widget.properties.foo, 'bar');
 			assert.strictEqual(widget.properties.bar, 'foo');
 		},
-		'payload are only attached once'() {
-			let invalidateCount = 0;
-			function getProperties(payload: any, properties: WidgetProperties): WidgetProperties {
-				return payload;
-			}
-
-			@inject({ name: 'inject-one', getProperties })
-			class TestWidget extends WidgetBase<any> {}
-			const widget = new TestWidget();
-			widget.__setCoreProperties__({ bind: widget, baseRegistry: registry });
-			widget.__setProperties__({});
-			widget.on('invalidated', () => {
-				invalidateCount++;
-			});
-			injectorOne.set({});
-			assert.strictEqual(invalidateCount, 1);
-		},
 		'programmatic registration'() {
 			function getPropertiesOne(payload: any, properties: WidgetProperties): WidgetProperties {
 				return payload;

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -54,7 +54,6 @@ registerSuite('support/meta/Drag', {
 			assert.strictEqual((div.firstChild as HTMLElement).getAttribute('touch-action'), 'none', 'Should have set touch-action attribute to none');
 			assert.strictEqual((div.firstChild as HTMLElement).style.touchAction, 'none', 'Should have set touch-action type to none');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -83,7 +82,6 @@ registerSuite('support/meta/Drag', {
 
 			assert.deepEqual(dragResults, [ emptyResults, emptyResults ], 'should have been called twice, both empty results');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -182,7 +180,6 @@ registerSuite('support/meta/Drag', {
 				}
 			], 'the stack of should represent a drag state');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -309,7 +306,6 @@ registerSuite('support/meta/Drag', {
 				}
 			], 'the stack of should represent a drag state');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -430,7 +426,6 @@ registerSuite('support/meta/Drag', {
 				}
 			], 'the stack of should represent a drag state');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -498,7 +493,6 @@ registerSuite('support/meta/Drag', {
 				emptyResults
 			], 'the widget does not invalidate on ignored events');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -601,7 +595,6 @@ registerSuite('support/meta/Drag', {
 				}
 			], 'dragging should be attributed to parent node');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -695,7 +688,6 @@ registerSuite('support/meta/Drag', {
 				emptyResults
 			], 'there should be no drag results');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -781,7 +773,6 @@ registerSuite('support/meta/Drag', {
 				emptyResults
 			], 'the stack of should represent a drag state');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -893,7 +884,6 @@ registerSuite('support/meta/Drag', {
 				}
 			], 'the stack of should represent a drag state');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -999,7 +989,6 @@ registerSuite('support/meta/Drag', {
 				}
 			], 'the stack of should represent a drag state');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		}
 	}

--- a/tests/unit/meta/Matches.ts
+++ b/tests/unit/meta/Matches.ts
@@ -54,7 +54,6 @@ registerSuite('support/meta/Matches', {
 
 			assert.deepEqual(results, [ true ], 'should have been called and the target matched');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -89,7 +88,6 @@ registerSuite('support/meta/Matches', {
 
 			assert.deepEqual(results, [ true ], 'should have been called and the target matched');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -132,7 +130,6 @@ registerSuite('support/meta/Matches', {
 
 			assert.deepEqual(results, [ false ], 'should have been called and the target not matching');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		},
 
@@ -187,7 +184,6 @@ registerSuite('support/meta/Matches', {
 
 			assert.deepEqual(results, [ true, false, false, true ], 'should have been called twice and keys changed');
 
-			widget.destroy();
 			document.body.removeChild(div);
 		}
 	}

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -24,7 +24,6 @@ registerSuite('mixins/I18nMixin', {
 		switchLocale(systemLocale);
 
 		if (localized) {
-			localized.destroy();
 			localized = <any> null;
 		}
 	},

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -8,7 +8,6 @@ import { v } from '../../../src/d';
 import { ProjectorMixin, ProjectorAttachState } from '../../../src/mixins/Projector';
 import { WidgetBase } from '../../../src/WidgetBase';
 import { beforeRender } from './../../../src/decorators/beforeRender';
-import { Registry } from './../../../src/Registry';
 import { HNode } from './../../../src/interfaces';
 
 const Event = global.window.Event;
@@ -351,25 +350,6 @@ registerSuite('mixins/projectorMixin', {
 			// Demonstrates the type guarding for widget properties
 
 			// projector.setProperties({ foo: true });
-		},
-		'registry destroyed when a new registry is received'() {
-			let registryDestroyedCount = 0;
-			class TestRegistry extends Registry {
-				destroy(): Promise<any> {
-					registryDestroyedCount++;
-					return super.destroy();
-				}
-			}
-			const projector = new BaseTestWidget();
-			projector.setProperties({ registry: new TestRegistry() });
-			assert.strictEqual(registryDestroyedCount, 0);
-			projector.setProperties({ registry: new TestRegistry() });
-			assert.strictEqual(registryDestroyedCount, 1);
-			projector.setProperties({ registry: undefined });
-			assert.strictEqual(registryDestroyedCount, 2);
-			projector.setProperties({ registry: new TestRegistry() });
-			projector.destroy();
-			assert.strictEqual(registryDestroyedCount, 3);
 		},
 		'properties are reset to original state on render'() {
 			const testProperties = {

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -19,7 +19,7 @@ registerSuite('DomWrapper', {
 
 	afterEach() {
 		resolvers.restore();
-		projector && projector.destroy();
+		projector = undefined;
 	},
 
 	tests: {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes `Evented` and `Destroyable` from `WidgetBase`, `WidgetBase` has been updated to accept an optional `invalidate` method in the `constructor` that will be called to propagate invalidation up the widget tree.

*Performance Comparison against master:*

<img width="881" alt="interactive_results" src="https://user-images.githubusercontent.com/1982678/32608983-fcb431b4-c555-11e7-9e17-bcfbf304e0ec.png">

*Memory Usage against master:*

<img width="540" alt="interactive_results_and_inbox__3__-_agubler_gmail_com_-_gmail" src="https://user-images.githubusercontent.com/1982678/32609023-1a7608ee-c556-11e7-9be7-b06f8a849c79.png">

Related to: #760 
