### PR TITLE
Invalidator Fixes: Inject invalidator via setter and reset renderState in scheduleRender

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -135,7 +135,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			this._parentInvalidator = invalidator;
 		}
 		else {
-			console.warn('Unable to update parent invalidator after if has been initially set');
+			console.warn('Unable to update parent invalidator after it has been set');
 		}
 	}
 

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -113,16 +113,12 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 	public readonly nodeHandler: NodeHandler = new NodeHandler();
 
-	protected parentInvalidate: Function;
+	private _parentInvalidator: Function;
 
 	/**
 	 * @constructor
 	 */
-	constructor(invalidate?: Function) {
-		if (invalidate) {
-			this.parentInvalidate = invalidate;
-		}
-
+	constructor() {
 		this._children = [];
 		this._decoratorCache = new Map<string, any[]>();
 		this._properties = <P> {};
@@ -132,6 +128,15 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		this._boundRenderFunc = this.render.bind(this);
 		this._boundInvalidate = this.invalidate.bind(this);
 		this._registry.on('invalidate', this._boundInvalidate);
+	}
+
+	public set parentInvalidator(invalidator: Function) {
+		if (this._parentInvalidator === undefined) {
+			this._parentInvalidator = invalidator;
+		}
+		else {
+			console.warn('Unable to update parent invalidator after if has been initially set');
+		}
 	}
 
 	protected meta<T extends WidgetMetaBase>(MetaType: WidgetMetaConstructor<T>): T {
@@ -197,14 +202,13 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		const registeredDiffPropertyNames = this.getDecorator('registeredDiffProperty');
 		const changedPropertyKeys: string[] = [];
 		const propertyNames = Object.keys(properties);
+		this._renderState = WidgetRenderState.PROPERTIES;
 
 		if (this._initialProperties === false || registeredDiffPropertyNames.length !== 0) {
 			const allProperties = [ ...propertyNames, ...Object.keys(this._properties) ];
 			const checkedProperties: string[] = [];
 			const diffPropertyResults: any = {};
 			let runReactions = false;
-
-			this._renderState = WidgetRenderState.PROPERTIES;
 
 			for (let i = 0; i < allProperties.length; i++) {
 				const propertyName = allProperties[i];
@@ -296,8 +300,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	public invalidate(): void {
 		if (this._renderState === WidgetRenderState.IDLE) {
 			this._dirty = true;
-			if (this.parentInvalidate) {
-				this.parentInvalidate();
+			if (this._parentInvalidator) {
+				this._parentInvalidator();
 			}
 		}
 		else if (this._renderState === WidgetRenderState.PROPERTIES) {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -163,7 +163,9 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		constructor(...args: any[]) {
 			super(...args);
 
-			this.parentInvalidator = this.scheduleRender.bind(this);
+			this.parentInvalidator = () => {
+				this.scheduleRender();
+			};
 			this._projectionOptions = {
 				transitions: cssTransitions
 			};
@@ -218,6 +220,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			if (this.projectorState === ProjectorAttachState.Attached) {
 				this.__setProperties__(this._projectorProperties);
 				this.__setChildren__(this._projectorChildren);
+				(this as any)._renderState = 1;
 				if (!this._scheduled && !this._paused) {
 					if (this._async) {
 						this._scheduled = global.requestAnimationFrame(this._boundDoRender);

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -163,7 +163,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		constructor(...args: any[]) {
 			super(...args);
 
-			this.parentInvalidate = this.scheduleRender.bind(this);
+			this.parentInvalidator = this.scheduleRender.bind(this);
 			this._projectionOptions = {
 				transitions: cssTransitions
 			};

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -665,8 +665,9 @@ function createDom(
 			}
 			widgetConstructor = item;
 		}
-		const instance = new widgetConstructor(parentInstance.invalidate.bind(parentInstance));
+		const instance = new widgetConstructor();
 		dnode.instance = instance;
+		instance.parentInvalidator = parentInstance.invalidate.bind(parentInstance);
 		instance.__setCoreProperties__(dnode.coreProperties);
 		instance.__setChildren__(dnode.children);
 		instance.__setProperties__(dnode.properties);

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -230,6 +230,18 @@ registerSuite('mixins/projectorMixin', {
 			projector.root = root;
 			assert.equal(projector.root, root);
 		},
+		'scheduleRender'() {
+			rafStub.restore();
+			rafStub = stub(global, 'requestAnimationFrame').returns(1);
+			const projector = new BaseTestWidget();
+			const scheduleRenderStub = spy(projector, 'scheduleRender');
+			projector.append();
+			assert.isTrue(scheduleRenderStub.notCalled);
+			projector.invalidate();
+			assert.isTrue(scheduleRenderStub.calledOnce);
+			projector.invalidate();
+			assert.isTrue(scheduleRenderStub.calledTwice);
+		},
 		'pause'() {
 			const projector = new BaseTestWidget();
 

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -456,8 +456,8 @@ describe('vdom', () => {
 
 				private myClass = false;
 
-				constructor(invalidate: Function) {
-					super(invalidate);
+				constructor() {
+					super();
 					fooInvalidate = this.invalidate.bind(this);
 				}
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Having an optional constructor argument for the parent invalidate function is unintuitive and horrible for end users needing to know that they have to pass the arguments on when anything is done in a widget constructor. Moves the injection of the parent invalidate function to a public setter that can only be set once.

The `WidgetBase` render state needs to be reset after running `__setProperties__()` and `__setChildren__()` in `Projector#scheduleRender()`

Related to #745 
