### PR TITLE
Pass parent DNode over domNode when processing the vdom tree

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -548,20 +548,15 @@ function checkDistinguishable(
 				const node = childNodes[i];
 				if (same(node, childNode)) {
 					let nodeIdentifier: string;
-					const parentName = (parentInstance as any).constructor.name;
+					const parentName = (parentInstance as any).constructor.name || 'unknown';
 					if (isWNode(childNode)) {
-						nodeIdentifier = (childNode.widgetConstructor as any).name;
+						nodeIdentifier = (childNode.widgetConstructor as any).name || 'unknown';
 					}
 					else {
 						nodeIdentifier = childNode.tag;
 					}
 
-					let errorMsg = 'A widget has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique \'key\' property when using the same widget or element multiple times as siblings';
-
-					if (nodeIdentifier && parentName) {
-						errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${nodeIdentifier}) multiple times as siblings`;
-					}
-					console.warn(errorMsg);
+					console.warn(`A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${nodeIdentifier}) multiple times as siblings`);
 					break;
 				}
 			}

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -940,9 +940,7 @@ function createProjection(dnode: InternalDNode | InternalDNode[], parentInstance
 			let domNode = projectionOptions.rootNode;
 
 			updatedDNode = filterAndDecorateChildren(updatedDNode, parentInstance);
-			const parentDNode = toTextHNode('');
-			parentDNode.domNode = domNode;
-			updateChildren(parentDNode, projectionDNode, updatedDNode as InternalDNode[], parentInstance, projectionOptions);
+			updateChildren(toParentHNode(domNode), projectionDNode, updatedDNode as InternalDNode[], parentInstance, projectionOptions);
 			const instanceData = widgetInstanceMap.get(parentInstance)!;
 			instanceData.nodeHandler.addRoot();
 			runDeferredRenderCallbacks(projectionOptions);

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -565,7 +565,7 @@ function checkDistinguishable(
 }
 
 function updateChildren(
-	parentDNode: InternalDNode,
+	parentHNode: InternalHNode,
 	oldChildren: InternalDNode[],
 	newChildren: InternalDNode[],
 	parentInstance: DefaultWidgetBaseInterface,
@@ -586,7 +586,7 @@ function updateChildren(
 		const newChild = newChildren[newIndex];
 
 		if (oldChild !== undefined && same(oldChild, newChild)) {
-			textUpdated = updateDom(oldChild, newChild, projectionOptions, parentDNode, parentInstance) || textUpdated;
+			textUpdated = updateDom(oldChild, newChild, projectionOptions, parentHNode, parentInstance) || textUpdated;
 			oldIndex++;
 		}
 		else {
@@ -601,7 +601,7 @@ function updateChildren(
 					});
 					nodeToRemove(oldChildren[i], transitions, projectionOptions);
 				}
-				textUpdated = updateDom(oldChildren[findOldIndex], newChild, projectionOptions, parentDNode, parentInstance) || textUpdated;
+				textUpdated = updateDom(oldChildren[findOldIndex], newChild, projectionOptions, parentHNode, parentInstance) || textUpdated;
 				oldIndex = findOldIndex + 1;
 			}
 			else {
@@ -628,7 +628,7 @@ function updateChildren(
 					}
 				}
 
-				createDom(newChild, parentDNode, insertBefore, projectionOptions, parentInstance);
+				createDom(newChild, parentHNode, insertBefore, projectionOptions, parentInstance);
 				nodeAdded(newChild, transitions);
 				const indexToCheck = newIndex;
 				projectionOptions.afterRenderCallbacks.push(() => {
@@ -654,7 +654,7 @@ function updateChildren(
 }
 
 function addChildren(
-	parentDNode: InternalDNode,
+	parentHNode: InternalHNode,
 	children: InternalDNode[] | undefined,
 	projectionOptions: ProjectionOptions,
 	parentInstance: DefaultWidgetBaseInterface,
@@ -665,8 +665,8 @@ function addChildren(
 		return;
 	}
 
-	if (projectionOptions.merge && childNodes === undefined && isHNode(parentDNode)) {
-		childNodes = arrayFrom(parentDNode.domNode!.childNodes);
+	if (projectionOptions.merge && childNodes === undefined) {
+		childNodes = arrayFrom(parentHNode.domNode!.childNodes);
 	}
 
 	for (let i = 0; i < children.length; i++) {
@@ -682,10 +682,10 @@ function addChildren(
 					}
 				}
 			}
-			createDom(child, parentDNode, insertBefore, projectionOptions, parentInstance);
+			createDom(child, parentHNode, insertBefore, projectionOptions, parentInstance);
 		}
 		else {
-			createDom(child, parentDNode, insertBefore, projectionOptions, parentInstance, childNodes);
+			createDom(child, parentHNode, insertBefore, projectionOptions, parentInstance, childNodes);
 		}
 	}
 }
@@ -713,7 +713,7 @@ function initPropertiesAndChildren(
 
 function createDom(
 	dnode: InternalDNode,
-	parentDNode: any,
+	parentHNode: InternalHNode,
 	insertBefore: Node | undefined,
 	projectionOptions: ProjectionOptions,
 	parentInstance: DefaultWidgetBaseInterface,
@@ -741,7 +741,7 @@ function createDom(
 		if (rendered) {
 			const filteredRendered = filterAndDecorateChildren(rendered, instance);
 			dnode.rendered = filteredRendered;
-			addChildren(parentDNode, filteredRendered, projectionOptions, instance, insertBefore, childNodes);
+			addChildren(parentHNode, filteredRendered, projectionOptions, instance, insertBefore, childNodes);
 		}
 		instanceData.nodeHandler.addRoot();
 		projectionOptions.afterRenderCallbacks.push(() => {
@@ -755,7 +755,7 @@ function createDom(
 			initPropertiesAndChildren(domNode!, dnode, parentInstance, projectionOptions);
 			return;
 		}
-		const doc = parentDNode.domNode!.ownerDocument;
+		const doc = parentHNode.domNode!.ownerDocument;
 		if (dnode.tag === '') {
 			if (dnode.domNode !== undefined) {
 				const newDomNode = dnode.domNode.ownerDocument.createTextNode(dnode.text!);
@@ -765,10 +765,10 @@ function createDom(
 			else {
 				domNode = dnode.domNode = doc.createTextNode(dnode.text!);
 				if (insertBefore !== undefined) {
-					parentDNode.domNode!.insertBefore(domNode, insertBefore);
+					parentHNode.domNode!.insertBefore(domNode, insertBefore);
 				}
 				else {
-					parentDNode.domNode!.appendChild(domNode);
+					parentHNode.domNode!.appendChild(domNode);
 				}
 			}
 		}
@@ -788,17 +788,17 @@ function createDom(
 				domNode = dnode.domNode;
 			}
 			if (insertBefore !== undefined) {
-				parentDNode.domNode!.insertBefore(domNode, insertBefore);
+				parentHNode.domNode!.insertBefore(domNode, insertBefore);
 			}
-			else if (domNode!.parentNode !== parentDNode.domNode!) {
-				parentDNode.domNode!.appendChild(domNode);
+			else if (domNode!.parentNode !== parentHNode.domNode!) {
+				parentHNode.domNode!.appendChild(domNode);
 			}
 			initPropertiesAndChildren(domNode!, dnode, parentInstance, projectionOptions);
 		}
 	}
 }
 
-function updateDom(previous: any, dnode: InternalDNode, projectionOptions: ProjectionOptions, parentDNode: InternalDNode, parentInstance: DefaultWidgetBaseInterface) {
+function updateDom(previous: any, dnode: InternalDNode, projectionOptions: ProjectionOptions, parentHNode: InternalHNode, parentInstance: DefaultWidgetBaseInterface) {
 	if (isWNode(dnode)) {
 		const { instance, rendered: previousRendered } = previous;
 		if (instance && previousRendered) {
@@ -810,12 +810,12 @@ function updateDom(previous: any, dnode: InternalDNode, projectionOptions: Proje
 			const rendered = instance.__render__();
 			dnode.rendered = filterAndDecorateChildren(rendered, instance);
 			if (hasRenderChanged(previousRendered, rendered)) {
-				updateChildren(parentDNode, previousRendered, dnode.rendered, instance, projectionOptions);
+				updateChildren(parentHNode, previousRendered, dnode.rendered, instance, projectionOptions);
 				instanceData.nodeHandler.addRoot();
 			}
 		}
 		else {
-			createDom(dnode, parentDNode, undefined, projectionOptions, parentInstance);
+			createDom(dnode, parentHNode, undefined, projectionOptions, parentInstance);
 		}
 	}
 	else {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -1050,14 +1050,10 @@ describe('vdom', () => {
 				}
 			}
 
-			const widgetName = (Foo as any).name;
-			const parentName = (Baz as any).name;
+			const widgetName = (Foo as any).name || 'unknown';
+			const parentName = (Baz as any).name || 'unknown';
 
-			let errorMsg = 'A widget has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique \'key\' property when using the same widget or element multiple times as siblings';
-
-			if (widgetName) {
-				errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
-			}
+			const errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
 
 			const widget = new Baz();
 			const projection = dom.create(widget.__render__() as HNode, widget);
@@ -2079,13 +2075,9 @@ describe('vdom', () => {
 
 		it('will throw an error when vdom is not sure which node is added', () => {
 			const widgetName = 'span';
-			const parentName = projectorStub.constructor.name;
+			const parentName = projectorStub.constructor.name || 'unknown';
+			const errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
 
-			let errorMsg = 'A widget has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique \'key\' property when using the same widget or element multiple times as siblings';
-
-			if (widgetName) {
-				errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
-			}
 			const projection = dom.create(v('div', [
 				v('span', [ 'a' ]),
 				v('span', [ 'c' ])
@@ -2107,13 +2099,8 @@ describe('vdom', () => {
 
 		it('will throw an error when vdom is not sure which node is removed', () => {
 			const widgetName = 'span';
-			const parentName = projectorStub.constructor.name;
-
-			let errorMsg = 'A widget has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique \'key\' property when using the same widget or element multiple times as siblings';
-
-			if (widgetName) {
-				errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
-			}
+			const parentName = projectorStub.constructor.name || 'unknown';
+			const errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
 
 			const projection = dom.create(v('div', [
 				v('span', [ 'a' ]),

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -22,7 +22,10 @@ const projectorStub: any = {
 	onElementCreated: stub(),
 	onElementUpdated: stub(),
 	onAttach: stub(),
-	onDetach: stub()
+	onDetach: stub(),
+	constructor: {
+		name: 'projectorStub'
+	}
 };
 
 widgetInstanceMap.set(projectorStub, projectorStub);
@@ -1031,13 +1034,6 @@ describe('vdom', () => {
 				}
 			}
 
-			const widgetName = (Foo as any).name;
-			let errorMsg = 'It is recommended to provide a unique \'key\' property when using the same widget multiple times as siblings';
-
-			if (widgetName) {
-				errorMsg = `It is recommended to provide a unique 'key' property when using the same widget (${widgetName}) multiple times as siblings`;
-			}
-
 			class Baz extends WidgetBase {
 
 				show = false;
@@ -1054,13 +1050,23 @@ describe('vdom', () => {
 				}
 			}
 
+			const widgetName = (Foo as any).name;
+			const parentName = (Baz as any).name;
+
+			let errorMsg = 'A widget has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique \'key\' property when using the same widget or element multiple times as siblings';
+
+			if (widgetName) {
+				errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
+			}
+
 			const widget = new Baz();
 			const projection = dom.create(widget.__render__() as HNode, widget);
 			assert.isTrue(consoleStub.notCalled);
 			widget.invalidate();
 			widget.show = true;
 			projection.update(widget.__render__() as HNode);
-			assert.isTrue(consoleStub.calledTwice);
+			resolvers.resolve();
+			assert.isTrue(consoleStub.calledOnce);
 			assert.isTrue(consoleStub.calledWith(errorMsg));
 		});
 
@@ -2072,31 +2078,60 @@ describe('vdom', () => {
 		});
 
 		it('will throw an error when vdom is not sure which node is added', () => {
+			const widgetName = 'span';
+			const parentName = projectorStub.constructor.name;
+
+			let errorMsg = 'A widget has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique \'key\' property when using the same widget or element multiple times as siblings';
+
+			if (widgetName) {
+				errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
+			}
 			const projection = dom.create(v('div', [
 				v('span', [ 'a' ]),
 				v('span', [ 'c' ])
 			]), projectorStub);
-			assert.throws(() => {
-				projection.update(v('div', [
-					v('span', [ 'a' ]),
-					v('span', [ 'b' ]),
-					v('span', [ 'c' ])
-				]));
-			});
+
+			assert.isTrue(consoleStub.notCalled);
+
+			projection.update(v('div', [
+				v('span', [ 'a' ]),
+				v('span', [ 'b' ]),
+				v('span', [ 'c' ])
+			]));
+
+			resolvers.resolve();
+
+			assert.isTrue(consoleStub.calledOnce);
+			assert.isTrue(consoleStub.calledWith(errorMsg));
 		});
 
 		it('will throw an error when vdom is not sure which node is removed', () => {
+			const widgetName = 'span';
+			const parentName = projectorStub.constructor.name;
+
+			let errorMsg = 'A widget has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique \'key\' property when using the same widget or element multiple times as siblings';
+
+			if (widgetName) {
+				errorMsg = `A widget (${parentName}) has had a child addded or removed, but they were not able to uniquely identified. It is recommended to provide a unique 'key' property when using the same widget or element (${widgetName}) multiple times as siblings`;
+			}
+
 			const projection = dom.create(v('div', [
 				v('span', [ 'a' ]),
 				v('span', [ 'b' ]),
 				v('span', [ 'c' ])
 			]), projectorStub);
-			assert.throws(() => {
-				projection.update(v('div', [
-					v('span', [ 'a' ]),
-					v('span', [ 'c' ])
-				]));
-			});
+
+			assert.isTrue(consoleStub.notCalled);
+
+			projection.update(v('div', [
+				v('span', [ 'a' ]),
+				v('span', [ 'c' ])
+			]));
+
+			resolvers.resolve();
+
+			assert.isTrue(consoleStub.calledOnce);
+			assert.isTrue(consoleStub.calledWith(errorMsg));
 		});
 
 		it('allows a contentEditable tag to be altered', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

To enable enhancements to the render algorithm it is necessary to pass the parent DNode instead of the parent DOM Node.

As part of these changes `checkDistinguisable` no longer throws an error for non unique sibling nodes, a warning is logged to the console to mirror the behaviour if there are non unique widgets detected.

`checkDistinguisable` is also now runs on `requestIdleCallback`.

No functional changes delivered as part of these changes
