### PR TITLE
Fix registry typings

### DIFF
--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -8,7 +8,13 @@ import { Injector } from './Injector';
 
 export type WidgetBaseConstructorFunction = () => Promise<WidgetBaseConstructor>;
 
-export type RegistryItem = WidgetBaseConstructor | Promise<WidgetBaseConstructor> | WidgetBaseConstructorFunction;
+export type ESMDefaultWidgetBaseFunction = () => Promise<ESMDefaultWidgetBase<WidgetBaseInterface>>;
+
+export type RegistryItem =
+	| WidgetBaseConstructor
+	| Promise<WidgetBaseConstructor>
+	| WidgetBaseConstructorFunction
+	| ESMDefaultWidgetBaseFunction;
 
 /**
  * Widget base symbol type
@@ -111,10 +117,7 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 	/**
 	 * Emit loaded event for registry label
 	 */
-	private emitLoadedEvent(
-		widgetLabel: RegistryLabel,
-		item: WidgetBaseConstructorFunction | WidgetBaseConstructor | Injector
-	): void {
+	private emitLoadedEvent(widgetLabel: RegistryLabel, item: WidgetBaseConstructor | Injector): void {
 		this.emit({
 			type: widgetLabel,
 			action: 'loaded',
@@ -144,7 +147,7 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 					throw error;
 				}
 			);
-		} else {
+		} else if (isWidgetBaseConstructor(item)) {
 			this.emitLoadedEvent(label, item);
 		}
 	}

--- a/tests/unit/Registry.ts
+++ b/tests/unit/Registry.ts
@@ -169,6 +169,26 @@ registerSuite('Registry', {
 					assert.strictEqual(factory, WidgetBase);
 				});
 			}
+		},
+		emit: {
+			'emits loaded event concrete Widget item'() {
+				let loadedEvent = false;
+				const registry = new Registry();
+				registry.on('foo', ({ type }) => {
+					loadedEvent = true;
+				});
+				registry.define('foo', WidgetBase);
+				assert.isTrue(loadedEvent);
+			},
+			'does not emits loaded event when defining a function'() {
+				let loadedEvent = false;
+				const registry = new Registry();
+				registry.on('foo', ({ type }) => {
+					loadedEvent = true;
+				});
+				registry.define('foo', () => Promise.resolve(WidgetBase));
+				assert.isFalse(loadedEvent);
+			}
 		}
 	},
 	Injector: {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Supports required typings to register an item of `() => import('./MyWidget')` that has a default export.

Resolves #828 
