### PR TITLE
alwaysRender Decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,15 @@ class MyClass extends WidgetBase<MyClassProperties> {
 }
 ```
 
+##### AlwaysRender
+
+The `alwaysRender` decorator is used to force a widget to always render regardless of whether the widget's properties are considered different.
+
+```ts
+@alwaysRender()
+class MyClass extends WidgetBase {}
+```
+
 ##### BeforeRender
 
 The `beforeRender` lifecycle hook receives the widget's `render` function, `properties` and `children` and is expected to return a function that satisfies the `render` API. The `properties` and `children` are passed to enable them to be manipulated or decorated prior to `render` being called.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.5.1-rc.1",
+  "version": "0.5.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -91,7 +91,7 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/chai": {
@@ -106,7 +106,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/diff": {
@@ -138,7 +138,7 @@
       "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/fs-extra": {
@@ -147,7 +147,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/glob": {
@@ -157,8 +157,8 @@
       "dev": true,
       "requires": {
         "@types/events": "1.1.0",
-        "@types/minimatch": "3.0.2",
-        "@types/node": "8.5.5"
+        "@types/minimatch": "3.0.3",
+        "@types/node": "8.5.8"
       }
     },
     "@types/grunt": {
@@ -167,7 +167,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/handlebars": {
@@ -269,7 +269,7 @@
       "dev": true,
       "requires": {
         "@types/jquery": "3.2.17",
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/jszip": {
@@ -279,9 +279,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.91",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
-      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
+      "version": "4.14.92",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.92.tgz",
+      "integrity": "sha512-cdvY1fyUGYgG7/i07a/sR5PnD6+Z+ljUrD0CNVf0qj645VvEdLNtZPjvCp4siPy3rQ/KRXMfUATIqi3+9x57Sw==",
       "dev": true
     },
     "@types/marked": {
@@ -303,15 +303,15 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
-      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/node": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.5.tgz",
-      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+      "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
       "dev": true
     },
     "@types/platform": {
@@ -332,7 +332,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/selenium-webdriver": {
@@ -363,7 +363,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/sinon": {
@@ -396,7 +396,7 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.5"
+        "@types/node": "8.5.8"
       }
     },
     "@types/yargs": {
@@ -754,9 +754,9 @@
       "dev": true
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "async": {
@@ -785,7 +785,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000787",
+        "caniuse-db": "1.0.30000789",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1193,7 +1193,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000787",
+        "caniuse-db": "1.0.30000789",
         "electron-to-chromium": "1.3.30"
       }
     },
@@ -1249,20 +1249,20 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000787",
+        "caniuse-db": "1.0.30000789",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000787",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000787.tgz",
-      "integrity": "sha1-ygeigb5Taoi9f6yWuolfPPU/gRs=",
+      "version": "1.0.30000789",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000789.tgz",
+      "integrity": "sha1-XPP+x1SABBqxYsoGQTFTFB4jQyU=",
       "dev": true
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
@@ -1289,7 +1289,7 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "check-error": "1.0.2",
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
@@ -1952,7 +1952,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -3456,7 +3456,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.4",
+        "intern": "4.1.5",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -4017,9 +4017,9 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.4.tgz",
-      "integrity": "sha512-QL5+pVjpjNVtp5mB2QwTgf3fuG3l+lA3UzhHTxjhahWt0Z84LfdFfHFXN6UeB72IYQq7LDhjStO6I51rsTjb6Q==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.5.tgz",
+      "integrity": "sha512-wY3xxstQ2zHpOU/ktjMcyvzmzazyjvlcipD79RqDGm+kyMdJcyI+00qfHvPlzrwhGwX+XVs2+tqwJCiSMKzYUg==",
       "dev": true,
       "requires": {
         "@dojo/core": "0.3.0",
@@ -4040,7 +4040,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.91",
+        "@types/lodash": "4.14.92",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -5814,9 +5814,9 @@
       }
     },
     "npm-path": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
-      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
         "which": "1.2.14"
@@ -5838,7 +5838,7 @@
       "dev": true,
       "requires": {
         "commander": "2.12.2",
-        "npm-path": "2.0.3",
+        "npm-path": "2.0.4",
         "which": "1.2.14"
       },
       "dependencies": {
@@ -6746,7 +6746,7 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.15",
+        "postcss": "6.0.16",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
@@ -6788,9 +6788,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.15",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -6956,7 +6956,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.15"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6997,9 +6997,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.15",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7031,7 +7031,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.15"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7072,9 +7072,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.15",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7106,7 +7106,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.15"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7147,9 +7147,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.15",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7181,7 +7181,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.15"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7222,9 +7222,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.15",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -8189,9 +8189,9 @@
       }
     },
     "serve": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-6.4.3.tgz",
-      "integrity": "sha512-oD2sedcq5kvjhGdkA78xJFe9lczWx+Bw5ZQIoNkMGDpNMrgnh55yx2PwF2vBeAWZw3+W1Xnz5PpuMxEOdwV+Bg==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-6.4.4.tgz",
+      "integrity": "sha512-gP1DMxiWkTYJgJicsbdpuAPSNIeiURsnkXDHtHFoMmsyxjPVCiohVl/uFWK772zt28vZDWvQFh4XoafyLMB4IA==",
       "dev": true,
       "requires": {
         "args": "3.0.8",
@@ -10226,7 +10226,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.91",
+        "@types/lodash": "4.14.92",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.5.1-pre",
+  "version": "0.5.1-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -2,6 +2,7 @@ import { WidgetBase } from './WidgetBase';
 import { inject, GetProperties } from './decorators/inject';
 import { Constructor, DNode, RegistryLabel } from './interfaces';
 import { w } from './d';
+import { alwaysRender } from './decorators/alwaysRender';
 
 export type Container<T extends WidgetBase> = Constructor<WidgetBase<Partial<T['properties']>>>;
 
@@ -10,12 +11,9 @@ export function Container<W extends WidgetBase>(
 	name: RegistryLabel,
 	{ getProperties }: { getProperties: GetProperties }
 ): Container<W> {
+	@alwaysRender()
 	@inject({ name, getProperties })
 	class WidgetContainer extends WidgetBase<Partial<W['properties']>> {
-		public __setProperties__(properties: Partial<W['properties']>): void {
-			super.__setProperties__(properties as any);
-			this.invalidate();
-		}
 		protected render(): DNode {
 			return w(component, this.properties, this.children);
 		}

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -200,12 +200,12 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	}
 
 	public __setProperties__(originalProperties: this['properties']): void {
+		this._renderState = WidgetRenderState.PROPERTIES;
 		const properties = this._runBeforeProperties(originalProperties);
 		const registeredDiffPropertyNames = this.getDecorator('registeredDiffProperty');
 		const changedPropertyKeys: string[] = [];
 		const propertyNames = Object.keys(properties);
 		const instanceData = widgetInstanceMap.get(this)!;
-		this._renderState = WidgetRenderState.PROPERTIES;
 
 		if (this._initialProperties === false || registeredDiffPropertyNames.length !== 0) {
 			const allProperties = [...propertyNames, ...Object.keys(this._properties)];

--- a/src/decorators/alwaysRender.ts
+++ b/src/decorators/alwaysRender.ts
@@ -1,0 +1,13 @@
+import { WidgetBase } from './../WidgetBase';
+import { handleDecorator } from './handleDecorator';
+import { beforeProperties } from './beforeProperties';
+
+export function alwaysRender() {
+	return handleDecorator((target, propertyKey) => {
+		beforeProperties(function(this: WidgetBase) {
+			this.invalidate();
+		})(target);
+	});
+}
+
+export default alwaysRender;

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -1,4 +1,5 @@
 import './afterRender';
+import './alwaysRender';
 import './beforeProperties';
 import './beforeRender';
 import './diffProperty';

--- a/tests/unit/decorators/alwaysRender.ts
+++ b/tests/unit/decorators/alwaysRender.ts
@@ -1,0 +1,35 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+import { WidgetBase } from './../../../src/WidgetBase';
+import { w } from './../../../src/d';
+import { ProjectorMixin } from './../../../src/mixins/Projector';
+import { alwaysRender } from './../../../src/decorators/alwaysRender';
+
+describe('decorators/alwaysRender', () => {
+	it('Widgets should always render', () => {
+		let renderCount = 0;
+
+		@alwaysRender()
+		class Widget extends WidgetBase {
+			render() {
+				renderCount++;
+				return super.render();
+			}
+		}
+
+		class Parent extends ProjectorMixin(WidgetBase) {
+			render() {
+				return w(Widget, {});
+			}
+		}
+
+		const projector = new Parent();
+		projector.async = false;
+		projector.setProperties({});
+		projector.append();
+		assert.strictEqual(renderCount, 1);
+		projector.setProperties({});
+		assert.strictEqual(renderCount, 2);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add support `alwaysRender` decorator that will cause the widget to always re-render regardless of whether there are any property diffs.

Using the decorator for `Container` resolves the an issue that causes the the rendering to get caught in a loop instead of overriding the `__setProperties__` `WidgetBase` API.

Resolves #821
Resolves #676

  