### PR TITLE
Bug: Ensure correct `insertBefore` is correctly calculated

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -579,13 +579,15 @@ function updateChildren(
 				let insertBefore: Node | undefined = undefined;
 				let child: InternalDNode = oldChildren[oldIndex];
 				if (child) {
+					let nextIndex = oldIndex + 1;
 					while (insertBefore === undefined) {
 						if (isWNode(child)) {
 							if (child.rendered) {
 								child = child.rendered[0];
 							}
-							else if (oldChildren[oldIndex + 1]) {
-								child = oldChildren[oldIndex + 1];
+							else if (oldChildren[nextIndex]) {
+								child = oldChildren[nextIndex];
+								nextIndex++;
 							}
 							else {
 								break;

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -581,7 +581,15 @@ function updateChildren(
 				if (child) {
 					while (insertBefore === undefined) {
 						if (isWNode(child)) {
-							child = child.rendered[0];
+							if (child.rendered) {
+								child = child.rendered[0];
+							}
+							else if (oldChildren[oldIndex + 1]) {
+								child = oldChildren[oldIndex + 1];
+							}
+							else {
+								break;
+							}
 						}
 						else {
 							insertBefore = child.domNode;

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -510,6 +510,64 @@ describe('vdom', () => {
 			assert.lengthOf(fooDiv.childNodes, 1);
 		});
 
+		it('Should insert nodes at correct position the previous widget returned null', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [ 'foo' ]);
+				}
+			}
+
+			class Bar extends WidgetBase {
+				render() {
+					return v('div', [ 'bar' ]);
+				}
+			}
+
+			class Baz extends WidgetBase<any> {
+				render() {
+					const { widget = 'default' } = this.properties;
+					return v('div', [
+						v('div', [ 'first' ]),
+						w(widget, {}),
+						v('div', [ 'second' ])
+					]);
+				}
+			}
+
+			const baseRegistry = new Registry();
+			baseRegistry.define('foo', Foo);
+			baseRegistry.define('bar', Bar);
+			const widget = new Baz();
+			widget.__setCoreProperties__({ bind: widget, baseRegistry });
+			const projection = dom.create(widget.__render__(), widget);
+			const root: any = projection.domNode.childNodes[0];
+			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
+			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'second');
+			widget.__setProperties__({ widget: 'other' });
+			projection.update(widget.__render__());
+			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
+			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'second');
+			widget.__setProperties__({ widget: 'foo' });
+			projection.update(widget.__render__());
+			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
+			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'foo');
+			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
+			widget.__setProperties__({ widget: 'bar' });
+			projection.update(widget.__render__());
+			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
+			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'bar');
+			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
+			widget.__setProperties__({ widget: 'other' });
+			projection.update(widget.__render__());
+			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
+			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'second');
+			widget.__setProperties__({ widget: 'bar' });
+			projection.update(widget.__render__());
+			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
+			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'bar');
+			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
+		});
+
 		it('should allow a widget returned from render', () => {
 
 			class Bar extends WidgetBase<any> {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -529,7 +529,8 @@ describe('vdom', () => {
 					return v('div', [
 						v('div', [ 'first' ]),
 						w(widget, {}),
-						v('div', [ 'second' ])
+						v('div', [ 'second' ]),
+						w(widget, {})
 					]);
 				}
 			}
@@ -552,11 +553,13 @@ describe('vdom', () => {
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
 			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'foo');
 			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
+			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'foo');
 			widget.__setProperties__({ widget: 'bar' });
 			projection.update(widget.__render__());
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
 			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'bar');
 			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
+			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'bar');
 			widget.__setProperties__({ widget: 'other' });
 			projection.update(widget.__render__());
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
@@ -566,6 +569,7 @@ describe('vdom', () => {
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
 			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'bar');
 			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
+			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'bar');
 		});
 
 		it('should allow a widget returned from render', () => {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -529,6 +529,7 @@ describe('vdom', () => {
 					return v('div', [
 						v('div', [ 'first' ]),
 						w(widget, {}),
+						w(widget, {}),
 						v('div', [ 'second' ]),
 						w(widget, {})
 					]);
@@ -552,14 +553,16 @@ describe('vdom', () => {
 			projection.update(widget.__render__());
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
 			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'foo');
-			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
-			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'foo');
+			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'foo');
+			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'second');
+			assert.strictEqual(root.childNodes[4].childNodes[0].data, 'foo');
 			widget.__setProperties__({ widget: 'bar' });
 			projection.update(widget.__render__());
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
 			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'bar');
-			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
-			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'bar');
+			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'bar');
+			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'second');
+			assert.strictEqual(root.childNodes[4].childNodes[0].data, 'bar');
 			widget.__setProperties__({ widget: 'other' });
 			projection.update(widget.__render__());
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
@@ -568,8 +571,9 @@ describe('vdom', () => {
 			projection.update(widget.__render__());
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'first');
 			assert.strictEqual(root.childNodes[1].childNodes[0].data, 'bar');
-			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'second');
-			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'bar');
+			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'bar');
+			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'second');
+			assert.strictEqual(root.childNodes[4].childNodes[0].data, 'bar');
 		});
 
 		it('should allow a widget returned from render', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

If `rendered` doesn't exist for the `WNode`, check the next old child if it exists otherwise break.

Resolves #775 
