### PR TITLE
Update deprecated sinon.reset()

### DIFF
--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -35,7 +35,7 @@ export function createResolvers() {
 		for (let i = 0; i < rICStub.callCount; i++) {
 			rICStub.getCall(i).callArg(0);
 		}
-		rICStub.reset();
+		rICStub.resetHistory();
 	}
 
 	return {

--- a/tests/unit/NodeHandler.ts
+++ b/tests/unit/NodeHandler.ts
@@ -35,9 +35,9 @@ registerSuite('NodeHandler', {
 		},
 		events: {
 			beforeEach() {
-				elementStub.reset();
-				widgetStub.reset();
-				projectorStub.reset();
+				elementStub.resetHistory();
+				widgetStub.resetHistory();
+				projectorStub.resetHistory();
 
 				nodeHandler.on('foo', elementStub);
 				nodeHandler.on(NodeEventType.Widget, widgetStub);

--- a/tests/unit/meta/Dimensions.ts
+++ b/tests/unit/meta/Dimensions.ts
@@ -37,7 +37,7 @@ function resolveRAF() {
 	for (let i = 0; i < rAF.callCount; i++) {
 		rAF.getCall(i).args[0]();
 	}
-	rAF.reset();
+	rAF.resetHistory();
 }
 
 registerSuite('meta - Dimensions', {
@@ -110,7 +110,7 @@ registerSuite('meta - Dimensions', {
 			resolveRAF();
 			assert.isTrue(invalidateStub.calledOnce);
 
-			onSpy.reset();
+			onSpy.resetHistory();
 			dimensions.get('foo');
 
 			assert.isFalse(onSpy.called);

--- a/tests/unit/meta/Intersection.ts
+++ b/tests/unit/meta/Intersection.ts
@@ -129,7 +129,7 @@ registerSuite('meta - Intersection', {
 				const element = document.createElement('div');
 				nodeHandler.add(element, 'root');
 				assert.isTrue(invalidateStub.calledOnce);
-				onSpy.reset();
+				onSpy.resetHistory();
 				intersection.get('root');
 				assert.isFalse(onSpy.called);
 			},
@@ -153,7 +153,7 @@ registerSuite('meta - Intersection', {
 
 				assert.isTrue(invalidateStub.calledOnce);
 
-				onSpy.reset();
+				onSpy.resetHistory();
 				intersection.get('root');
 
 				assert.isFalse(onSpy.called);

--- a/tests/unit/meta/WebAnimation.ts
+++ b/tests/unit/meta/WebAnimation.ts
@@ -128,16 +128,16 @@ describe('WebAnimation', () => {
 		});
 
 		beforeEach(() => {
-			keyframeCtorStub.reset();
-			animationCtorStub.reset();
-			pauseStub.reset();
-			playStub.reset();
-			reverseStub.reset();
-			cancelStub.reset();
-			finishStub.reset();
-			startStub.reset();
-			currentStub.reset();
-			playbackRateStub.reset();
+			keyframeCtorStub.resetHistory();
+			animationCtorStub.resetHistory();
+			pauseStub.resetHistory();
+			playStub.resetHistory();
+			reverseStub.resetHistory();
+			cancelStub.resetHistory();
+			finishStub.resetHistory();
+			startStub.resetHistory();
+			currentStub.resetHistory();
+			playbackRateStub.resetHistory();
 			metaNode = document.createElement('div');
 
 			widget = new TestWidget();

--- a/tests/unit/meta/meta.ts
+++ b/tests/unit/meta/meta.ts
@@ -103,7 +103,7 @@ registerSuite('meta base', {
 			resolvers.resolve();
 			assert.isTrue(invalidate.calledOnce);
 
-			onSpy.reset();
+			onSpy.resetHistory();
 			meta.callGetNode('foo');
 
 			assert.isFalse(onSpy.called);
@@ -128,7 +128,7 @@ registerSuite('meta base', {
 			meta.callGetNode('foo');
 			assert.isTrue(onSpy.calledOnce);
 			assert.isTrue(onSpy.firstCall.calledWith('foo'));
-			onSpy.reset();
+			onSpy.resetHistory();
 			meta.callGetNode('foo');
 			assert.isTrue(onSpy.notCalled);
 			assert.isTrue(invalidate.notCalled);

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -60,12 +60,12 @@ describe('vdom', () => {
 	const spys: SinonSpy[] = [];
 
 	beforeEach(() => {
-		projectorStub.nodeHandler.add.reset();
-		projectorStub.nodeHandler.addRoot.reset();
-		projectorStub.onElementCreated.reset();
-		projectorStub.onElementUpdated.reset();
-		projectorStub.onAttach.reset();
-		projectorStub.onDetach.reset();
+		projectorStub.nodeHandler.add.resetHistory();
+		projectorStub.nodeHandler.addRoot.resetHistory();
+		projectorStub.onElementCreated.resetHistory();
+		projectorStub.onElementUpdated.resetHistory();
+		projectorStub.onAttach.resetHistory();
+		projectorStub.onDetach.resetHistory();
 		consoleStub = stub(console, 'warn');
 		resolvers.stub();
 	});
@@ -2564,7 +2564,7 @@ describe('vdom', () => {
 			const projection = dom.create(v('div', { key: '1' }), projectorStub);
 			assert.isTrue(projectorStub.nodeHandler.add.called);
 			assert.isTrue(projectorStub.nodeHandler.add.calledWith(projection.domNode.childNodes[0] as Element, '1'));
-			projectorStub.nodeHandler.add.reset();
+			projectorStub.nodeHandler.add.resetHistory();
 			projection.update(v('div', { key: '1' }));
 			assert.isTrue(projectorStub.nodeHandler.add.called);
 			assert.isTrue(projectorStub.nodeHandler.add.calledWith(projection.domNode.childNodes[0] as Element, '1'));
@@ -2574,7 +2574,7 @@ describe('vdom', () => {
 			const projection = dom.create(v('div', { key: 0 }), projectorStub);
 			assert.isTrue(projectorStub.nodeHandler.add.called);
 			assert.isTrue(projectorStub.nodeHandler.add.calledWith(projection.domNode.childNodes[0] as Element, '0'));
-			projectorStub.nodeHandler.add.reset();
+			projectorStub.nodeHandler.add.resetHistory();
 			projection.update(v('div', { key: 0 }));
 			assert.isTrue(projectorStub.nodeHandler.add.called);
 			assert.isTrue(projectorStub.nodeHandler.add.calledWith(projection.domNode.childNodes[0] as Element, '0'));
@@ -2597,11 +2597,11 @@ describe('vdom', () => {
 
 			const projection = dom.create(widget.__render__(), projectorStub);
 			assert.isTrue(projectorStub.nodeHandler.addRoot.called);
-			projectorStub.nodeHandler.addRoot.reset();
+			projectorStub.nodeHandler.addRoot.resetHistory();
 			widget.invalidate();
 			projection.update(widget.__render__());
 			assert.isTrue(projectorStub.nodeHandler.addRoot.called);
-			projectorStub.nodeHandler.addRoot.reset();
+			projectorStub.nodeHandler.addRoot.resetHistory();
 		});
 
 		it('addRoot called on node handler for updated widgets with key', () => {
@@ -2610,11 +2610,11 @@ describe('vdom', () => {
 
 			const projection = dom.create(widget.__render__(), projectorStub);
 			assert.isTrue(projectorStub.nodeHandler.addRoot.called);
-			projectorStub.nodeHandler.addRoot.reset();
+			projectorStub.nodeHandler.addRoot.resetHistory();
 			widget.invalidate();
 			projection.update(widget.__render__());
 			assert.isTrue(projectorStub.nodeHandler.addRoot.called);
-			projectorStub.nodeHandler.addRoot.reset();
+			projectorStub.nodeHandler.addRoot.resetHistory();
 		});
 	});
 
@@ -2636,7 +2636,7 @@ describe('vdom', () => {
 				);
 				projection.update(v('div', { updateAnimation }, ['textBefore', v('span'), 'newTextAfter']));
 				assert.isTrue(updateAnimation.calledOnce);
-				updateAnimation.reset();
+				updateAnimation.resetHistory();
 
 				projection.update(v('div', { updateAnimation }, ['textBefore', v('span'), 'newTextAfter']));
 				assert.isTrue(updateAnimation.notCalled);


### PR DESCRIPTION
**Description:**

Sinon v4 warns that `.reset()` is deprecated
