### PR TITLE
Add `onAttach` and `onDetach` lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ class MyClass extends WidgetBase {
 
 #### onDetach
 
-`onDetach` is called when a widget is removed from the render tree and therefore the DOM. `onDetach` is called recursively down the widget tree to ensure that even if a widget at the top of the tree is removed all the child widgets `onDetach` callbacks are fired.
+`onDetach` is called when a widget is removed from the widget tree and therefore the DOM. `onDetach` is called recursively down the tree to ensure that even if a widget at the top of the tree is removed all the child widgets `onDetach` callbacks are fired.
 
 ```ts
 class MyClass extends WidgetBase {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ widget-core is a library to create powerful, composable user interface widgets.
 - [Advanced Concepts](#advanced-concepts)
     - [Advanced Properties](#advanced-properties)
     - [Registry](#registry)
-    - [Render Lifecycle Hooks](#render-lifecycle-hooks)
+    - [Decorator Lifecycle Hooks](#decorator-lifecycle-hooks)
+    - [Method Lifecycle Hooks](#method-lifecycle-hooks)
     - [Containers](#containers--injectors)
     - [Decorators](#decorators)
     - [DOM Wrapper](#domwrapper)
@@ -708,7 +709,7 @@ class MyWidget extends WidgetBase {
 }
 ```
 
-### Lifecycle Hooks
+### Decorator Lifecycle Hooks
 
 Occasionally, in a mixin or a widget class, it my be required to provide logic that needs to be executed before properties are diffed using `beforeProperties` or either side of a widget's `render` call using `beforeRender` & `afterRender`.
 
@@ -768,6 +769,34 @@ class MyBaseClass extends WidgetBase<WidgetProperties> {
     myAfterRender(result: DNode): DNode {
         // do something with the result
         return result;
+    }
+}
+```
+
+### Method Lifecycle Hooks
+
+Method lifecycle hooks are used by overriding methods in a widget class. Currently `onAttach` and `onDetach` are supported that provide callbacks for when a widget has been first attached and then it has subsequently been removed (destroyed) from the virtual dom.
+
+#### onAttach
+
+On attach is called once when a widget is first rendered and attached to the DOM.
+
+```ts
+class MyClass extends WidgetBase {
+    onAttach() {
+        // do things when attached to the DOM
+    }
+}
+```
+
+#### onDetach
+
+On detach is called when a widget is removed from the render tree and therefore the DOM. This is called recurvively down the widget tree to ensure that even when a widget at the top of the tree is removed all children widgets `onDetach` callbacks are also fired.
+
+```ts
+class MyClass extends WidgetBase {
+    onDetach() {
+        // do things when removed to the DOM
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -775,11 +775,11 @@ class MyBaseClass extends WidgetBase<WidgetProperties> {
 
 ### Method Lifecycle Hooks
 
-Method lifecycle hooks are used by overriding methods in a widget class. Currently `onAttach` and `onDetach` are supported that provide callbacks for when a widget has been first attached and then it has subsequently been removed (destroyed) from the virtual dom.
+These lifecycle hooks are used by overriding methods in a widget class. Currently `onAttach` and `onDetach` are supported and provide callbacks for when a widget has been first attached and removed (destroyed) from the virtual dom.
 
 #### onAttach
 
-On attach is called once when a widget is first rendered and attached to the DOM.
+`onAttach` is called once when a widget is first rendered and attached to the DOM.
 
 ```ts
 class MyClass extends WidgetBase {
@@ -791,12 +791,12 @@ class MyClass extends WidgetBase {
 
 #### onDetach
 
-On detach is called when a widget is removed from the render tree and therefore the DOM. This is called recurvively down the widget tree to ensure that even when a widget at the top of the tree is removed all children widgets `onDetach` callbacks are also fired.
+`onDetach` is called when a widget is removed from the render tree and therefore the DOM. `onDetach` is called recursively down the widget tree to ensure that even if a widget at the top of the tree is removed all the child widgets `onDetach` callbacks are fired.
 
 ```ts
 class MyClass extends WidgetBase {
     onDetach() {
-        // do things when removed to the DOM
+        // do things when removed from the DOM
     }
 }
 ```

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -122,6 +122,12 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			onElementUpdated: (element: HTMLElement, key: string) => {
 				this.onElementUpdated(element, key);
 			},
+			onAttach: (): void => {
+				this.onAttach();
+			},
+			onDetach: (): void => {
+				this.onDetach();
+			},
 			nodeHandler: this._nodeHandler,
 			registry: () => {
 				return this.registry;
@@ -166,6 +172,14 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	 * @param key The vdom node's key.
 	 */
 	protected onElementUpdated(element: Element, key: string): void {
+		// Do nothing by default.
+	}
+
+	protected onAttach(): void {
+		// Do nothing by default.
+	}
+
+	protected onDetach(): void {
 		// Do nothing by default.
 	}
 

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -492,9 +492,6 @@ function nodeToRemove(
 	projectionOptions: ProjectionOptions,
 	parentInstance: DefaultWidgetBaseInterface
 ) {
-	projectionOptions.afterRenderCallbacks.push(() => {
-		callOnDetach(dnode, parentInstance);
-	});
 	if (isWNode(dnode)) {
 		const rendered = dnode.rendered || emptyArray;
 		for (let i = 0; i < rendered.length; i++) {
@@ -596,7 +593,11 @@ function updateChildren(
 			const findOldIndex = findIndexOfChild(oldChildren, newChild, oldIndex + 1);
 			if (findOldIndex >= 0) {
 				for (i = oldIndex; i < findOldIndex; i++) {
-					nodeToRemove(oldChildren[i], transitions, projectionOptions, parentInstance);
+					const oldChild = oldChildren[i];
+					projectionOptions.afterRenderCallbacks.push(() => {
+						callOnDetach(oldChild, parentInstance);
+					});
+					nodeToRemove(oldChild, transitions, projectionOptions, parentInstance);
 					checkDistinguishable(oldChildren, i, domNode, 'removed');
 				}
 				textUpdated = updateDom(oldChildren[findOldIndex], newChild, projectionOptions, domNode, parentInstance) || textUpdated;
@@ -626,7 +627,11 @@ function updateChildren(
 	if (oldChildrenLength > oldIndex) {
 		// Remove child fragments
 		for (i = oldIndex; i < oldChildrenLength; i++) {
-			nodeToRemove(oldChildren[i], transitions, projectionOptions, parentInstance);
+			const oldChild = oldChildren[i];
+			projectionOptions.afterRenderCallbacks.push(() => {
+				callOnDetach(oldChild, parentInstance);
+			});
+			nodeToRemove(oldChild, transitions, projectionOptions, parentInstance);
 			checkDistinguishable(oldChildren, i, domNode, 'removed');
 		}
 	}

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -486,12 +486,7 @@ function callOnDetach(dNodes: InternalDNode | InternalDNode[], parentInstance: D
 	}
 }
 
-function nodeToRemove(
-	dnode: InternalDNode,
-	transitions: TransitionStrategy,
-	projectionOptions: ProjectionOptions,
-	parentInstance: DefaultWidgetBaseInterface
-) {
+function nodeToRemove(dnode: InternalDNode, transitions: TransitionStrategy, projectionOptions: ProjectionOptions) {
 	if (isWNode(dnode)) {
 		const rendered = dnode.rendered || emptyArray;
 		for (let i = 0; i < rendered.length; i++) {
@@ -500,7 +495,7 @@ function nodeToRemove(
 				child.domNode!.parentNode!.removeChild(child.domNode!);
 			}
 			else {
-				nodeToRemove(child, transitions, projectionOptions, parentInstance);
+				nodeToRemove(child, transitions, projectionOptions);
 			}
 		}
 	}
@@ -597,7 +592,7 @@ function updateChildren(
 					projectionOptions.afterRenderCallbacks.push(() => {
 						callOnDetach(oldChild, parentInstance);
 					});
-					nodeToRemove(oldChild, transitions, projectionOptions, parentInstance);
+					nodeToRemove(oldChild, transitions, projectionOptions);
 					checkDistinguishable(oldChildren, i, domNode, 'removed');
 				}
 				textUpdated = updateDom(oldChildren[findOldIndex], newChild, projectionOptions, domNode, parentInstance) || textUpdated;
@@ -631,7 +626,7 @@ function updateChildren(
 			projectionOptions.afterRenderCallbacks.push(() => {
 				callOnDetach(oldChild, parentInstance);
 			});
-			nodeToRemove(oldChild, transitions, projectionOptions, parentInstance);
+			nodeToRemove(oldChild, transitions, projectionOptions);
 			checkDistinguishable(oldChildren, i, domNode, 'removed');
 		}
 	}

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -807,6 +807,18 @@ describe('vdom', () => {
 			let barDetachCount = 0;
 			let bazAttachCount = 0;
 			let bazDetachCount = 0;
+			let quxAttachCount = 0;
+			let quxDetachCount = 0;
+
+			class Qux extends WidgetBase {
+				onAttach() {
+					quxAttachCount++;
+				}
+
+				onDetach() {
+					quxDetachCount++;
+				}
+			}
 
 			class Foo extends WidgetBase {
 				onAttach() {
@@ -815,6 +827,10 @@ describe('vdom', () => {
 
 				onDetach() {
 					fooDetachCount++;
+				}
+
+				render() {
+					return w(Qux, {});
 				}
 			}
 
@@ -853,6 +869,8 @@ describe('vdom', () => {
 			assert.strictEqual(fooDetachCount, 0);
 			assert.strictEqual(barAttachCount, 0);
 			assert.strictEqual(barDetachCount, 0);
+			assert.strictEqual(quxAttachCount, 1);
+			assert.strictEqual(quxDetachCount, 0);
 			widget.invalidate();
 			projection.update(widget.__render__());
 			resolvers.resolve();
@@ -862,6 +880,8 @@ describe('vdom', () => {
 			assert.strictEqual(fooDetachCount, 1);
 			assert.strictEqual(barAttachCount, 1);
 			assert.strictEqual(barDetachCount, 0);
+			assert.strictEqual(quxAttachCount, 1);
+			assert.strictEqual(quxDetachCount, 1);
 			widget.invalidate();
 			projection.update(widget.__render__());
 			resolvers.resolve();
@@ -871,6 +891,19 @@ describe('vdom', () => {
 			assert.strictEqual(fooDetachCount, 1);
 			assert.strictEqual(barAttachCount, 1);
 			assert.strictEqual(barDetachCount, 1);
+			assert.strictEqual(quxAttachCount, 2);
+			assert.strictEqual(quxDetachCount, 1);
+			widget.invalidate();
+			projection.update(widget.__render__());
+			resolvers.resolve();
+			assert.strictEqual(bazAttachCount, 1);
+			assert.strictEqual(bazDetachCount, 0);
+			assert.strictEqual(fooAttachCount, 2);
+			assert.strictEqual(fooDetachCount, 2);
+			assert.strictEqual(barAttachCount, 2);
+			assert.strictEqual(barDetachCount, 1);
+			assert.strictEqual(quxAttachCount, 2);
+			assert.strictEqual(quxDetachCount, 2);
 		});
 
 		it('remove elements for embedded WNodes', () => {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -849,6 +849,10 @@ describe('vdom', () => {
 				}
 			}
 
+			class FooBar extends WidgetBase {
+
+			}
+
 			class Baz extends WidgetBase {
 				private _foo = false;
 
@@ -862,7 +866,12 @@ describe('vdom', () => {
 
 				render() {
 					this._foo = !this._foo;
-					return this._foo ? w(Foo, {}) : w(Bar, {});
+					return v('div', [
+						w(FooBar, {}),
+						this._foo ? w(Foo, {}) : null,
+						w(FooBar, {}),
+						this._foo ? w(Foo, {}) : w(Bar, {})
+					]);
 				}
 			}
 			const widget = new Baz();
@@ -870,34 +879,12 @@ describe('vdom', () => {
 			resolvers.resolve();
 			assert.strictEqual(bazAttachCount, 1);
 			assert.strictEqual(bazDetachCount, 0);
-			assert.strictEqual(fooAttachCount, 1);
+			assert.strictEqual(fooAttachCount, 2);
 			assert.strictEqual(fooDetachCount, 0);
 			assert.strictEqual(barAttachCount, 0);
 			assert.strictEqual(barDetachCount, 0);
-			assert.strictEqual(quxAttachCount, 2);
-			assert.strictEqual(quxDetachCount, 0);
-			widget.invalidate();
-			projection.update(widget.__render__());
-			resolvers.resolve();
-			assert.strictEqual(bazAttachCount, 1);
-			assert.strictEqual(bazDetachCount, 0);
-			assert.strictEqual(fooAttachCount, 1);
-			assert.strictEqual(fooDetachCount, 1);
-			assert.strictEqual(barAttachCount, 1);
-			assert.strictEqual(barDetachCount, 0);
-			assert.strictEqual(quxAttachCount, 2);
-			assert.strictEqual(quxDetachCount, 2);
-			widget.invalidate();
-			projection.update(widget.__render__());
-			resolvers.resolve();
-			assert.strictEqual(bazAttachCount, 1);
-			assert.strictEqual(bazDetachCount, 0);
-			assert.strictEqual(fooAttachCount, 2);
-			assert.strictEqual(fooDetachCount, 1);
-			assert.strictEqual(barAttachCount, 1);
-			assert.strictEqual(barDetachCount, 1);
 			assert.strictEqual(quxAttachCount, 4);
-			assert.strictEqual(quxDetachCount, 2);
+			assert.strictEqual(quxDetachCount, 0);
 			widget.invalidate();
 			projection.update(widget.__render__());
 			resolvers.resolve();
@@ -905,10 +892,32 @@ describe('vdom', () => {
 			assert.strictEqual(bazDetachCount, 0);
 			assert.strictEqual(fooAttachCount, 2);
 			assert.strictEqual(fooDetachCount, 2);
-			assert.strictEqual(barAttachCount, 2);
-			assert.strictEqual(barDetachCount, 1);
+			assert.strictEqual(barAttachCount, 1);
+			assert.strictEqual(barDetachCount, 0);
 			assert.strictEqual(quxAttachCount, 4);
 			assert.strictEqual(quxDetachCount, 4);
+			widget.invalidate();
+			projection.update(widget.__render__());
+			resolvers.resolve();
+			assert.strictEqual(bazAttachCount, 1);
+			assert.strictEqual(bazDetachCount, 0);
+			assert.strictEqual(fooAttachCount, 4);
+			assert.strictEqual(fooDetachCount, 2);
+			assert.strictEqual(barAttachCount, 1);
+			assert.strictEqual(barDetachCount, 1);
+			assert.strictEqual(quxAttachCount, 8);
+			assert.strictEqual(quxDetachCount, 4);
+			widget.invalidate();
+			projection.update(widget.__render__());
+			resolvers.resolve();
+			assert.strictEqual(bazAttachCount, 1);
+			assert.strictEqual(bazDetachCount, 0);
+			assert.strictEqual(fooAttachCount, 4);
+			assert.strictEqual(fooDetachCount, 4);
+			assert.strictEqual(barAttachCount, 2);
+			assert.strictEqual(barDetachCount, 1);
+			assert.strictEqual(quxAttachCount, 8);
+			assert.strictEqual(quxDetachCount, 8);
 		});
 
 		it('remove elements for embedded WNodes', () => {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -830,7 +830,12 @@ describe('vdom', () => {
 				}
 
 				render() {
-					return w(Qux, {});
+					return [
+						w(Qux, {}),
+						v('div', [
+							w(Qux, {})
+						])
+					];
 				}
 			}
 
@@ -869,7 +874,7 @@ describe('vdom', () => {
 			assert.strictEqual(fooDetachCount, 0);
 			assert.strictEqual(barAttachCount, 0);
 			assert.strictEqual(barDetachCount, 0);
-			assert.strictEqual(quxAttachCount, 1);
+			assert.strictEqual(quxAttachCount, 2);
 			assert.strictEqual(quxDetachCount, 0);
 			widget.invalidate();
 			projection.update(widget.__render__());
@@ -880,8 +885,8 @@ describe('vdom', () => {
 			assert.strictEqual(fooDetachCount, 1);
 			assert.strictEqual(barAttachCount, 1);
 			assert.strictEqual(barDetachCount, 0);
-			assert.strictEqual(quxAttachCount, 1);
-			assert.strictEqual(quxDetachCount, 1);
+			assert.strictEqual(quxAttachCount, 2);
+			assert.strictEqual(quxDetachCount, 2);
 			widget.invalidate();
 			projection.update(widget.__render__());
 			resolvers.resolve();
@@ -891,8 +896,8 @@ describe('vdom', () => {
 			assert.strictEqual(fooDetachCount, 1);
 			assert.strictEqual(barAttachCount, 1);
 			assert.strictEqual(barDetachCount, 1);
-			assert.strictEqual(quxAttachCount, 2);
-			assert.strictEqual(quxDetachCount, 1);
+			assert.strictEqual(quxAttachCount, 4);
+			assert.strictEqual(quxDetachCount, 2);
 			widget.invalidate();
 			projection.update(widget.__render__());
 			resolvers.resolve();
@@ -902,8 +907,8 @@ describe('vdom', () => {
 			assert.strictEqual(fooDetachCount, 2);
 			assert.strictEqual(barAttachCount, 2);
 			assert.strictEqual(barDetachCount, 1);
-			assert.strictEqual(quxAttachCount, 2);
-			assert.strictEqual(quxDetachCount, 2);
+			assert.strictEqual(quxAttachCount, 4);
+			assert.strictEqual(quxDetachCount, 4);
 		});
 
 		it('remove elements for embedded WNodes', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds two lifecycle methods `onAttach` and `onDetach` for when a widget has attached and when it is detached.

Resolves #766 
