### PR TITLE
Add typings for `styles` on `VNodeProperties`

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -131,7 +131,7 @@ export interface VNodeProperties {
 	/**
 	 * An object literal like `{height:'100px'}` which allows styles to be changed dynamically. All values must be strings.
 	 */
-	readonly styles?: { [index: string]: string | null | undefined };
+	readonly styles?: Partial<CSSStyleDeclaration>;
 
 	// Pointer Events
 	onpointermove?(ev?: PointerEvent): boolean | void;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Use `Partial<CSSStyleDeclaration>` type for `styles` on `VNodeProperties`
