### PR TITLE
Instance WeakMap for widgets in vdom

### DIFF
--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -9,7 +9,7 @@ import { WidgetBase } from './../WidgetBase';
 import { afterRender } from './../decorators/afterRender';
 import { v } from './../d';
 import { Registry } from './../Registry';
-import { dom } from './../vdom';
+import { dom, widgetInstanceMap } from './../vdom';
 
 /**
  * Represents the attach state of the projector
@@ -163,7 +163,9 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		constructor(...args: any[]) {
 			super(...args);
 
-			this.parentInvalidator = () => {
+			const instanceData = widgetInstanceMap.get(this)!;
+
+			instanceData.parentInvalidate = () => {
 				this.scheduleRender();
 			};
 			this._projectionOptions = {

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -20,7 +20,7 @@ export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): D
 			return hNode;
 		}
 
-		public onElementCreated(element: Element, key: string) {
+		protected onElementCreated(element: Element, key: string) {
 			options.onAttached && options.onAttached();
 		}
 

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -4,7 +4,7 @@ import { match, spy, stub, SinonStub } from 'sinon';
 import { createResolvers } from './../support/util';
 import sendEvent from './../support/sendEvent';
 
-import { dom, InternalHNode, InternalWNode } from '../../src/vdom';
+import { dom, InternalHNode, InternalWNode, widgetInstanceMap } from '../../src/vdom';
 import { v, w } from '../../src/d';
 import { HNode } from '../../src/interfaces';
 import { WidgetBase } from '../../src/WidgetBase';
@@ -22,6 +22,8 @@ const projectorStub: any = {
 	onElementCreated: stub(),
 	onElementUpdated: stub()
 };
+
+widgetInstanceMap.set(projectorStub, projectorStub);
 
 class MainBar extends WidgetBase<any> {
 	render() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

An instance `WeakMap` to vdom to share private/protected properties between widget instances and the vdom mechanism. Removes the need to publicly expose methods and properties from the instance just because they are required to process instances during the render process.

The next stage would be to remove all the existing double underscrore'd methods (for example `__setProperties__`) and reference them from the instance map. This will clean the WidgetBase API to simply `properties` and `children`
