### PR TITLE
Fix custom element decorator

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -226,8 +226,8 @@ export function initializeElement(element: CustomElement) {
 	attributes.forEach(attribute => {
 		const attributeName = attribute.attributeName;
 
-		const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attributeName, element.getAttribute(attributeName), attribute);
-		initialProperties[ propertyName ] = propertyValue;
+		const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attributeName, element.getAttribute(attributeName.toLowerCase()), attribute);
+		initialProperties[propertyName] = propertyValue;
 	});
 
 	let customProperties: PropertyDescriptorMap = {};
@@ -235,9 +235,9 @@ export function initializeElement(element: CustomElement) {
 	attributes.reduce((properties, attribute) => {
 		const { propertyName = attribute.attributeName } = attribute;
 
-		properties[ propertyName ] = {
+		properties[propertyName] = {
 			get() {
-				return element.getWidgetInstance().properties[ propertyName ];
+				return element.getWidgetInstance().properties[propertyName];
 			},
 			set(value: any) {
 				const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attribute.attributeName, value, attribute);
@@ -256,7 +256,7 @@ export function initializeElement(element: CustomElement) {
 
 		properties[ propertyName ] = {
 			get() {
-				const value = element.getWidgetInstance().properties[ widgetPropertyName ];
+				const value = element.getWidgetInstance().properties[widgetPropertyName];
 				return getValue ? getValue(value) : value;
 			},
 
@@ -278,7 +278,7 @@ export function initializeElement(element: CustomElement) {
 	events.forEach((event) => {
 		const { propertyName, eventName } = event;
 
-		initialProperties[ propertyName ] = (event: any) => {
+		initialProperties[propertyName] = (event: any) => {
 			element.dispatchEvent(new customEventClass(eventName, {
 				bubbles: false,
 				detail: event
@@ -330,8 +330,10 @@ export function handleAttributeChanged(element: CustomElement, name: string, new
 	const attributes = element.getDescriptor().attributes || [];
 
 	attributes.forEach((attribute) => {
-		if (attribute.attributeName === name) {
-			const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(name, newValue, attribute);
+		const { attributeName } = attribute;
+
+		if (attributeName.toLowerCase() ===  name.toLowerCase()) {
+			const [ propertyName, propertyValue ] = getWidgetPropertyFromAttribute(attributeName, newValue, attribute);
 			element.getWidgetInstance().setProperties(assign(
 				{},
 				element.getWidgetInstance().properties,

--- a/src/decorators/customElement.ts
+++ b/src/decorators/customElement.ts
@@ -2,6 +2,8 @@ import { CustomElementInitializer } from '../customElements';
 import { Constructor, WidgetProperties } from '../interfaces';
 import registerCustomElement from '../registerCustomElement';
 
+declare const __dojoCustomElements__: boolean;
+
 /**
  * Defines the custom element configuration used by the customElement decorator
  */
@@ -39,17 +41,19 @@ export interface CustomElementConfig<P extends WidgetProperties> {
  */
 export function customElement<P extends WidgetProperties = WidgetProperties>({ tag, properties, attributes, events, initialization }: CustomElementConfig<P>) {
 	return function <T extends Constructor<any>>(target: T) {
-		registerCustomElement(() => ({
-			tagName: tag,
-			widgetConstructor: target,
-			attributes: (attributes || []).map(attributeName => ({ attributeName })),
-			properties: (properties || []).map(propertyName => ({ propertyName })),
-			events: (events || []).map(propertyName => ({
-				propertyName,
-				eventName: propertyName.replace('on', '').toLowerCase()
-			})),
-			initialization
-		}));
+		if (__dojoCustomElements__) {
+			registerCustomElement(() => ({
+				tagName: tag,
+				widgetConstructor: target,
+				attributes: (attributes || []).map(attributeName => ({ attributeName })),
+				properties: (properties || []).map(propertyName => ({ propertyName })),
+				events: (events || []).map(propertyName => ({
+					propertyName,
+					eventName: propertyName.replace('on', '').toLowerCase()
+				})),
+				initialization
+			}));
+		}
 	};
 }
 

--- a/src/decorators/customElement.ts
+++ b/src/decorators/customElement.ts
@@ -1,4 +1,4 @@
-import { CustomElementInitializer, CustomElementAttributeDescriptor } from '../customElements';
+import { CustomElementInitializer } from '../customElements';
 import { Constructor, WidgetProperties } from '../interfaces';
 import registerCustomElement from '../registerCustomElement';
 
@@ -22,7 +22,7 @@ export interface CustomElementConfig<P extends WidgetProperties> {
 	/**
 	 * List of attributes on the custom element to map to widget properties
 	 */
-	attributes?: ((keyof P) | { attributeName: keyof P, value?: (attribute: string | null) => any })[];
+	attributes?: (keyof P)[];
 
 	/**
 	 * List of events to expose
@@ -35,10 +35,6 @@ export interface CustomElementConfig<P extends WidgetProperties> {
 	initialization?: CustomElementInitializer;
 }
 
-function createAttributeDescriptor(attributeConfig: string | { attributeName: string, value?: (attribute: string | null) => any }): CustomElementAttributeDescriptor {
-	return typeof attributeConfig === 'string' ? { attributeName: attributeConfig } : attributeConfig;
-}
-
 /**
  * This Decorator is provided properties that define the behavior of a custom element, and
  * registers that custom element.
@@ -49,7 +45,7 @@ export function customElement<P extends WidgetProperties = WidgetProperties>({ t
 			registerCustomElement(() => ({
 				tagName: tag,
 				widgetConstructor: target,
-				attributes: (attributes || []).map<CustomElementAttributeDescriptor>(createAttributeDescriptor),
+				attributes: (attributes || []).map(attributeName => ({ attributeName })),
 				properties: (properties || []).map(propertyName => ({ propertyName })),
 				events: (events || []).map(propertyName => ({
 					propertyName,

--- a/src/decorators/customElement.ts
+++ b/src/decorators/customElement.ts
@@ -45,7 +45,7 @@ function createAttributeDescriptor(attributeConfig: string | { attributeName: st
  */
 export function customElement<P extends WidgetProperties = WidgetProperties>({ tag, properties, attributes, events, initialization }: CustomElementConfig<P>) {
 	return function <T extends Constructor<any>>(target: T) {
-		if (__dojoCustomElements__) {
+		if (typeof __dojoCustomElements__ !== 'undefined') {
 			registerCustomElement(() => ({
 				tagName: tag,
 				widgetConstructor: target,

--- a/src/decorators/customElement.ts
+++ b/src/decorators/customElement.ts
@@ -1,4 +1,4 @@
-import { CustomElementInitializer } from '../customElements';
+import { CustomElementInitializer, CustomElementAttributeDescriptor } from '../customElements';
 import { Constructor, WidgetProperties } from '../interfaces';
 import registerCustomElement from '../registerCustomElement';
 
@@ -22,7 +22,7 @@ export interface CustomElementConfig<P extends WidgetProperties> {
 	/**
 	 * List of attributes on the custom element to map to widget properties
 	 */
-	attributes?: (keyof P)[];
+	attributes?: ((keyof P) | { attributeName: keyof P, value?: (attribute: string | null) => any })[];
 
 	/**
 	 * List of events to expose
@@ -35,6 +35,10 @@ export interface CustomElementConfig<P extends WidgetProperties> {
 	initialization?: CustomElementInitializer;
 }
 
+function createAttributeDescriptor(attributeConfig: string | { attributeName: string, value?: (attribute: string | null) => any }): CustomElementAttributeDescriptor {
+	return typeof attributeConfig === 'string' ? { attributeName: attributeConfig } : attributeConfig;
+}
+
 /**
  * This Decorator is provided properties that define the behavior of a custom element, and
  * registers that custom element.
@@ -45,7 +49,7 @@ export function customElement<P extends WidgetProperties = WidgetProperties>({ t
 			registerCustomElement(() => ({
 				tagName: tag,
 				widgetConstructor: target,
-				attributes: (attributes || []).map(attributeName => ({ attributeName })),
+				attributes: (attributes || []).map<CustomElementAttributeDescriptor>(createAttributeDescriptor),
 				properties: (properties || []).map(propertyName => ({ propertyName })),
 				events: (events || []).map(propertyName => ({
 					propertyName,

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -71,7 +71,7 @@ export function registerCustomElement(descriptorFactory: CustomElementDescriptor
 		}
 
 		static get observedAttributes(): string[] {
-			return (descriptor.attributes || []).map(attribute => attribute.attributeName);
+			return (descriptor.attributes || []).map(attribute => attribute.attributeName.toLowerCase());
 		}
 	});
 }

--- a/tests/functional/customElement.ts
+++ b/tests/functional/customElement.ts
@@ -182,6 +182,25 @@ registerSuite('customElement', {
 				.then((text: string) => {
 					assert.strictEqual(text, 'programmatic top level child');
 				});
+		},
+		'should not register custom elements if the __dojoCustomElements__ global is not present'() {
+			if (skip) {
+				this.skip('not compatible with iOS 9.1 or Safari 9.1');
+			}
+
+			return this.remote
+				.get('_build/tests/functional/decorators/noCustomElement.html')
+				.setFindTimeout(200)
+				.findByCssSelector('button')
+				.then(
+					() => {
+						assert.fail('Should not have registered custom elements;, page should have no buttons');
+					},
+					() => {
+						// should end up here
+					}
+				);
 		}
+
 	}
 });

--- a/tests/functional/decorators/customElement.html
+++ b/tests/functional/decorators/customElement.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <test-button id="testButton-2" label="world" labelsuffix="hello"></test-button>
-<test-button id="testButton" label="hello" labelsuffix="  world   "></test-button>
+<test-button id="testButton" label="hello" labelsuffix="world"></test-button>
 
 <no-attributes id="noAttributes" label="hello" labelsuffix="world"></no-attributes>
 <child-wrapper id="parent-element">

--- a/tests/functional/decorators/customElement.html
+++ b/tests/functional/decorators/customElement.html
@@ -7,10 +7,10 @@
 	<script src="../../../../node_modules/@dojo/loader/loader.js"></script>
 </head>
 <body>
-<test-button id="testButton-2" label="world" suffix="hello"></test-button>
-<test-button id="testButton" label="hello" suffix="world"></test-button>
+<test-button id="testButton-2" label="world" labelsuffix="hello"></test-button>
+<test-button id="testButton" label="hello" labelsuffix="  world   "></test-button>
 
-<no-attributes id="noAttributes" label="hello" suffix="world"></no-attributes>
+<no-attributes id="noAttributes" label="hello" labelsuffix="world"></no-attributes>
 <child-wrapper id="parent-element">
 	<child-wrapper id="nested-parent">
 		<div>nested child</div>

--- a/tests/functional/decorators/customElement.html
+++ b/tests/functional/decorators/customElement.html
@@ -17,11 +17,12 @@
 	</child-wrapper>
 	<div>top level child</div>
 </child-wrapper>
-
+<not-used></not-used>
 <script>
 	window.buttonClicked = false;
 	window.ready = false;
 	window.connectedEvent = false;
+	window.__dojoCustomElements__ = true;
 
 	require.config(shimAmdDependencies({
 		baseUrl: '../../../../'

--- a/tests/functional/decorators/customElement.ts
+++ b/tests/functional/decorators/customElement.ts
@@ -5,13 +5,13 @@ import customElement from '../../../src/decorators/customElement';
 
 interface TestButtonProperties extends WidgetProperties {
 	label: string;
-	suffix: string;
+	labelSuffix: string;
 	onClick: () => void;
 }
 
 @customElement<TestButtonProperties>({
 	tag: 'test-button',
-	attributes: [ 'label', 'suffix' ],
+	attributes: [ 'label', { attributeName: 'labelSuffix', value: attribute => attribute && attribute.trim() } ],
 	events: [ 'onClick' ]
 })
 @customElement<TestButtonProperties>({
@@ -26,12 +26,12 @@ export class TestButton extends WidgetBase<TestButtonProperties> {
 
 	render(this: TestButton) {
 		const { onClick : onclick } = this;
-		const { label = '', suffix = '' } = this.properties;
+		const { label = '', labelSuffix = '' } = this.properties;
 
 		return v('button', {
 			onclick
 		}, [
-			label + ((suffix !== '') ? (' ' + suffix) : '')
+			label + ((labelSuffix !== '') ? (' ' + labelSuffix) : '')
 		]);
 	}
 }

--- a/tests/functional/decorators/customElement.ts
+++ b/tests/functional/decorators/customElement.ts
@@ -11,7 +11,7 @@ interface TestButtonProperties extends WidgetProperties {
 
 @customElement<TestButtonProperties>({
 	tag: 'test-button',
-	attributes: [ 'label', { attributeName: 'labelSuffix', value: attribute => attribute && attribute.trim() } ],
+	attributes: [ 'label', 'labelSuffix' ],
 	events: [ 'onClick' ]
 })
 @customElement<TestButtonProperties>({

--- a/tests/functional/decorators/noCustomElement.html
+++ b/tests/functional/decorators/noCustomElement.html
@@ -7,10 +7,10 @@
 	<script src="../../../../node_modules/@dojo/loader/loader.js"></script>
 </head>
 <body>
-<test-button id="testButton-2" label="world" suffix="hello"></test-button>
-<test-button id="testButton" label="hello" suffix="world"></test-button>
+<test-button id="testButton-2" label="world" labelsuffix="hello"></test-button>
+<test-button id="testButton" label="hello" labelsuffix="world"></test-button>
 
-<no-attributes id="noAttributes" label="hello" suffix="world"></no-attributes>
+<no-attributes id="noAttributes" label="hello" labelsuffix="world"></no-attributes>
 <child-wrapper id="parent-element">
 	<child-wrapper id="nested-parent">
 		<div>nested child</div>

--- a/tests/functional/decorators/noCustomElement.html
+++ b/tests/functional/decorators/noCustomElement.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<script src="../../../../node_modules/@dojo/shim/util/amd.js"></script>
+	<script src="../../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+	<script src="../../../../node_modules/@webcomponents/custom-elements/src/native-shim.js"></script>
+	<script src="../../../../node_modules/@dojo/loader/loader.js"></script>
+</head>
+<body>
+<test-button id="testButton-2" label="world" suffix="hello"></test-button>
+<test-button id="testButton" label="hello" suffix="world"></test-button>
+
+<no-attributes id="noAttributes" label="hello" suffix="world"></no-attributes>
+<child-wrapper id="parent-element">
+	<child-wrapper id="nested-parent">
+		<div>nested child</div>
+	</child-wrapper>
+	<div>top level child</div>
+</child-wrapper>
+<not-used></not-used>
+<script>
+	window.buttonClicked = false;
+	window.ready = false;
+	window.connectedEvent = false;
+
+	require.config(shimAmdDependencies({
+		baseUrl: '../../../../'
+	}));
+
+	document.getElementById('testButton').addEventListener('connected', function() {
+		window.connectedEvent = true;
+	});
+
+	require(['@dojo/shim/main'], function() {
+		require(['_build/tests/functional/decorators/customElement'], function () {
+			window.ready = true;
+		});
+	});
+</script>
+</body>
+</html>
+

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -30,7 +30,7 @@ function createFakeElement(attributes: any, descriptor: CustomElementDescriptor)
 		getDescriptor: () => descriptor,
 		children: [],
 		getAttribute(name: string) {
-			return attributes[ name ] || null;
+			return attributes[name] || null;
 		},
 		dispatchEvent(event: Event) {
 			events.push(event);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates the custom element decorator so that it only registers the element if `__dojoCustomElements__` is defined. Also fixes some issues with the simplified attribute configuration.
