### PR TITLE
Set instance as dirty over calling invalidate

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -2,6 +2,7 @@ import { WidgetBase } from './WidgetBase';
 import { inject, GetProperties } from './decorators/inject';
 import { Constructor, DNode, RegistryLabel } from './interfaces';
 import { w } from './d';
+import { widgetInstanceMap } from './vdom';
 
 export type Container<T extends WidgetBase> = Constructor<WidgetBase<Partial<T['properties']>>>;
 
@@ -14,7 +15,8 @@ export function Container<W extends WidgetBase>(
 	class WidgetContainer extends WidgetBase<Partial<W['properties']>> {
 		public __setProperties__(properties: Partial<W['properties']>): void {
 			super.__setProperties__(properties as any);
-			this.invalidate();
+			const instanceData = widgetInstanceMap.get(this)!;
+			instanceData.dirty = true;
 		}
 		protected render(): DNode {
 			return w(component, this.properties, this.children);

--- a/tests/unit/Container.ts
+++ b/tests/unit/Container.ts
@@ -6,6 +6,7 @@ import { Container } from './../../src/Container';
 import { Registry } from './../../src/Registry';
 import { Injector } from './../../src/Injector';
 import { ProjectorMixin } from './../../src/mixins/Projector';
+import { widgetInstanceMap } from './../../src/vdom';
 
 interface TestWidgetProperties {
 	foo: string;
@@ -93,6 +94,22 @@ registerSuite('mixins/Container', {
 			const renderResult: any = widget.__render__();
 
 			assert.strictEqual(renderResult.widgetConstructor, 'test-widget');
+		},
+		'container always marked as dirty'() {
+			class Child extends WidgetBase<{ foo: string }> {}
+			const ContainerClass = Container(Child, 'test-state-1', { getProperties });
+			const widget = new ContainerClass();
+			const instanceData = widgetInstanceMap.get(widget)!;
+			assert.isTrue(instanceData.dirty);
+			widget.__setCoreProperties__({ bind: widget, baseRegistry: registry });
+			widget.__setProperties__({ foo: 'bar' });
+			assert.isTrue(instanceData.dirty);
+			widgetInstanceMap.set(widget, { ...instanceData, dirty: false })!;
+			widget.__setProperties__({ foo: 'bar' });
+			assert.isTrue(instanceData.dirty);
+			widgetInstanceMap.set(widget, { ...instanceData, dirty: false })!;
+			widget.__setProperties__({ foo: 'bar' });
+			assert.isTrue(instanceData.dirty);
 		},
 		'integration test'() {
 			class Child extends WidgetBase<{ foo: string }> {}

--- a/tests/unit/Container.ts
+++ b/tests/unit/Container.ts
@@ -94,7 +94,7 @@ registerSuite('mixins/Container', {
 
 			assert.strictEqual(renderResult.widgetConstructor, 'test-widget');
 		},
-		'Container should always render but invalidate when properties have not changed'() {
+		'Container should always render but not invalidate when properties have not changed'() {
 			let invalidateCount = 0;
 			let renderCount = 0;
 			class Child extends WidgetBase<{ foo: string }> {}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Set `instanceData.`dirty` to `true` over using `this.invalidate()` in the `Container`s `__setProperties__` override.

Resolves #821
