### PR TITLE
Allow Injector's initial payload to be optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ class MyClass extends WidgetBase {
 
 There is built in support for side-loading/injecting values into sections of the widget tree and mapping them to a widget's properties. This is achieved by registering a `@dojo/widget-core/Injector` instance against a `registry` that is available to your application (i.e. set on the projector instance, `projector.setProperties({ registry })`).
 
-Create an `Injector` instance and pass the `payload` that needs to be injected to the constructor:
+Create an `Injector` instance and pass an optional `payload` that needs to be injected to the constructor (if no `payload` is provided, then the injector itself is used as the initial payload):
 
 ```ts
 const injector = new Injector({ foo: 'baz' });

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -2,14 +2,14 @@ import { Evented } from '@dojo/core/Evented';
 
 export class Injector<T = any> extends Evented {
 
-	private _payload: T;
+	private _payload: T | Injector<T>;
 
-	constructor(payload: T) {
+	constructor(payload?: T) {
 		super({});
-		this._payload = payload;
+		this._payload = payload || this;
 	}
 
-	public get(): T {
+	public get(): T | Injector<T> {
 		return this._payload;
 	}
 

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -19,5 +19,12 @@ registerSuite('Injector', {
 		});
 		injector.set({});
 		assert.isTrue(invalidateCalled);
+	},
+	'without an initial payload'() {
+		const injector = new Injector();
+		assert.strictEqual(injector.get(), injector);
+
+		injector.set({});
+		assert.notStrictEqual(injector.get(), injector);
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Makes the `payload` passed to the `Injector` constructor optional. When no payload is provided, `this` will be used as the initial payload. This has the benefit of simplifying custom injectors used by simpler applications that do not need a full-featured store, allowing the injector itself to be used as the store. For example, the injector created in the [state management tutorial](https://dojo.io/tutorials/1010_containers_and_injecting_state/#1) must override `get` and pass an empty object to `super`:

```
class ApplicationContext extends Injector {
    constructor() {
        super({});
        // ...
    }

    get() {
        return this;
    }
}
```

With these changes, `super` can be called without an argument and `get` will not need to be modified:

```
class ApplicationContext extends Injector {
    constructor() {
        super();
        // ...
    }
}
```

Resolves #753 
