### PR TITLE
Check for rendered children before calling onDetach

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -474,7 +474,9 @@ function callOnDetach(dNodes: InternalDNode | InternalDNode[], parentInstance: D
 	for (let i = 0; i < dNodes.length; i++) {
 		const dNode = dNodes[i];
 		if (isWNode(dNode)) {
-			callOnDetach(dNode.rendered, dNode.instance);
+			if (dNode.rendered) {
+				callOnDetach(dNode.rendered, dNode.instance);
+			}
 			const instanceData = widgetInstanceMap.get(dNode.instance)!;
 			instanceData.onDetach();
 		}

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -1017,6 +1017,38 @@ describe('vdom', () => {
 			assert.strictEqual(quxDetachCount, 8);
 		});
 
+		it('should not throw error running `onDetach` for widgets that do not have any rendered children', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return null;
+				}
+			}
+
+			class Bar extends WidgetBase {
+				render() {
+					return w(Foo, {});
+				}
+			}
+
+			class Baz extends WidgetBase {
+				private _show = false;
+
+				render() {
+					this._show = !this._show;
+					return this._show ? w(Bar, {}) : null;
+				}
+			}
+
+			const widget = new Baz();
+			const projection = dom.create(widget.__render__(), widget);
+			resolvers.resolve();
+			widget.invalidate();
+			projection.update(widget.__render__());
+			assert.doesNotThrow(() => {
+				resolvers.resolve();
+			});
+		});
+
 		it('remove elements for embedded WNodes', () => {
 			class Foo extends WidgetBase {
 				render() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Check `rendered` children on `WNode` before calling `callOnDetach`.

Resolves #813 
