### PR TITLE
Remove dependency on chai and use what comes with Intern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.4.0",
+  "version": "0.4.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@dojo/core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-boiwQHfV7idOZfZnDzgLrofS2LA7ELGKjd6tl0/hLBunJ3psozAd4CpNcT7XC00/OPYFIxVHFEpI+FZNlpUgfw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-SnmiQcbPUqtjzy1sOmkLvg3C6UFUaXDNUNqHzGaF2QM1Ebp1Lw+j+BE+E6uJgxISlgckjAZ6myjwFI+obZ316w==",
       "dev": true
     },
     "@dojo/has": {
@@ -32,55 +32,44 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.1.0.tgz",
-      "integrity": "sha512-008RP8DB175ib26dde7wQWFiYIbSACFaArLdLHYdY/cQLN9s3yVj2Gtp5C/9YoY3Ziy9wA241myOjy6QcVHcWw==",
-      "dev": true
-    },
-    "@theintern/digdug": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.3.tgz",
-      "integrity": "sha512-H+XhQeuspFrFgZCn2+rTF0qzmCc6IR2hAW4xCDLUv+20VdMowRQrIwJCYW/nk/YynqKz/p041KNeENajVF5CFg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
+      "integrity": "sha512-DzpD1D90D1vsHuqPqGb78JFfykf0Nvbel+iAupYVPEwq+LVxAZPDC8nGZRsAaVfWSsFLuKPcbRRIInf+emCFAw==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.1.0",
+        "intersection-observer": "0.4.3",
+        "pepjs": "0.4.3",
+        "tslib": "1.8.0"
+      }
+    },
+    "@theintern/digdug": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.4.tgz",
+      "integrity": "sha512-BTcYNMxOnGlTEaOYqab9WygE2sLz9ZRWRsuTwUttceewzEDn/Ok/4lWdIgwwX+bb3MybvFPU1wBkq8Co+Bfqyw==",
+      "dev": true,
+      "requires": {
+        "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.1.0",
-        "@dojo/shim": "0.1.0",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
         "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "@dojo/interfaces": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.1.0.tgz",
-          "integrity": "sha512-rpBALDc5Ya/+JrlyFvrt7wKGdGA1xq2gSFGce6j3L9meB8tAFYQvs/bx9DDp+CSdpEzzeVZWr8C4FpoUId2New==",
-          "dev": true
-        }
       }
     },
     "@theintern/leadfoot": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.2.tgz",
-      "integrity": "sha512-WHDp40qrM5BgBHFfeVfdOVVqHV1vCnJeDMobChfD7CYMqW2UHGjsJDgNRW3+xZr/Tek1IsHvfwt+t29iEdNrOg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.3.tgz",
+      "integrity": "sha512-J9wLAMjAU+Wyv5jGmHdVN4xnuyaD24kK7mAoLUPBLRNxflkJoTo9Ph5g4BKUHp+xpKd/IMU00ulgMMf++Xqm4A==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.1.0",
+        "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.1.0",
-        "@dojo/shim": "0.1.0",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
         "tslib": "1.8.0"
-      },
-      "dependencies": {
-        "@dojo/interfaces": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.1.0.tgz",
-          "integrity": "sha512-rpBALDc5Ya/+JrlyFvrt7wKGdGA1xq2gSFGce6j3L9meB8tAFYQvs/bx9DDp+CSdpEzzeVZWr8C4FpoUId2New==",
-          "dev": true
-        }
       }
     },
     "@types/babel-types": {
@@ -102,13 +91,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/chai": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.35.tgz",
-      "integrity": "sha1-6NZfg0ktKUT4FvxiB0GCHCioyQA=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
+      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
       "dev": true
     },
     "@types/charm": {
@@ -117,13 +106,19 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/diff": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -143,7 +138,7 @@
       "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/fs-extra": {
@@ -152,7 +147,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/glob": {
@@ -162,7 +157,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/grunt": {
@@ -171,7 +166,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/handlebars": {
@@ -257,7 +252,7 @@
       "dev": true,
       "requires": {
         "@types/jquery": "3.2.16",
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/jszip": {
@@ -267,9 +262,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.86",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.86.tgz",
-      "integrity": "sha512-DIiC7xZkI+iqwb6A28+JDfrioxcFRHAUXl+AEZ9lULQppiArWRfex4ugVUAJKZHxcgqZJ1w2de2DTahVyrEp4Q==",
+      "version": "4.14.87",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
+      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
       "dev": true
     },
     "@types/marked": {
@@ -297,10 +292,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==",
-      "dev": true
+      "version": "8.0.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.54.tgz",
+      "integrity": "sha512-qetMdTv3Ytz9u9ESLdcYs45LPI0mczYZIbC184n7kY0jczOqPNQsabBfVCh+na3B2shAfvC459JqHV771A8Rxg==",
+      "dev": true,
+      "requires": {
+        "@types/events": "1.1.0"
+      }
     },
     "@types/platform": {
       "version": "1.3.1",
@@ -320,7 +318,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/selenium-webdriver": {
@@ -351,7 +349,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/sinon": {
@@ -384,7 +382,7 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.54"
       }
     },
     "@types/yargs": {
@@ -461,9 +459,9 @@
       }
     },
     "ajv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
-      "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -734,7 +732,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000775",
+        "caniuse-db": "1.0.30000778",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1058,9 +1056,9 @@
       "dev": true
     },
     "boxen": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
-      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
@@ -1069,7 +1067,7 @@
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
-        "widest-line": "1.0.0"
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1142,8 +1140,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000775",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-db": "1.0.30000778",
+        "electron-to-chromium": "1.3.28"
       }
     },
     "buffer": {
@@ -1198,15 +1196,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000775",
+        "caniuse-db": "1.0.30000778",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000775",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000775.tgz",
-      "integrity": "sha1-BLzN0CFO3yW5f2GglmCfetaQQzM=",
+      "version": "1.0.30000778",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
+      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2394,9 +2392,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
     "emojis-list": {
@@ -3250,7 +3248,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.2",
+        "intern": "4.1.3",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -3566,7 +3564,7 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.1",
         "har-schema": "2.0.0"
       }
     },
@@ -3786,19 +3784,19 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.2.tgz",
-      "integrity": "sha512-R4hJ+PUkp733rVtq5ndIlVmYS5JDLjueYR0vJq1OHwOFoQv2fMcIZMdNGyZh2KbNa4PlTeZOA4934tF7Tkc/IQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
+      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.1.0",
+        "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.1.0",
-        "@dojo/shim": "0.1.0",
-        "@theintern/digdug": "2.0.3",
-        "@theintern/leadfoot": "2.0.2",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
+        "@theintern/digdug": "2.0.4",
+        "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.6",
+        "@types/chai": "4.0.8",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3809,7 +3807,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.86",
+        "@types/lodash": "4.14.87",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3843,18 +3841,6 @@
         "ws": "2.3.1"
       },
       "dependencies": {
-        "@dojo/interfaces": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.1.0.tgz",
-          "integrity": "sha512-rpBALDc5Ya/+JrlyFvrt7wKGdGA1xq2gSFGce6j3L9meB8tAFYQvs/bx9DDp+CSdpEzzeVZWr8C4FpoUId2New==",
-          "dev": true
-        },
-        "@types/chai": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.6.tgz",
-          "integrity": "sha512-IzRWv/7IpaMm41KLLJcaaD/UKit/MrHu4rWs61oWiVjuk4aKWe2eopx3XyhAHhSnMyB5EeCMRr2AsJtuQ8COWA==",
-          "dev": true
-        },
         "body-parser": {
           "version": "1.17.2",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
@@ -4922,9 +4908,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -7460,6 +7446,27 @@
           "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
         },
+        "boxen": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
+          "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+          "dev": true,
+          "requires": {
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.3.0",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "1.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
@@ -7498,6 +7505,15 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
           }
         },
         "jsonfile": {
@@ -7558,6 +7574,28 @@
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "widest-line": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+          "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
           }
         }
       }
@@ -9467,7 +9505,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.86",
+        "@types/lodash": "4.14.87",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -9475,7 +9513,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.6",
+        "marked": "0.3.7",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -9705,7 +9743,7 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.2.2",
+        "boxen": "1.3.0",
         "chalk": "2.3.0",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
@@ -9972,34 +10010,12 @@
       "dev": true
     },
     "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        }
+        "string-width": "2.1.1"
       }
     },
     "window-size": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@dojo/interfaces": "~0.2.0",
     "@dojo/loader": "~0.1.1",
-    "@types/chai": "3.4.*",
     "@types/glob": "5.0.*",
     "@types/grunt": "0.4.*",
     "@types/jsdom": "2.0.*",

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -75,7 +75,7 @@ describe('WidgetBase', () => {
 		const renderResult = widget.render() as HNode;
 		assert.strictEqual(renderResult.tag, 'div');
 		assert.deepEqual(renderResult.properties, {});
-		assert.lengthOf(renderResult.children, 1);
+		assert.lengthOf(renderResult.children!, 1);
 		assert.strictEqual(renderResult.children![0], 'child');
 	});
 
@@ -110,7 +110,7 @@ describe('WidgetBase', () => {
 			const widget = new TestWidget();
 			const renderResult = widget.__render__() as HNode;
 			assert.strictEqual(renderResult.tag, 'my-app');
-			assert.lengthOf(renderResult.children, 1);
+			assert.lengthOf(renderResult.children!, 1);
 			assert.strictEqual(renderResult.children![0], 'child');
 		});
 	});
@@ -259,7 +259,7 @@ describe('WidgetBase', () => {
 			const invalidateSpy = spy(widget, 'invalidate');
 			widget.__setCoreProperties__({ bind: widget, baseRegistry });
 			assert.isTrue(invalidateSpy.calledOnce);
-			assert.strictEqual(widget.registry.getInjector('label'), 'item');
+			assert.strictEqual(widget.registry.getInjector('label'), 'item' as any);
 		});
 
 		it('The same baseRegistry does not causes an invalidation', () => {
@@ -279,7 +279,7 @@ describe('WidgetBase', () => {
 			assert.isNull(widget.registry.getInjector('label'));
 			const invalidateSpy = spy(widget, 'invalidate');
 			widget.__setCoreProperties__({ bind: widget, baseRegistry });
-			assert.strictEqual(widget.registry.getInjector('label'), 'item');
+			assert.strictEqual(widget.registry.getInjector('label'), 'item' as any);
 			assert.isTrue(invalidateSpy.called);
 		});
 	});

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -356,7 +356,7 @@ registerSuite('customElements', {
 		sendEvent(div, 'connected');
 		assert.isTrue(invalidateSpy.calledOnce);
 		widget.__render__() as InternalHNode;
-		assert.deepEqual(widgetInstance.properties, { key: 'root', foo: 'bar' });
+		assert.deepEqual(widgetInstance.properties, { key: 'root', foo: 'bar' } as any);
 	},
 
 	'initialization': {

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -52,7 +52,7 @@ registerSuite('d', {
 
 			assert.equal(dNode.type, WNODE);
 			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
-			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]} as any);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
 		},
@@ -91,7 +91,7 @@ registerSuite('d', {
 
 			assert.equal(dNode.type, WNODE);
 			assert.deepEqual(dNode.widgetConstructor, 'my-widget');
-			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]} as any);
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
@@ -103,7 +103,7 @@ registerSuite('d', {
 			const dNode = w(symbolLabel, properties, [ w(WidgetBase, properties) ]);
 			assert.equal(dNode.type, WNODE);
 			assert.strictEqual(dNode.widgetConstructor, symbolLabel);
-			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]} as any);
 			assert.lengthOf(dNode.children, 1);
 			assert.isTrue(isWNode(dNode));
 			assert.isFalse(isHNode(dNode));
@@ -120,21 +120,21 @@ registerSuite('d', {
 		},
 		'create HNode wrapper with children'() {
 			const hNode = v('div', {}, [ v('div'), v('div') ]);
-			assert.lengthOf(hNode.children, 2);
+			assert.lengthOf(hNode.children!, 2);
 			assert.equal(hNode.type, HNODE);
 			assert.isTrue(isHNode(hNode));
 			assert.isFalse(isWNode(hNode));
 		},
 		'create HNode wrapper with children as options param'() {
 			const hNode = v('div', [ v('div'), v('div') ]);
-			assert.lengthOf(hNode.children, 2);
+			assert.lengthOf(hNode.children!, 2);
 			assert.equal(hNode.type, HNODE);
 			assert.isTrue(isHNode(hNode));
 			assert.isFalse(isWNode(hNode));
 		},
 		'create HNode wrapper with text node children'() {
 			const hNode = v('div', {}, [ 'This Text Node', 'That Text Node' ]);
-			assert.lengthOf(hNode.children, 2);
+			assert.lengthOf(hNode.children!, 2);
 			assert.equal(hNode.type, HNODE);
 			assert.isTrue(isHNode(hNode));
 			assert.isFalse(isWNode(hNode));

--- a/tests/unit/tsx.ts
+++ b/tests/unit/tsx.ts
@@ -26,14 +26,14 @@ registerSuite('tsx', {
 		'tsx generate a WNode'() {
 			const node: WNode = tsx(WidgetBase, { hello: 'world' }, [ 'child' ]) as WNode;
 			assert.deepEqual(node.widgetConstructor, WidgetBase);
-			assert.deepEqual(node.properties, { hello: 'world' });
+			assert.deepEqual(node.properties, { hello: 'world' } as any);
 			assert.deepEqual(node.children, [ 'child' ]);
 		},
 		'tsx generate a WNode from a RegistryWrapper'() {
 			const RegistryWrapper = fromRegistry<WidgetProperties>('tag');
 			const node: WNode = tsx(RegistryWrapper, { hello: 'world' }, [ 'child' ]) as WNode;
 			assert.deepEqual(node.widgetConstructor, 'tag');
-			assert.deepEqual(node.properties, { hello: 'world' });
+			assert.deepEqual(node.properties, { hello: 'world' } as any);
 			assert.deepEqual(node.children, [ 'child' ]);
 		},
 		'children arrays are spread correctly'() {

--- a/tests/unit/tsxIntegration.tsx
+++ b/tests/unit/tsxIntegration.tsx
@@ -39,7 +39,7 @@ registerSuite('tsx integration', {
 		bar.__setCoreProperties__({ bind: bar, baseRegistry: registry });
 		bar.__setProperties__({ registry });
 		const barRender = bar.__render__() as WNode;
-		assert.deepEqual(barRender.properties, { hello: 'world' });
+		assert.deepEqual(barRender.properties, { hello: 'world' } as any);
 		assert.strictEqual(barRender.widgetConstructor, Foo);
 		assert.lengthOf(barRender.children, 0);
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Intern now uses the new typings for chai which conflict with the pinned ones.