### PR TITLE
Remove replace from the vdom API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.6.3",
+  "version": "0.6.4-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -24,14 +24,12 @@ export enum ProjectorAttachState {
  */
 export enum AttachType {
 	Append = 1,
-	Merge = 2,
-	Replace = 3
+	Merge = 2
 }
 
 export interface AttachOptions {
 	/**
-	 * If `'append'` it will appended to the root. If `'merge'` it will merged with the root. If `'replace'` it will
-	 * replace the root.
+	 * If `'append'` it will appended to the root. If `'merge'` it will merged with the root.
 	 */
 	type: AttachType;
 
@@ -61,11 +59,6 @@ export interface ProjectorMixin<P> {
 	 * @param root The root element that the root virtual DOM node will be merged with.  Defaults to `document.body`.
 	 */
 	merge(root?: Element): Handle;
-
-	/**
-	 * Replace the root with the projector node.
-	 */
-	replace(root?: Element): Handle;
 
 	/**
 	 * Pause the projector.
@@ -185,15 +178,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		public merge(root?: Element): Handle {
 			const options = {
 				type: AttachType.Merge,
-				root
-			};
-
-			return this._attach(options);
-		}
-
-		public replace(root?: Element): Handle {
-			const options = {
-				type: AttachType.Replace,
 				root
 			};
 
@@ -363,9 +347,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 					break;
 				case AttachType.Merge:
 					this._projection = dom.merge(this.root, this._boundRender(), this, this._projectionOptions);
-					break;
-				case AttachType.Replace:
-					this._projection = dom.replace(this.root, this._boundRender(), this, this._projectionOptions);
 					break;
 			}
 

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -995,36 +995,5 @@ export const dom = {
 		runDeferredRenderCallbacks(finalProjectorOptions);
 		runAfterRenderCallbacks(finalProjectorOptions);
 		return createProjection(decoratedNode, instance, finalProjectorOptions);
-	},
-	replace: function(
-		element: Element,
-		dNode: RenderResult,
-		instance: DefaultWidgetBaseInterface,
-		projectionOptions?: Partial<ProjectionOptions>
-	): Projection {
-		if (Array.isArray(dNode)) {
-			throw new Error(
-				'Unable to replace a node with an array of nodes. (consider adding one extra level to the virtual DOM)'
-			);
-		}
-		const finalProjectorOptions = getProjectionOptions(projectionOptions);
-		const decoratedNode = filterAndDecorateChildren(dNode, instance)[0] as InternalVNode;
-		finalProjectorOptions.rootNode = element.parentNode! as Element;
-		createDom(
-			decoratedNode,
-			toParentVNode(finalProjectorOptions.rootNode),
-			element,
-			finalProjectorOptions,
-			instance
-		);
-		const instanceData = widgetInstanceMap.get(instance)!;
-		instanceData.nodeHandler.addRoot();
-		finalProjectorOptions.afterRenderCallbacks.push(() => {
-			instanceData.onAttach();
-		});
-		runDeferredRenderCallbacks(finalProjectorOptions);
-		runAfterRenderCallbacks(finalProjectorOptions);
-		element.parentNode!.removeChild(element);
-		return createProjection(decoratedNode, instance, finalProjectorOptions);
 	}
 };

--- a/tests/unit/mixins/Projector.ts
+++ b/tests/unit/mixins/Projector.ts
@@ -150,20 +150,6 @@ registerSuite('mixins/projectorMixin', {
 				assert.strictEqual(child.tagName.toLowerCase(), 'div');
 				assert.strictEqual((child.firstChild as HTMLElement).tagName.toLowerCase(), 'h2');
 			},
-			replace() {
-				const projector = new class extends BaseTestWidget {
-					render() {
-						return v('body', this.children);
-					}
-				}();
-
-				projector.setChildren([v('h2', ['foo'])]);
-				projector.replace();
-				assert.strictEqual(document.body.childNodes.length, 1, 'child should have been added');
-				const child = document.body.lastChild as HTMLElement;
-				assert.strictEqual(child.innerHTML, 'foo');
-				assert.strictEqual(child.tagName.toLowerCase(), 'h2');
-			},
 			merge: {
 				standard() {
 					const div = document.createElement('div');
@@ -313,20 +299,6 @@ registerSuite('mixins/projectorMixin', {
 				projector.append(div);
 				assert.strictEqual(projector.toHtml(), `<div><h2>foo</h2></div>`);
 				assert.strictEqual(projector.toHtml(), (projector.root.lastChild as Element).outerHTML);
-				projector.destroy();
-			},
-			replaced() {
-				const div = document.createElement('div');
-				const root = document.createElement('div');
-				document.body.appendChild(root);
-				root.appendChild(div);
-
-				const projector = new BaseTestWidget();
-				projector.setChildren([v('h2', ['foo'])]);
-
-				projector.replace(div);
-				assert.strictEqual(projector.toHtml(), `<div><h2>foo</h2></div>`);
-				assert.strictEqual(projector.toHtml(), (root.lastChild as Element).outerHTML);
 				projector.destroy();
 			},
 			merged() {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -769,24 +769,6 @@ describe('vdom', () => {
 			);
 		});
 
-		it('should throw an error when attempting to replace with an array of node', () => {
-			class Foo extends WidgetBase {
-				render() {
-					return [v('div', ['1']), v('div', ['2']), v('div', ['3'])];
-				}
-			}
-
-			const div = document.createElement('div');
-			const widget = new Foo();
-			assert.throws(
-				() => {
-					dom.replace(div, widget.__render__() as VNode, widget);
-				},
-				Error,
-				'Unable to replace a node with an array of nodes. (consider adding one extra level to the virtual DOM)'
-			);
-		});
-
 		it('removes existing widget and uses new widget when widget changes', () => {
 			let fooCreated = false;
 			let barCreatedCount = 0;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes `replace` from the `vdom` and `projector` APIs.

Resolves #741 
