### PR TITLE
Ensure that meta and registry resources are torn down when a widget is detached

### DIFF
--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -13,16 +13,26 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 	private _registry = new Registry();
 	private _registryWidgetLabelMap: Map<Registry, RegistryLabel[]> = new Map();
 	private _registryInjectorLabelMap: Map<Registry, RegistryLabel[]> = new Map();
-	protected baseRegistry: Registry;
+	protected baseRegistry?: Registry;
 
 	constructor() {
 		super();
 		this.own(this._registry);
+		const destroy = () => {
+			if (this.baseRegistry) {
+				this._registryWidgetLabelMap.delete(this.baseRegistry);
+				this._registryInjectorLabelMap.delete(this.baseRegistry);
+				this.baseRegistry = undefined;
+			}
+		};
+		this.own({ destroy });
 	}
 
 	public set base(baseRegistry: Registry) {
-		this._registryWidgetLabelMap.delete(this.baseRegistry);
-		this._registryInjectorLabelMap.delete(this.baseRegistry);
+		if (this.baseRegistry) {
+			this._registryWidgetLabelMap.delete(this.baseRegistry);
+			this._registryInjectorLabelMap.delete(this.baseRegistry);
+		}
 		this.baseRegistry = baseRegistry;
 	}
 
@@ -35,11 +45,11 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 	}
 
 	public has(label: RegistryLabel): boolean {
-		return this._registry.has(label) || this.baseRegistry.has(label);
+		return this._registry.has(label) || Boolean(this.baseRegistry && this.baseRegistry.has(label));
 	}
 
 	public hasInjector(label: RegistryLabel): boolean {
-		return this._registry.hasInjector(label) || this.baseRegistry.hasInjector(label);
+		return this._registry.hasInjector(label) || Boolean(this.baseRegistry && this.baseRegistry.hasInjector(label));
 	}
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel, globalPrecedence: boolean = false): Constructor<T> | null {

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -11,9 +11,9 @@ export interface RegistryHandlerEventMap {
 
 export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 	private _registry = new Registry();
-	private _baseRegistry: Registry;
 	private _registryWidgetLabelMap: Map<Registry, RegistryLabel[]> = new Map();
 	private _registryInjectorLabelMap: Map<Registry, RegistryLabel[]> = new Map();
+	protected baseRegistry: Registry;
 
 	constructor() {
 		super();
@@ -21,9 +21,9 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 	}
 
 	public set base(baseRegistry: Registry) {
-		this._registryWidgetLabelMap.delete(this._baseRegistry);
-		this._registryInjectorLabelMap.delete(this._baseRegistry);
-		this._baseRegistry = baseRegistry;
+		this._registryWidgetLabelMap.delete(this.baseRegistry);
+		this._registryInjectorLabelMap.delete(this.baseRegistry);
+		this.baseRegistry = baseRegistry;
 	}
 
 	public define(label: RegistryLabel, widget: RegistryItem): void {
@@ -35,11 +35,11 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 	}
 
 	public has(label: RegistryLabel): boolean {
-		return this._registry.has(label) || this._baseRegistry.has(label);
+		return this._registry.has(label) || this.baseRegistry.has(label);
 	}
 
 	public hasInjector(label: RegistryLabel): boolean {
-		return this._registry.hasInjector(label) || this._baseRegistry.hasInjector(label);
+		return this._registry.hasInjector(label) || this.baseRegistry.hasInjector(label);
 	}
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel, globalPrecedence: boolean = false): Constructor<T> | null {
@@ -51,7 +51,7 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 	}
 
 	private _get(label: RegistryLabel, globalPrecedence: boolean, getFunctionName: 'getInjector' | 'get', labelMap: Map<Registry, RegistryLabel[]>): any {
-		const registries = globalPrecedence ? [ this._baseRegistry, this._registry ] : [ this._registry, this._baseRegistry ];
+		const registries = globalPrecedence ? [ this.baseRegistry, this._registry ] : [ this._registry, this.baseRegistry ];
 		for (let i = 0; i < registries.length; i++) {
 			const registry: any = registries[i];
 			if (!registry) {

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -118,6 +118,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			},
 			onDetach: (): void => {
 				this.onDetach();
+				this._destroy();
 			},
 			nodeHandler: this._nodeHandler,
 			registry: () => {
@@ -371,6 +372,20 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		}
 
 		return allDecorators;
+	}
+
+	/**
+	 * Destroys private resources for WidgetBase
+	 */
+	private _destroy() {
+		if (this._registry) {
+			this._registry.destroy();
+		}
+		if (this._metaMap !== undefined) {
+			this._metaMap.forEach((meta) => {
+				meta.destroy();
+			});
+		}
 	}
 
 	/**

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -37,6 +37,21 @@ registerSuite('RegistryHandler', {
 				assert.isTrue(registryHandler.has(bar));
 			}
 		},
+		destroy: {
+			'destroying the registry handler clears base registry'() {
+				const registry = new Registry();
+				class TestRegistryHandler extends RegistryHandler {
+					getBaseRegistry() {
+						return this.baseRegistry;
+					}
+				}
+				const registryHandler = new TestRegistryHandler();
+				registryHandler.base = registry;
+				return registryHandler.destroy().then(() => {
+					assert.isUndefined(registryHandler.getBaseRegistry());
+				});
+			}
+		},
 		get: {
 			base() {
 				const registryHandler = new RegistryHandler();

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -189,10 +189,6 @@ describe('WidgetBase', () => {
 			assert.isUndefined(widget.properties.foobar);
 		});
 
-		it('Runs registered reactions when property is considered changed', () => {
-
-		});
-
 		it('Automatically binds functions properties', () => {
 			class TestWidget extends BaseTestWidget {
 				public called = false;
@@ -282,6 +278,16 @@ describe('WidgetBase', () => {
 			assert.strictEqual(widget.registry.getInjector('label'), 'item' as any);
 			assert.isTrue(invalidateSpy.called);
 		});
+	});
+
+	it('destroys registry when WidgetBase is detached', () => {
+		const widget = new BaseTestWidget();
+		const registry = widget.registry;
+		const instanceData = widgetInstanceMap.get(widget)!;
+		instanceData.onDetach();
+		assert.throws(() => {
+			registry.own({ destroy() {} });
+		}, 'Call made to destroyed method');
 	});
 
 	describe('meta', () => {

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -330,6 +330,22 @@ describe('WidgetBase', () => {
 			instanceData.nodeHandler.addRoot();
 			assert.isTrue(meta.widgetEvent);
 		});
+
+		it('Meta is destroyed when the widget is detached', () => {
+			let metaDestroyed = false;
+			class DestroyableMeta extends TestMeta {
+				destroy() {
+					const result = super.destroy();
+					metaDestroyed = true;
+					return result;
+				}
+			}
+			const widget = new BaseTestWidget();
+			widget.meta(DestroyableMeta);
+			const instanceData = widgetInstanceMap.get(widget)!;
+			instanceData.onDetach();
+			assert.isTrue(metaDestroyed);
+		});
 	});
 
 	describe('decorators', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Internal resources; registryHandler and associated meta instances for a WidgetBase instance need to be torn down when it is detached.

Resolves #799 
