### PR TITLE
802 - Animation Timing Properties cast correctly

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -87,7 +87,7 @@ export type SupportedClassName = string | null | undefined;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
-export interface VirtualDomProperties {
+export interface VNodeProperties {
 	/**
 	 * The animation to perform when this node is added to an already existing parent.
 	 * When this value is a string, you must pass a `projectionOptions.transitions` object when creating the

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -87,60 +87,7 @@ export type SupportedClassName = string | null | undefined;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
-/**
- * Animation controls are used to control the web animation that has been applied
- * to a vdom node.
- */
-export interface AnimationControls {
-	play?: boolean;
-	onFinish?: () => void;
-	onCancel?: () => void;
-	reverse?: boolean;
-	cancel?: boolean;
-	finish?: boolean;
-	playbackRate?: number;
-	startTime?: number;
-	currentTime?: number;
-}
-
-export enum AnimationFill { 'none', 'forwards', 'backwards', 'both', 'auto' }
-export enum AnimationDirection { 'normal', 'reverse', 'alternate', 'alternate-reverse' }
-
-/**
- * Animation timing properties passed to a new KeyframeEffect.
- */
-export interface AnimationTimingProperties {
-	duration?: number;
-	delay?: number;
-	direction?: AnimationDirection;
-	easing?: string;
-	endDelay?: number;
-	fill?: AnimationFill;
-	iterations?: number;
-	iterationStart?: number;
-}
-
-/**
- * Animation propertiues that can be passed as vdom property `animate`
- */
-export interface AnimationProperties {
-	id: string;
-	effects: any[];
-	controls?: AnimationControls;
-	timing?: AnimationTimingProperties;
-}
-
-/**
- * Info returned by the `get` function on WebAnimation meta
- */
-export interface AnimationInfo {
-	currentTime: number;
-	playState: 'idle' | 'pending' | 'running' | 'paused' | 'finished';
-	playbackRate: number;
-	startTime: number;
-}
-
-export interface VNodeProperties {
+export interface VirtualDomProperties {
 	/**
 	 * The animation to perform when this node is added to an already existing parent.
 	 * When this value is a string, you must pass a `projectionOptions.transitions` object when creating the

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -103,16 +103,19 @@ export interface AnimationControls {
 	currentTime?: number;
 }
 
+export enum AnimationFill { 'none', 'forwards', 'backwards', 'both', 'auto' }
+export enum AnimationDirection { 'normal', 'reverse', 'alternate', 'alternate-reverse' }
+
 /**
  * Animation timing properties passed to a new KeyframeEffect.
  */
 export interface AnimationTimingProperties {
 	duration?: number;
 	delay?: number;
-	direction?: 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';
+	direction?: AnimationDirection;
 	easing?: string;
 	endDelay?: number;
-	fill?: 'none' | 'forwards' | 'backwards' | 'both' | 'auto';
+	fill?: AnimationFill;
 	iterations?: number;
 	iterationStart?: number;
 }

--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -1,8 +1,60 @@
 import 'web-animations-js/web-animations-next-lite.min';
 import { Base } from './Base';
-import { AnimationControls, AnimationProperties, AnimationInfo } from '../interfaces';
 import Map from '@dojo/shim/Map';
 import global from '@dojo/shim/global';
+
+/**
+ * Animation controls are used to control the web animation that has been applied
+ * to a vdom node.
+ */
+export interface AnimationControls {
+	play?: boolean;
+	onFinish?: () => void;
+	onCancel?: () => void;
+	reverse?: boolean;
+	cancel?: boolean;
+	finish?: boolean;
+	playbackRate?: number;
+	startTime?: number;
+	currentTime?: number;
+}
+
+export enum AnimationFill { 'none', 'forwards', 'backwards', 'both', 'auto' }
+export enum AnimationDirection { 'normal', 'reverse', 'alternate', 'alternate-reverse' }
+
+/**
+ * Animation timing properties passed to a new KeyframeEffect.
+ */
+export interface AnimationTimingProperties {
+	duration?: number;
+	delay?: number;
+	direction?: AnimationDirection;
+	easing?: string;
+	endDelay?: number;
+	fill?: AnimationFill;
+	iterations?: number;
+	iterationStart?: number;
+}
+
+/**
+ * Animation propertiues that can be passed as vdom property `animate`
+ */
+export interface AnimationProperties {
+	id: string;
+	effects: any[];
+	controls?: AnimationControls;
+	timing?: AnimationTimingProperties;
+}
+
+/**
+ * Info returned by the `get` function on WebAnimation meta
+ */
+export interface AnimationInfo {
+	currentTime: number;
+	playState: 'idle' | 'pending' | 'running' | 'paused' | 'finished';
+	playbackRate: number;
+	startTime: number;
+}
 
 export interface AnimationPlayer {
 	player: Animation;
@@ -24,7 +76,7 @@ export class WebAnimations extends Base {
 		const keyframeEffect = new KeyframeEffect(
 			node,
 			fx,
-			timing as AnimationEffectTiming
+			timing as any
 		);
 
 		return new Animation(keyframeEffect, global.document.timeline);

--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -19,19 +19,16 @@ export interface AnimationControls {
 	currentTime?: number;
 }
 
-export enum AnimationFill { 'none', 'forwards', 'backwards', 'both', 'auto' }
-export enum AnimationDirection { 'normal', 'reverse', 'alternate', 'alternate-reverse' }
-
 /**
  * Animation timing properties passed to a new KeyframeEffect.
  */
 export interface AnimationTimingProperties {
 	duration?: number;
 	delay?: number;
-	direction?: AnimationDirection;
+	direction?: 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';
 	easing?: string;
 	endDelay?: number;
-	fill?: AnimationFill;
+	fill?: 'none' | 'forwards' | 'backwards' | 'both' | 'auto';
 	iterations?: number;
 	iterationStart?: number;
 }

--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -24,7 +24,7 @@ export class WebAnimations extends Base {
 		const keyframeEffect = new KeyframeEffect(
 			node,
 			fx,
-			timing
+			timing as AnimationEffectTiming
 		);
 
 		return new Animation(keyframeEffect, global.document.timeline);

--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -76,7 +76,7 @@ export class WebAnimations extends Base {
 		const keyframeEffect = new KeyframeEffect(
 			node,
 			fx,
-			timing as any
+			timing as AnimationEffectTiming
 		);
 
 		return new Animation(keyframeEffect, global.document.timeline);

--- a/tests/unit/meta/WebAnimation.ts
+++ b/tests/unit/meta/WebAnimation.ts
@@ -1,8 +1,7 @@
 import global from '@dojo/shim/global';
 const { assert } = intern.getPlugin('chai');
 const { beforeEach, before, describe, it} = intern.getInterface('bdd');
-import WebAnimation from '../../../src/meta/WebAnimation';
-import { AnimationControls, AnimationTimingProperties } from '../../../src/interfaces';
+import WebAnimation, { AnimationControls, AnimationTimingProperties } from '../../../src/meta/WebAnimation';
 import { WidgetBase } from '../../../src/WidgetBase';
 import { v } from '../../../src/d';
 import { spy, stub } from 'sinon';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moves the `AnimationProperties` used by the `WebAnimation` meta out of interfaces. Casts as the polyfilled type upon usage to avoid issues.

Breaking as it changes location of the interfaces.

Resolves #802
