### PR TITLE
Update I18n mixin to use injector pattern.

### DIFF
--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -4,15 +4,19 @@ import i18n, {
 	Bundle,
 	formatMessage,
 	getCachedMessages,
-	Messages,
-	observeLocale
+	Messages
 } from '@dojo/i18n/i18n';
-import { Constructor, DNode, WidgetProperties, VirtualDomProperties } from './../interfaces';
-import { WidgetBase } from './../WidgetBase';
-import { afterRender } from './../decorators/afterRender';
 import { isHNode } from './../d';
+import { afterRender } from './../decorators/afterRender';
+import { inject } from './../decorators/inject';
+import { Constructor, DNode, WidgetProperties, VirtualDomProperties } from './../interfaces';
+import { Injector } from './../Injector';
+import { Registry } from './../Registry';
+import { WidgetBase } from './../WidgetBase';
 
-export interface I18nProperties extends WidgetProperties {
+export const INJECTOR_KEY = Symbol('i18n');
+
+export interface LocaleData {
 	/**
 	 * The locale for the widget. If not specified, then the root locale (as determined by `@dojo/i18n`) is assumed.
 	 * If specified, the widget's node will have a `lang` property set to the locale.
@@ -26,6 +30,8 @@ export interface I18nProperties extends WidgetProperties {
 	 */
 	rtl?: boolean;
 }
+
+export interface I18nProperties extends LocaleData, WidgetProperties {}
 
 /**
  * @private
@@ -72,21 +78,33 @@ export interface I18nMixin {
 	properties: I18nProperties;
 }
 
+export function registerI18nInjector(localeData: LocaleData, registry: Registry): Injector {
+	const injector = new Injector(localeData);
+	registry.defineInjector(INJECTOR_KEY, injector);
+	return injector;
+}
+
 export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & Constructor<I18nMixin> {
+	@inject({
+		name: INJECTOR_KEY,
+		getProperties: (localeData: LocaleData, properties: I18nProperties) => {
+			const { locale, rtl } = localeData;
+			const injected: Partial<I18nProperties> = {};
+
+			if (!properties.locale) {
+				injected.locale = locale;
+			}
+
+			if (typeof properties.rtl === 'undefined') {
+				injected.rtl = rtl;
+			}
+
+			return injected;
+		}
+	})
 	class I18n extends Base {
 
 		public properties: I18nProperties;
-
-		constructor(...args: any[]) {
-			super(...args);
-			observeLocale({
-				next: () => {
-					if (!this.properties.locale) {
-						this.invalidate();
-					}
-				}
-			});
-		}
 
 		public localizeBundle<T extends Messages>(bundle: Bundle<T>): LocalizedMessages<T> {
 			const { locale } = this.properties;

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -88,18 +88,8 @@ export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & 
 	@inject({
 		name: INJECTOR_KEY,
 		getProperties: (localeData: LocaleData, properties: I18nProperties) => {
-			const { locale, rtl } = localeData;
-			const injected: Partial<I18nProperties> = {};
-
-			if (!properties.locale) {
-				injected.locale = locale;
-			}
-
-			if (typeof properties.rtl === 'undefined') {
-				injected.rtl = rtl;
-			}
-
-			return injected;
+			const { locale = localeData.locale, rtl = localeData.rtl } = properties;
+			return { locale, rtl };
 		}
 	})
 	class I18n extends Base {

--- a/src/mixins/Themed.ts
+++ b/src/mixins/Themed.ts
@@ -89,12 +89,13 @@ export function registerThemeInjector(theme: any, themeRegistry: Registry): Inje
 export function ThemedMixin<E, T extends Constructor<WidgetBase<ThemedProperties<E>>>>(Base: T): Constructor<ThemedMixin<E>> & T {
 	@inject({
 		name: INJECTED_THEME_KEY,
-		getProperties: (theme: Theme, properties: ThemedProperties): ThemedProperties  => {
-		if (!properties.theme) {
-			return { theme };
+		getProperties: (theme: Theme, properties: ThemedProperties): ThemedProperties => {
+			if (!properties.theme) {
+				return { theme };
+			}
+			return {};
 		}
-		return {};
-	}})
+	})
 	class Themed extends Base {
 
 		public properties: ThemedProperties<E>;

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -114,14 +114,19 @@ registerSuite('mixins/I18nMixin', {
 
 			'properties can be registered with helper'() {
 				const registry = new Registry();
-				registerI18nInjector({ locale: 'fr' }, registry);
+				const injector = registerI18nInjector({ locale: 'fr' }, registry);
 
 				localized = new Localized();
 				localized.__setCoreProperties__({ bind: localized, baseRegistry: registry });
 				localized.__setProperties__({});
 
-				const result = localized.__render__();
+				let result = localized.__render__();
 				assert.strictEqual(result.properties!['lang'], 'fr');
+
+				injector.set({ locale: 'jp' });
+				localized.__setProperties__({});
+				result = localized.__render__();
+				assert.strictEqual(result.properties!['lang'], 'jp');
 			}
 		},
 		'does not decorate properties for wNode'() {

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -1,8 +1,9 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import i18n, { invalidate, switchLocale, systemLocale } from '@dojo/i18n/i18n';
-import * as sinon from 'sinon';
-import { I18nMixin, I18nProperties } from '../../../src/mixins/I18n';
+import { INJECTOR_KEY, I18nMixin, I18nProperties, registerI18nInjector } from '../../../src/mixins/I18n';
+import { Injector } from '../../../src/Injector';
+import { Registry } from '../../../src/Registry';
 import { WidgetBase } from '../../../src/WidgetBase';
 import bundle from '../../support/nls/greetings';
 import { fetchCldrData } from '../../support/util';
@@ -82,25 +83,45 @@ registerSuite('mixins/I18nMixin', {
 				});
 			}
 		},
+		'locale data can be injected by defining an Injector with a registry': {
+			'defaults to the injector data'() {
+				const injector = new Injector({ locale: 'ar', rtl: true });
+				const registry = new Registry();
 
-		'root locale switching': {
-			'Updates when no `locale` property is set'() {
+				registry.defineInjector(INJECTOR_KEY, injector);
 				localized = new Localized();
-				sinon.spy(localized, 'invalidate');
+				localized.__setCoreProperties__({ bind: localized, baseRegistry: registry });
+				localized.__setProperties__({});
 
-				switchLocale('fr');
-
-				assert.isTrue(localized.invalidate.called, 'Widget invalidated.');
+				const result = localized.__render__();
+				assert.strictEqual(result.properties!['lang'], 'ar');
+				assert.strictEqual(result.properties!['dir'], 'rtl');
 			},
 
-			'Does not update when `locale` property is set'() {
+			'does not override property values'() {
+				const injector = new Injector({ locale: 'ar', rtl: true });
+				const registry = new Registry();
+
+				registry.defineInjector(INJECTOR_KEY, injector);
 				localized = new Localized();
-				localized.__setProperties__({ locale: 'en' });
-				sinon.spy(localized, 'invalidate');
+				localized.__setCoreProperties__({ bind: localized, baseRegistry: registry });
+				localized.__setProperties__({ locale: 'fr', rtl: false });
 
-				switchLocale('fr');
+				const result = localized.__render__();
+				assert.strictEqual(result.properties!['lang'], 'fr');
+				assert.strictEqual(result.properties!['dir'], 'ltr');
+			},
 
-				assert.isFalse(localized.invalidate.called, 'Widget not invalidated.');
+			'properties can be registered with helper'() {
+				const registry = new Registry();
+				registerI18nInjector({ locale: 'fr' }, registry);
+
+				localized = new Localized();
+				localized.__setCoreProperties__({ bind: localized, baseRegistry: registry });
+				localized.__setProperties__({});
+
+				const result = localized.__render__();
+				assert.strictEqual(result.properties!['lang'], 'fr');
 			}
 		},
 		'does not decorate properties for wNode'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updates the `I18n` mixin to use the injector pattern for passing locale data to children and removes the locale observer from the `I18n` constructor.

Resolves #781 
