### PR TITLE
Reset Render state if widget is not considered dirty during setProperties

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -271,6 +271,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		if (this._changedPropertyKeys.length > 0) {
 			this.invalidate();
 		}
+		else {
+			this._renderState = WidgetRenderState.IDLE;
+		}
 	}
 
 	public get children(): (C | null)[] {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Reset the render state to IDLE if there are no properties considered "changed" during diffing.

Resolves #796 
