### PR TITLE
Skip render call if widget is not dirty

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -80,8 +80,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	 */
 	private _changedPropertyKeys: string[] = [];
 
-	private _cachedDNode: DNode | DNode[];
-
 	/**
 	 * map of decorators that are applied to this widget
 	 */
@@ -296,17 +294,15 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	}
 
 	public __render__(): DNode | DNode[] {
-		const instanceData = widgetInstanceMap.get(this)!;
 		this._renderState = WidgetRenderState.RENDER;
-		if (instanceData.dirty || this._cachedDNode === undefined) {
-			instanceData.dirty = false;
-			const render = this._runBeforeRenders();
-			let dNode = render();
-			this._cachedDNode = this.runAfterRenders(dNode);
-			this._nodeHandler.clear();
-		}
+		const instanceData = widgetInstanceMap.get(this)!;
+		instanceData.dirty = false;
+		const render = this._runBeforeRenders();
+		let dNode = render();
+		dNode = this.runAfterRenders(dNode);
+		this._nodeHandler.clear();
 		this._renderState = WidgetRenderState.IDLE;
-		return this._cachedDNode;
+		return dNode;
 	}
 
 	public invalidate(): void {

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -455,16 +455,6 @@ export function filterAndDecorateChildren(children: undefined | DNode | DNode[],
 	return children as InternalDNode[];
 }
 
-function hasRenderChanged(previousRendered: InternalDNode[], rendered: InternalDNode | InternalDNode[]): boolean {
-	const arrayRender = Array.isArray(rendered);
-	if (arrayRender) {
-		return previousRendered !== rendered;
-	}
-	else {
-		return Array.isArray(previousRendered) && previousRendered[0] !== rendered;
-	}
-}
-
 function nodeAdded(dnode: InternalDNode, transitions: TransitionStrategy) {
 	if (isHNode(dnode) && dnode.properties) {
 		const enterAnimation = dnode.properties.enterAnimation;
@@ -807,12 +797,15 @@ function updateDom(previous: any, dnode: InternalDNode, projectionOptions: Proje
 			instance.__setChildren__(dnode.children);
 			instance.__setProperties__(dnode.properties);
 			dnode.instance = instance;
-			const rendered = instance.__render__();
-			dnode.rendered = filterAndDecorateChildren(rendered, instance);
-			if (hasRenderChanged(previousRendered, rendered)) {
+			if (instanceData.dirty === true) {
+				const rendered = instance.__render__();
+				dnode.rendered = filterAndDecorateChildren(rendered, instance);
 				updateChildren(parentHNode, previousRendered, dnode.rendered, instance, projectionOptions);
-				instanceData.nodeHandler.addRoot();
 			}
+			else {
+				dnode.rendered = previousRendered;
+			}
+			instanceData.nodeHandler.addRoot();
 		}
 		else {
 			createDom(dnode, parentHNode, undefined, projectionOptions, parentInstance);

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -113,22 +113,6 @@ describe('WidgetBase', () => {
 			assert.lengthOf(renderResult.children, 1);
 			assert.strictEqual(renderResult.children![0], 'child');
 		});
-
-		it('returns cached DNode when widget is ', () => {
-			class TestWidget extends BaseTestWidget {
-				render() {
-					return v('my-app', [ 'child' ]);
-				}
-			}
-			const widget = new TestWidget();
-			const renderResult = widget.__render__();
-			const secondRenderResult = widget.__render__();
-			assert.strictEqual(secondRenderResult, renderResult);
-			widget.invalidate();
-			const thirdRenderResult = widget.__render__();
-			assert.notStrictEqual(thirdRenderResult, secondRenderResult);
-		});
-
 	});
 
 	describe('__setProperties__', () => {

--- a/tests/unit/decorators/diffProperty.ts
+++ b/tests/unit/decorators/diffProperty.ts
@@ -5,6 +5,7 @@ import { PropertyChangeRecord } from './../../../src/interfaces';
 import { always, ignore } from './../../../src/diff';
 import { diffProperty } from './../../../src/decorators/diffProperty';
 import { WidgetBase } from './../../../src/WidgetBase';
+import { widgetInstanceMap } from './../../../src/vdom';
 
 interface TestProperties {
 	id?: string;
@@ -235,13 +236,12 @@ registerSuite('decorators/diffProperty', {
 		class TestWidget extends WidgetBase<TestProperties> { }
 
 		const widget = new TestWidget();
-		const renderResult = widget.__render__();
-
+		widget.__render__();
 		widget.__setProperties__({
 			foo: '',
 			id: ''
 		});
-		assert.strictEqual(renderResult, widget.__render__());
+		assert.isFalse(widgetInstanceMap.get(widget)!.dirty);
 	},
 
 	'properties that are deleted dont get returned'() {

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -82,7 +82,7 @@ registerSuite('mixins/projectorMixin', {
 
 				result = 'my string';
 				renderedResult = projector.__render__() as HNode;
-				assert.strictEqual(renderedResult.tag, 'h1');
+				assert.strictEqual(renderedResult.tag, 'span');
 				assert.strictEqual(renderedResult.children![0], 'my string');
 			},
 			'null root node'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

There is no need to even attempt to render in `vdom` if a widget is not dirty, we can now use the `dirty` flag from the widget `instanceData` contained in the `widgetInstanceMap`

Resolves #779 
