### PR TITLE
Ensure that properties are only diff'd once when setting properties.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.6.3",
+  "version": "0.6.4-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -290,9 +290,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.92",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.92.tgz",
-      "integrity": "sha512-cdvY1fyUGYgG7/i07a/sR5PnD6+Z+ljUrD0CNVf0qj645VvEdLNtZPjvCp4siPy3rQ/KRXMfUATIqi3+9x57Sw==",
+      "version": "4.14.93",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.93.tgz",
+      "integrity": "sha512-xI9Il9Fqxse5hSh6bVwowEC5RXyEVJ2hssRJXANU70H/+NlirvsNi87JjvGMxtn6yTemyUPkkzSl9SCKFW4U3g==",
       "dev": true
     },
     "@types/marked": {
@@ -332,9 +332,9 @@
       "dev": true
     },
     "@types/ramda": {
-      "version": "0.25.15",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.25.15.tgz",
-      "integrity": "sha512-KlGg8px5Kz70uH1S1Hr00oHBGa19TtjfIBt1gwjUzzxun6N/sxQIjOfqnrVq0TauHqldU7JEdQAWYRx+xnKWCA==",
+      "version": "0.25.16",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.25.16.tgz",
+      "integrity": "sha512-jNxaEg+kSJ58iaM9bBawJugDxexXVPnLU245yEI1p2BTcfR5pcgM6mpsyBhRRo2ozyfJUvTmasL2Ft+C6BNkVQ==",
       "dev": true
     },
     "@types/resolve": {
@@ -1367,7 +1367,7 @@
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.6"
+        "type-detect": "4.0.7"
       }
     },
     "chalk": {
@@ -2425,7 +2425,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.6"
+        "type-detect": "4.0.7"
       }
     },
     "deep-equal": {
@@ -3952,7 +3952,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.92",
+        "@types/lodash": "4.14.93",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -8355,7 +8355,7 @@
         "lolex": "2.3.1",
         "nise": "1.2.0",
         "supports-color": "5.1.0",
-        "type-detect": "4.0.6"
+        "type-detect": "4.0.7"
       },
       "dependencies": {
         "diff": {
@@ -9011,9 +9011,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.6.tgz",
-      "integrity": "sha512-qZ3bAurt2IXGPR3c57PyaSYEnQiLRwPeS60G9TahElBZsdOABo+iKYch/PhRjSTZJ5/DF08x43XMt9qec2g3ig==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
+      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
       "dev": true
     },
     "type-is": {
@@ -10174,7 +10174,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.92",
+        "@types/lodash": "4.14.93",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -215,7 +215,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 			for (let i = 0; i < allProperties.length; i++) {
 				const propertyName = allProperties[i];
-				if (checkedProperties.indexOf(propertyName) > 0) {
+				if (checkedProperties.indexOf(propertyName) !== -1) {
 					continue;
 				}
 				checkedProperties.push(propertyName);

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -227,6 +227,32 @@ describe('WidgetBase', () => {
 			assert.isFalse(testWidget.functionIsBound);
 			assert.isTrue(testWidget.properties.functionIsBound);
 		});
+
+		it('properties are only diffed once', () => {
+			let diffCounter = 0;
+			function testDiff(previousProperty: any, newProperty: any) {
+				diffCounter++;
+				return {
+					value: newProperty,
+					changed: false
+				};
+			}
+
+			@diffProperty('foo', testDiff)
+			@diffProperty('bar', testDiff)
+			@diffProperty('baz', testDiff)
+			class TestWidget extends WidgetBase<any> {}
+			const testWidget = new TestWidget();
+			const properties = {
+				foo: 'foo',
+				bar: 'bar',
+				baz: 'baz'
+			};
+			testWidget.__setProperties__(properties);
+			assert.strictEqual(diffCounter, 3);
+			testWidget.__setProperties__(properties);
+			assert.strictEqual(diffCounter, 6);
+		});
 	});
 
 	it('__setChildren__', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensures that properties are only diffed once during `__setProperties__`.

Resolves #835
