### PR TITLE
Moved initPropertiesAndChildren before inserting into the DOM

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -744,7 +744,6 @@ function createDom(
 			} else {
 				domNode = dnode.domNode;
 			}
-			// add attributes and children so we have a fully formed node prior to attach
 			initPropertiesAndChildren(domNode! as Element, dnode, parentInstance, projectionOptions);
 			if (insertBefore !== undefined) {
 				parentVNode.domNode!.insertBefore(domNode, insertBefore);

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -744,12 +744,13 @@ function createDom(
 			} else {
 				domNode = dnode.domNode;
 			}
+			// add attributes and children so we have a fully formed node prior to attach
+			initPropertiesAndChildren(domNode! as Element, dnode, parentInstance, projectionOptions);
 			if (insertBefore !== undefined) {
 				parentVNode.domNode!.insertBefore(domNode, insertBefore);
 			} else if (domNode!.parentNode !== parentVNode.domNode!) {
 				parentVNode.domNode!.appendChild(domNode);
 			}
-			initPropertiesAndChildren(domNode! as Element, dnode, parentInstance, projectionOptions);
 		}
 	}
 }

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2737,7 +2737,7 @@ describe('vdom', () => {
 				subtree: true
 			});
 			const widget = new Foo();
-			dom.append(parent, widget.__render__() as VNode, widget);
+			dom.append(parent, widget.__render__(), widget);
 
 			const results = [...log, ...observer.takeRecords()];
 			observer.disconnect();

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -1,5 +1,3 @@
-import Test from 'intern/lib/Test';
-
 const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { match, spy, stub, SinonStub } from 'sinon';
@@ -2713,9 +2711,9 @@ describe('vdom', () => {
 	});
 
 	describe('behavior', () => {
-		it('will append nodes with attributes already attached', function(this: Test) {
+		it('will append nodes with attributes already attached', (test) => {
 			if (!global.window || !global.window.hasOwnProperty('MutationObserver')) {
-				this.skip('MutationObserver not present');
+				test.skip('MutationObserver not present');
 			}
 
 			class Foo extends WidgetBase {
@@ -2739,10 +2737,10 @@ describe('vdom', () => {
 			const widget = new Foo();
 			dom.append(parent, widget.__render__(), widget);
 
-			const results = [...log, ...observer.takeRecords()];
+			log.push(...observer.takeRecords());
 			observer.disconnect();
-			assert.isTrue(results.every((mutation) => mutation.type !== 'attributes'));
-			assert.lengthOf(results, 2);
+			assert.isTrue(log.every((mutation) => mutation.type !== 'attributes'));
+			assert.lengthOf(log, 2);
 		});
 	});
 });

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -1,7 +1,6 @@
 const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
-import { match, spy, stub, SinonStub } from 'sinon';
-import global from '@dojo/shim/global';
+import { match, spy, stub, SinonStub, SinonSpy } from 'sinon';
 import { createResolvers } from './../support/util';
 import sendEvent from './../support/sendEvent';
 
@@ -58,6 +57,8 @@ class TestWidget extends WidgetBase<any> {
 }
 
 describe('vdom', () => {
+	const spys: SinonSpy[] = [];
+
 	beforeEach(() => {
 		projectorStub.nodeHandler.add.reset();
 		projectorStub.nodeHandler.addRoot.reset();
@@ -72,6 +73,10 @@ describe('vdom', () => {
 	afterEach(() => {
 		consoleStub.restore();
 		resolvers.restore();
+		for (let spy of spys) {
+			spy.restore();
+		}
+		spys.length = 0;
 	});
 
 	describe('widgets', () => {
@@ -1422,6 +1427,28 @@ describe('vdom', () => {
 			assert.strictEqual(root.children[0].bar, 'bar');
 			assert.isFalse(appendChildSpy.called);
 		});
+
+		it('will append nodes with attributes already attached', (test) => {
+			const expected = '<div data-attr="test"></div>';
+			const appendedHtml: string[] = [];
+
+			const createElement = document.createElement.bind(document);
+			const createElementStub = stub(document, 'createElement', (name: string) => {
+				const node = createElement(name);
+				const appendChild = node.appendChild.bind(node);
+				stub(node, 'appendChild', (node: Element) => {
+					appendedHtml.push(node.outerHTML);
+					return appendChild(node);
+				});
+				return node;
+			});
+			spys.push(createElementStub);
+			const projection = dom.create(v('div', { 'data-attr': 'test' }), projectorStub);
+
+			assert.strictEqual(projection.domNode.innerHTML, expected);
+			assert.lengthOf(appendedHtml, 1);
+			assert.strictEqual(appendedHtml[0], expected);
+		});
 	});
 
 	describe('properties', () => {
@@ -2707,40 +2734,6 @@ describe('vdom', () => {
 					projection.update(v('div', [v('span', { enterAnimation: 'fadeIn' })]));
 				});
 			});
-		});
-	});
-
-	describe('behavior', () => {
-		it('will append nodes with attributes already attached', (test) => {
-			if (!global.window || !global.window.hasOwnProperty('MutationObserver')) {
-				test.skip('MutationObserver not present');
-			}
-
-			class Foo extends WidgetBase {
-				render() {
-					return [v('div', { attr: 'test' }), v('div', { attr: 'test' })];
-				}
-			}
-
-			const doc = global.window.document;
-			const log: MutationRecord[] = [];
-			const observer = new MutationObserver((mutations: MutationRecord[]) => {
-				log.push(...mutations);
-			});
-
-			const parent = doc.createElement('div');
-			observer.observe(parent, {
-				attributes: true,
-				childList: true,
-				subtree: true
-			});
-			const widget = new Foo();
-			dom.append(parent, widget.__render__(), widget);
-
-			log.push(...observer.takeRecords());
-			observer.disconnect();
-			assert.isTrue(log.every((mutation) => mutation.type !== 'attributes'));
-			assert.lengthOf(log, 2);
 		});
 	});
 });


### PR DESCRIPTION
Moved `initPropertiesAndChildren` in `vdom`'s `createDom` before the node is inserted into the DOM to prevent triggering observers and custom elements on an incomplete DOM. More details in the ticket.

Resolves #816
