### PR TITLE
Move web-animations typings as dep and remove intern config for polyfill

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -21,8 +21,7 @@
 					{ "name": "tests", "location": "_build/tests" },
 					{ "name": "cldr-data", "location": "node_modules/cldr-data" },
 					{ "name": "cldrjs", "location": "node_modules/cldrjs" },
-					{ "name": "globalize", "location": "node_modules/globalize", "main": "dist/globalize" },
-					{ "name": "web-animations-js", "location": "node_modules/web-animations-js" }
+					{ "name": "globalize", "location": "node_modules/globalize", "main": "dist/globalize" }
 				],
 				"map": {
 					"globalize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,8 +390,7 @@
     "@types/web-animations-js": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@types/web-animations-js/-/web-animations-js-2.2.5.tgz",
-      "integrity": "sha512-3kjO6yvLt1e673wtcKEz0lgLKqPkBiuwxQj0DQ1jj+48HB03emIlTQYcqKAvB9UwOXq09QrWy/Dm6ZU8xMZVTw==",
-      "dev": true
+      "integrity": "sha512-3kjO6yvLt1e673wtcKEz0lgLKqPkBiuwxQj0DQ1jj+48HB03emIlTQYcqKAvB9UwOXq09QrWy/Dm6ZU8xMZVTw=="
     },
     "@types/ws": {
       "version": "0.0.42",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "@types/jsdom": "2.0.*",
     "@types/ramda": "^0.25.5",
     "@types/selenium-webdriver": "^3.0.8",
-    "@types/sinon": "~4.1.2",
-    "@types/web-animations-js": "^2.2.5",
+    "@types/sinon": "^1.16.31",
     "@types/yargs": "^8.0.2",
     "@webcomponents/custom-elements": "^v1.0.0-rc.3",
     "bootstrap": "^3.3.7",
@@ -69,7 +68,8 @@
     "intersection-observer": "^0.4.2",
     "pepjs": "^0.4.2",
     "tslib": "~1.8.1",
-    "web-animations-js": "^2.3.1"
+    "web-animations-js": "^2.3.1",
+    "@types/web-animations-js": "^2.2.5"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/jsdom": "2.0.*",
     "@types/ramda": "^0.25.5",
     "@types/selenium-webdriver": "^3.0.8",
-    "@types/sinon": "^1.16.31",
+    "@types/sinon": "~4.1.2",
     "@types/yargs": "^8.0.2",
     "@webcomponents/custom-elements": "^v1.0.0-rc.3",
     "bootstrap": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
     "typescript": "~2.6.1"
   },
   "dependencies": {
-    "intersection-observer": "^0.4.2",
-    "pepjs": "^0.4.2",
+    "intersection-observer": "0.4.3",
+    "pepjs": "0.4.3",
     "tslib": "~1.8.1",
-    "web-animations-js": "^2.3.1",
-    "@types/web-animations-js": "^2.2.5"
+    "web-animations-js": "2.3.1",
+    "@types/web-animations-js": "2.2.5"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moves the web animation types from a dev dependency to a dependency in package.json and removes the web animations config from intern.json as this will be provided by shim.

Relies on: https://github.com/dojo/shim/pull/128

