### PR TITLE
652 - Registry decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,16 +703,51 @@ class MyWidget extends WidgetBase {
             const LoadingWidget = this.registry.get('loading', true);
             return w(LoadingWidget, {});
         }
-        return w(MyActualChildWidget, {};)
+        return w(MyActualChildWidget, {});
+    }
+}
+```
+
+#### Registry Decorator
+
+A registry decorator is provided to make adding widgets to a local registry easier. The decorator can take a single registry entry or an object containing multiple entries.
+
+```ts
+// single entry
+@registry('loading', LoadingWidget)
+class MyWidget extends WidgetBase {
+    render() {
+        if (this.properties) {
+            const LoadingWidget = this.registry.get('loading', true);
+            return w(LoadingWidget, {});
+        }
+        return w(MyActualChildWidget, {});
+    }
+}
+
+// multiple entries
+@registry({
+    'loading': LoadingWidget,
+    'heading': () => import('./HeadingWidget')
+})
+class MyWidget extends WidgetBase {
+    render() {
+        if (this.properties) {
+            const LoadingWidget = this.registry.get('loading', true);
+            return w(LoadingWidget, {});
+        }
+        return w(MyActualChildWidget, {}, [
+            w('heading', {})
+        ]);
     }
 }
 ```
 
 ### Decorator Lifecycle Hooks
 
-Occasionally, in a mixin or a widget class, it my be required to provide logic that needs to be executed before properties are diffed using `beforeProperties` or either side of a widget's `render` call using `beforeRender` & `afterRender`.
+Occasionally, in a mixin or a widget class, it my be required to provide logic that needs to be executed before properties are diffed using `beforeProperties`, either side of a widget's `render` call using `beforeRender` & `afterRender` or after a constructor using `afterContructor`.
 
-This functionality is provided by the `beforeProperties`, `beforeRender` and `afterRender` decorators that can be found in the `decorators` directory.
+This functionality is provided by the `beforeProperties`, `beforeRender`, `afterRender` and `afterConstructor` decorators that can be found in the `decorators` directory.
 
 ***Note:*** All lifecycle functions are executed in the order that they are specified from the super class up to the final class.
 
@@ -771,6 +806,10 @@ class MyBaseClass extends WidgetBase<WidgetProperties> {
     }
 }
 ```
+
+##### AfterConstructor
+
+The `afterConstructor` lifecycle hook does not receive any params and is ran after the `WidgetBase` constructor code. It is currently used in the `registry decorator` to create registry entries.
 
 ### Method Lifecycle Hooks
 

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ class MyWidget extends WidgetBase {
 
 #### Registry Decorator
 
-A registry decorator is provided to make adding widgets to a local registry easier. The decorator can take a single registry entry or an object containing multiple entries.
+A registry decorator is provided to make adding widgets to a local registry easier. The decorator can be stacked to register multiple entries.
 
 ```ts
 // single entry
@@ -726,10 +726,8 @@ class MyWidget extends WidgetBase {
 }
 
 // multiple entries
-@registry({
-    'loading': LoadingWidget,
-    'heading': () => import('./HeadingWidget')
-})
+@registry('loading', LoadingWidget)
+@registry('heading', () => import('./HeadingWidget')
 class MyWidget extends WidgetBase {
     render() {
         if (this.properties) {

--- a/README.md
+++ b/README.md
@@ -692,6 +692,8 @@ In some scenarios, it might be desirable to allow the `baseRegistry` to override
 
 The following example sets a default loading indicator widget, but passes `true` when getting the widget from the `registry`. This allows a consumer to register an overriding loading indicator in the `baseRegistry`.
 
+The Registry will automatically detect and handle widget constructors as default exports for imported esModules for you.
+
 ```ts
 class MyWidget extends WidgetBase {
     constructor() {

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -185,11 +185,7 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 	}
 
 	private _ctorIsDefaultExport<T>(module: WidgetBaseConstructor | ESMDefaultWidgetBase<T>): boolean {
-		// __esModule
-		// Object.default
-		// default is widgetbase consructor: isWidgetBaseConstructor
-
-		return (module.hasOwnProperty('__esModule') &&
+		return (module && module.hasOwnProperty('__esModule') &&
 			module.hasOwnProperty('default') &&
 			isWidgetBaseConstructor((module as ESMDefaultWidgetBase<T>).default));
 	}

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -89,6 +89,15 @@ export interface ESMDefaultWidgetBase<T> {
 	__esModule: boolean;
 }
 
+export function isWidgetConstructorDefaultExport<T>(item: any): item is ESMDefaultWidgetBase <T> {
+	return Boolean(
+		item &&
+		item.hasOwnProperty('__esModule') &&
+		item.hasOwnProperty('default') &&
+		isWidgetBaseConstructor(item.default)
+	);
+}
+
 /**
  * The Registry implementation
  */
@@ -170,8 +179,8 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 
 		promise.then((widgetCtor) => {
 
-			if (this._ctorIsDefaultExport<T>(widgetCtor)) {
-				widgetCtor = ((widgetCtor as any) as ESMDefaultWidgetBase<T>).default;
+			if (isWidgetConstructorDefaultExport<T>(widgetCtor)) {
+				widgetCtor = widgetCtor.default;
 			}
 
 			this._widgetRegistry.set(label, widgetCtor);
@@ -182,12 +191,6 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 		});
 
 		return null;
-	}
-
-	private _ctorIsDefaultExport<T>(module: WidgetBaseConstructor | ESMDefaultWidgetBase<T>): boolean {
-		return (module && module.hasOwnProperty('__esModule') &&
-			module.hasOwnProperty('default') &&
-			isWidgetBaseConstructor((module as ESMDefaultWidgetBase<T>).default));
 	}
 
 	public getInjector<T extends Injector>(label: RegistryLabel): T | null {

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -89,7 +89,7 @@ export interface ESMDefaultWidgetBase<T> {
 	__esModule: boolean;
 }
 
-export function isWidgetConstructorDefaultExport<T>(item: any): item is ESMDefaultWidgetBase <T> {
+export function isWidgetConstructorDefaultExport<T>(item: any): item is ESMDefaultWidgetBase<T> {
 	return Boolean(
 		item &&
 		item.hasOwnProperty('__esModule') &&

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -518,7 +518,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	}
 
 	private _runAfterConstructors(): void {
-		const afterConstructors = this.getDecorator('constructor');
+		const afterConstructors = this.getDecorator('afterConstructor');
 
 		if (afterConstructors.length > 0) {
 			afterConstructors.forEach(afterConstructor => afterConstructor.call(this));

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -127,6 +127,8 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 			coreProperties: {} as CoreProperties,
 			invalidate: this._boundInvalidate
 		});
+
+		this._runAfterConstructors();
 	}
 
 	protected meta<T extends WidgetMetaBase>(MetaType: WidgetMetaConstructor<T>): T {
@@ -513,6 +515,14 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		}
 
 		return dNode;
+	}
+
+	private _runAfterConstructors(): void {
+		const afterConstructors = this.getDecorator('constructor');
+
+		if (afterConstructors.length > 0) {
+			afterConstructors.forEach(afterConstructor => afterConstructor.call(this));
+		}
 	}
 }
 

--- a/src/decorators/handleDecorator.ts
+++ b/src/decorators/handleDecorator.ts
@@ -1,10 +1,12 @@
+export type DecoratorHandler = (target: any, propertyKey?: string) => void;
+
 /**
  * Generic decorator handler to take care of whether or not the decorator was called at the class level
  * or the method level.
  *
  * @param handler
  */
-export function handleDecorator(handler: (target: any, propertyKey?: string) => void) {
+export function handleDecorator(handler: DecoratorHandler) {
 	return function (target: any, propertyKey?: string, descriptor?: PropertyDescriptor) {
 		if (typeof target === 'function') {
 			handler(target.prototype, undefined);

--- a/src/decorators/registry.ts
+++ b/src/decorators/registry.ts
@@ -1,12 +1,22 @@
 import { handleDecorator } from './handleDecorator';
 
+export interface RegistryConfig {
+	[ name: string ]: () => Promise<any>;
+}
+
 /**
  * Decorator that can be used to register a widget with the registry
  */
-export function registry(name: string, loader: any) {
+export function registry(nameOrConfig: string | RegistryConfig, loader?: () => Promise<any>) {
 	return handleDecorator((target, propertyKey) => {
 		target.addDecorator('constructor', function(this: any) {
-			this.registry.define(name, loader);
+			if (typeof nameOrConfig === 'string') {
+				this.registry.define(nameOrConfig, loader);
+			} else {
+				Object.keys(nameOrConfig).forEach(name => {
+					this.registry.define(name, nameOrConfig[name]);
+				});
+			}
 		});
 	});
 }

--- a/src/decorators/registry.ts
+++ b/src/decorators/registry.ts
@@ -1,0 +1,14 @@
+import { handleDecorator } from './handleDecorator';
+
+/**
+ * Decorator that can be used to register a widget with the registry
+ */
+export function registry(name: string, loader: any) {
+	return handleDecorator((target, propertyKey) => {
+		target.addDecorator('constructor', () => {
+			target.registry.define(name, loader);
+		});
+	});
+}
+
+export default registry;

--- a/src/decorators/registry.ts
+++ b/src/decorators/registry.ts
@@ -1,20 +1,22 @@
-import { handleDecorator } from './handleDecorator';
+import { handleDecorator, DecoratorHandler } from './handleDecorator';
 import { RegistryItem } from '../Registry';
 
 export interface RegistryConfig {
-	[ name: string ]: RegistryItem;
+	[name: string]: RegistryItem;
 }
 
 /**
- * Decorator that can be used to register a widget with the registry
+ * Decorator that can be used to register a widget with the calling widgets local registry
  */
+export function registry(nameOrConfig: string, loader: RegistryItem): DecoratorHandler;
+export function registry(nameOrConfig: RegistryConfig): DecoratorHandler;
 export function registry(nameOrConfig: string | RegistryConfig, loader?: RegistryItem) {
 	return handleDecorator((target, propertyKey) => {
-		target.addDecorator('constructor', function(this: any) {
+		target.addDecorator('afterConstructor', function(this: any) {
 			if (typeof nameOrConfig === 'string') {
 				this.registry.define(nameOrConfig, loader);
 			} else {
-				Object.keys(nameOrConfig).forEach(name => {
+				Object.keys(nameOrConfig).forEach((name) => {
 					this.registry.define(name, nameOrConfig[name]);
 				});
 			}

--- a/src/decorators/registry.ts
+++ b/src/decorators/registry.ts
@@ -5,8 +5,8 @@ import { handleDecorator } from './handleDecorator';
  */
 export function registry(name: string, loader: any) {
 	return handleDecorator((target, propertyKey) => {
-		target.addDecorator('constructor', () => {
-			target.registry.define(name, loader);
+		target.addDecorator('constructor', function(this: any) {
+			this.registry.define(name, loader);
 		});
 	});
 }

--- a/src/decorators/registry.ts
+++ b/src/decorators/registry.ts
@@ -1,13 +1,14 @@
 import { handleDecorator } from './handleDecorator';
+import { RegistryItem } from '../Registry';
 
 export interface RegistryConfig {
-	[ name: string ]: () => Promise<any>;
+	[ name: string ]: RegistryItem;
 }
 
 /**
  * Decorator that can be used to register a widget with the registry
  */
-export function registry(nameOrConfig: string | RegistryConfig, loader?: () => Promise<any>) {
+export function registry(nameOrConfig: string | RegistryConfig, loader?: RegistryItem) {
 	return handleDecorator((target, propertyKey) => {
 		target.addDecorator('constructor', function(this: any) {
 			if (typeof nameOrConfig === 'string') {

--- a/tests/unit/Registry.ts
+++ b/tests/unit/Registry.ts
@@ -1,6 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import Registry from './../../src/Registry';
+import Registry, { ESMDefaultWidgetBase } from './../../src/Registry';
 import { WidgetBase } from './../../src/WidgetBase';
 import Promise from '@dojo/shim/Promise';
 import { Injector } from './../../src/Injector';
@@ -146,6 +146,27 @@ registerSuite('Registry', {
 				rejectFunction!(new Error('reject error'));
 
 				return promise;
+			},
+			'recognises esm modules with widget constructor as default'() {
+				let resolveFunction: (widget: ESMDefaultWidgetBase<WidgetBase>) => void;
+				const promise: Promise<any> = new Promise((resolve) => {
+					resolveFunction = resolve;
+				});
+				const lazyFactory = () => promise;
+
+				const factoryRegistry = new Registry();
+				factoryRegistry.define('my-widget', lazyFactory);
+				factoryRegistry.get('my-widget');
+
+				resolveFunction!({
+					default: WidgetBase,
+					__esModule: true
+				});
+
+				return promise.then(() => {
+					const factory = factoryRegistry.get('my-widget');
+					assert.strictEqual(factory, WidgetBase);
+				});
 			}
 		}
 	},

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -3,3 +3,4 @@ import './beforeProperties';
 import './beforeRender';
 import './diffProperty';
 import './inject';
+import './registry';

--- a/tests/unit/decorators/registry.ts
+++ b/tests/unit/decorators/registry.ts
@@ -1,0 +1,62 @@
+const { describe, it } = intern.getInterface('bdd');
+import { v, w } from '../../../src/d';
+const { assert } = intern.getPlugin('chai');
+
+import { registry } from './../../../src/decorators/registry';
+import { WidgetBase } from './../../../src/WidgetBase';
+import ProjectorMixin from './../../../src/mixins/Projector';
+
+export class Widget1 extends WidgetBase {
+	protected render () {
+		return v('span', { classes: ['widget1'] });
+	}
+}
+
+export class Widget2 extends WidgetBase {
+	protected render () {
+		return v('span', { classes: ['widget2'] });
+	}
+}
+
+describe('decorators/registry', () => {
+	it('should use the single entry decorator format to register reg-widget-1', () => {
+		@registry('reg-widget-1', Widget1)
+		class TestWidget1 extends WidgetBase {
+			render() {
+				return w('reg-widget-1', {});
+			}
+		}
+
+		const Projector = ProjectorMixin(TestWidget1);
+		const projector = new Projector();
+		projector.async = false;
+
+		const root = document.createElement('div');
+		projector.append(root);
+
+		assert.strictEqual(root.querySelectorAll('.widget1').length, 1);
+		assert.strictEqual(root.querySelectorAll('.widget2').length, 0);
+	});
+
+	it('should use the registry config format to register multiple widgets', () => {
+		@registry({
+			'reg-widget-1': Widget1,
+			'reg-widget-2': Widget2
+		})
+		class TestWidget2 extends WidgetBase {
+			render() {
+				return [ w('reg-widget-1', {}), w('reg-widget-2', {}) ];
+			}
+		}
+
+		const Projector = ProjectorMixin(TestWidget2);
+		const projector = new Projector();
+		projector.async = false;
+
+		const root = document.createElement('div');
+		projector.append(root);
+
+		assert.strictEqual(root.querySelectorAll('.widget1').length, 1);
+		assert.strictEqual(root.querySelectorAll('.widget2').length, 1);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Allows registry items to be defined via a decorator.
Also, `Registry` will automatically look for a widget constructor as the `default` import when an esModule is loaded.
Example:

```ts
@registry('reg-widget-1', Widget1) // single widget
class TestWidget1 extends WidgetBase {
	render() {
		return w('reg-widget-1', {}); // will render Widget1
	}
}

@registry({
	'reg-widget-1': Widget1,
	'reg-widget-2': Widget2
}) // multiple widgets
class TestWidget2 extends WidgetBase {
	render() {
		return [ w('reg-widget-1', {}), w('reg-widget-2', {}) ];
	} // will render Widget1, Widget2
}
```

Registry decorator can also accept promises the same way that the standard registry does ie.

```ts
@registry('reg-widget-1', () => import('path/to/Widget1')) // single widget
class TestWidget1 extends WidgetBase {
	render() {
		return w('reg-widget-1', {}); // will render Widget1
	}
}
```

Resolves #652 
