### PR TITLE
Custom element wrapper

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -110,7 +110,7 @@ export interface CustomElementDescriptor {
 	initialization?: CustomElementInitializer;
 
 	/**
-	 *
+	 * The type of children that the custom element accepts
 	 */
 	childrenType?: ChildrenType;
 }
@@ -132,10 +132,21 @@ export interface CustomElement extends HTMLElement {
 	setWidgetInstance(instance: ProjectorMixin<any>): void;
 }
 
+/**
+ * Properties for DomToWidgetWrapper
+ */
 export type DomToWidgetWrapperProperties = VirtualDomProperties & WidgetProperties;
 
+/**
+ * DomToWidgetWrapper type
+ */
 export type DomToWidgetWrapper = Constructor<WidgetBase<DomToWidgetWrapperProperties>>;
 
+/**
+ * DomToWidgetWrapper HOC
+ *
+ * @param domNode The dom node to wrap
+ */
 export function DomToWidgetWrapper(domNode: CustomElement): DomToWidgetWrapper {
 
 	return class DomToWidgetWrapper extends WidgetBase<DomToWidgetWrapperProperties> {

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -12,7 +12,7 @@ export type DomWrapperProperties = VirtualDomProperties & WidgetProperties;
 export type DomWrapper = Constructor<WidgetBase<DomWrapperProperties>>;
 
 export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): DomWrapper {
-	return class extends WidgetBase<DomWrapperProperties> {
+	return class DomWrapper extends WidgetBase<DomWrapperProperties> {
 
 		public __render__(): HNode {
 			const hNode = super.__render__() as InternalHNode;

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -297,7 +297,8 @@ registerSuite('customElements', {
 			});
 			element.children = [ {
 				key: 'test',
-				parentNode: element
+				parentNode: element,
+				addEventListener() {}
 			} ];
 
 			initializeElement(element)();

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -1,12 +1,14 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import { initializeElement, handleAttributeChanged, CustomElementDescriptor } from '../../src/customElements';
+import { ChildrenType, initializeElement, DomToWidgetWrapper, handleAttributeChanged, CustomElementDescriptor } from '../../src/customElements';
 import { WidgetBase } from '../../src/WidgetBase';
 import global from '@dojo/shim/global';
 import { assign } from '@dojo/core/lang';
 import * as projector from '../../src/mixins/Projector';
 import * as sinon from 'sinon';
+import sendEvent from './../support/sendEvent';
 import { v } from '../../src/d';
+import { InternalHNode } from '../../src/vdom';
 import { Constructor } from '../../src/interfaces';
 import ProjectorMixin from '../../src/mixins/Projector';
 
@@ -290,7 +292,32 @@ registerSuite('customElements', {
 	},
 
 	'children': {
-		'children get wrapped in dom wrappers'() {
+		'element children get wrapped in DomWrapper'() {
+			if (!(WidgetBase as any).name) {
+				this.skip();
+			}
+			let element = createFakeElement({}, {
+				tagName: 'test',
+				widgetConstructor: WidgetBase,
+				childrenType: ChildrenType.ELEMENT
+			});
+			element.children = [ {
+				key: 'test',
+				parentNode: element,
+				addEventListener() {}
+			} ];
+
+			initializeElement(element)();
+
+			assert.lengthOf(element.removedChildren(), 1);
+			assert.lengthOf(element.getWidgetInstance().children, 1);
+			assert.strictEqual(element.getWidgetInstance().children[0].widgetConstructor.name, 'DomWrapper');
+		},
+
+		'widget children get wrapped in DomToWidgetWrapper'() {
+			if (!(WidgetBase as any).name) {
+				this.skip();
+			}
 			let element = createFakeElement({}, {
 				tagName: 'test',
 				widgetConstructor: WidgetBase
@@ -305,7 +332,31 @@ registerSuite('customElements', {
 
 			assert.lengthOf(element.removedChildren(), 1);
 			assert.lengthOf(element.getWidgetInstance().children, 1);
+			assert.strictEqual(element.getWidgetInstance().children[0].widgetConstructor.name, 'DomToWidgetWrapper');
 		}
+	},
+
+	DomToWidgetWrapper() {
+		const widgetInstance = new (projector.ProjectorMixin(WidgetBase))();
+		const div: any = document.createElement('div');
+		div.getWidgetInstance = () => {
+			return widgetInstance;
+		};
+		const Wrapper = DomToWidgetWrapper(div);
+		const widget = new Wrapper();
+		widget.__setProperties__({ foo: 'bar' });
+		const invalidateSpy = sinon.spy(widget, 'invalidate');
+		const renderResult = widget.__render__() as InternalHNode;
+		assert.strictEqual(renderResult.tag, 'DIV');
+		assert.strictEqual(renderResult.domNode, div);
+		assert.deepEqual(renderResult.properties, { });
+		assert.deepEqual(widget.properties, { foo: 'bar' });
+		assert.deepEqual(widgetInstance.properties, { });
+		assert.isTrue(invalidateSpy.notCalled);
+		sendEvent(div, 'connected');
+		assert.isTrue(invalidateSpy.calledOnce);
+		widget.__render__() as InternalHNode;
+		assert.deepEqual(widgetInstance.properties, { key: 'root', foo: 'bar' });
 	},
 
 	'initialization': {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

For custom elements that are written to deal with Dojo 2 custom element children only, add support for widget-core to treat them as widgets meaning that they can be authored without needing to add specific code to deal with custom elements. 

**Enabling usage as follows:**

Using as a Dojo Widget:

```ts
class Example extends WidgetBase {

  private _onSelected(data: any) {
    console.log(data);
  }

  protected render() {
    return w(Menu, { onSelected: this._onSelected }, [
      w(MenuItem, { key: 'a', title: 'Menu Item A' }),
      w(MenuItem, { key: 'b', title: 'Menu Item B', selected: true }),
      w(MenuItem, { key: 'c', title: 'Menu Item C' })
    ]);
  }
}
```

Using as a Custom Element:

```html
<demo-menu id="menu">
  <demo-menu-item id="a" title="Menu Item A"></demo-menu-item>
  <demo-menu-item id="b" title="Menu Item B"></demo-menu-item>
  <demo-menu-item id="c" title="Menu Item C" selected></demo-menu-item>
</demo-menu>
<script>
  a.data = { foo: 'bar' };
  menu.addEventListener('selected', function(event) {
    const detail = event.detail;
    console.log(detail);
  });
</script>
```