### PR TITLE
Custom element decorator fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.6.4",
+  "version": "0.6.5-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -139,16 +139,17 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.11.0",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz",
-      "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
+      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "dev": true,
       "requires": {
+        "@types/events": "1.1.0",
         "@types/node": "9.3.0"
       }
     },
@@ -268,9 +269,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.18.tgz",
-      "integrity": "sha512-8dsVAEAbK73GBbQjXUEBhaCXX6A+gEp7+bM7CI7n/850ES6NFObYvJID2F4mGAahLUosKHiJI1QkLS8bV+9VGA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.0.tgz",
+      "integrity": "sha512-szaKV2OQgwxYTGTY6qd9eeBfGGCaP7n2OGit4JdbOcfGgc9VWjfhMhnu5AVNhIAu8WWDIB36q9dfPVba1fGeIQ==",
       "dev": true
     },
     "@types/jsdom": {
@@ -279,7 +280,7 @@
       "integrity": "sha512-xaHlMIzlReyciMIWGJBnkEdHngCOEpik2ojt9tJFe7rD+QiObCIcmr9/tAqxn7l1jflQ3wEIkh7+gt4ls5n1Dw==",
       "dev": true,
       "requires": {
-        "@types/jquery": "3.2.18",
+        "@types/jquery": "3.3.0",
         "@types/node": "9.3.0"
       }
     },
@@ -358,7 +359,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.11.0",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/mime": "2.0.0"
       }
     },
@@ -864,7 +865,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000794",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1055,7 +1056,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "platform": "1.3.4"
+        "platform": "1.3.5"
       },
       "dependencies": {
         "lodash": {
@@ -1266,7 +1267,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000794",
         "electron-to-chromium": "1.3.31"
       }
     },
@@ -1322,15 +1323,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000794",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000793",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000793.tgz",
-      "integrity": "sha1-PADGbkI6ehkHx92Wdpp4sq+opy4=",
+      "version": "1.0.30000794",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000794.tgz",
+      "integrity": "sha1-u+cRBPonfOSzYjh9VJBei4jlLzU=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2600,9 +2601,9 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
@@ -2754,7 +2755,7 @@
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "1.1.2",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "finalhandler": "1.0.6",
@@ -2939,7 +2940,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
@@ -3463,7 +3464,7 @@
         "postcss-cssnext": "2.11.0",
         "postcss-import": "9.1.0",
         "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.10.0",
+        "remap-istanbul": "0.10.1",
         "resolve-from": "2.0.0",
         "shelljs": "0.7.8",
         "tslint": "4.5.1",
@@ -3977,7 +3978,7 @@
         "lodash": "4.17.4",
         "mime-types": "2.1.17",
         "minimatch": "3.0.4",
-        "platform": "1.3.4",
+        "platform": "1.3.5",
         "resolve": "1.4.0",
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
@@ -4652,9 +4653,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.1.tgz",
-      "integrity": "sha512-2h586r2I/CqU7z1aa1kBgWaVAXWAZK+zHnceGi/jFgn7+7VSluxYer/i3xOZVearCxxXvyDkLtTBo+OeJCA3kA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
+      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ==",
       "dev": true
     },
     "js-tokens": {
@@ -4900,7 +4901,7 @@
         "jest-validate": "21.2.1",
         "listr": "0.13.0",
         "lodash": "4.17.4",
-        "log-symbols": "2.1.0",
+        "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "npm-which": "3.0.1",
         "p-map": "1.2.0",
@@ -5225,9 +5226,9 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0"
@@ -6197,9 +6198,9 @@
       "dev": true
     },
     "platform": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
-      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
     "pleeease-filters": {
@@ -6307,7 +6308,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.1",
+        "js-base64": "2.4.2",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -7833,17 +7834,25 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.0.tgz",
-      "integrity": "sha512-C3vinclZ2p8na07f/f+JWLchmiofgqroyxBrkKPA4kkbjsHHa94HFd5ZYkYrMEs9cbsufh53t5DFJyTK8UDVjg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.1.tgz",
+      "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
       "dev": true,
       "requires": {
         "amdefine": "1.0.1",
         "istanbul": "0.4.5",
         "minimatch": "3.0.4",
         "plugin-error": "0.1.2",
-        "source-map": "0.5.7",
+        "source-map": "0.6.1",
         "through2": "2.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
@@ -8063,7 +8072,7 @@
         "debug": "2.6.9",
         "depd": "1.1.2",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
@@ -8234,7 +8243,7 @@
             "debug": "2.6.9",
             "depd": "1.1.2",
             "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
+            "encodeurl": "1.0.2",
             "escape-html": "1.0.3",
             "etag": "1.8.1",
             "fresh": "0.5.2",
@@ -8269,7 +8278,7 @@
       "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
         "send": "0.15.6"
@@ -9137,13 +9146,15 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "dev": true,
               "optional": true
             },
             "ajv": {
               "version": "4.11.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9153,18 +9164,21 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "aproba": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+              "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9174,42 +9188,49 @@
             },
             "asn1": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
               "dev": true,
               "optional": true
             },
             "assert-plus": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
               "dev": true,
               "optional": true
             },
             "asynckit": {
               "version": "0.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
               "dev": true,
               "optional": true
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "dev": true,
               "optional": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
               "dev": true,
               "optional": true
             },
             "balanced-match": {
               "version": "0.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
               "dev": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9218,7 +9239,8 @@
             },
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3"
@@ -9226,7 +9248,8 @@
             },
             "boom": {
               "version": "2.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -9234,7 +9257,8 @@
             },
             "brace-expansion": {
               "version": "1.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+              "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
               "dev": true,
               "requires": {
                 "balanced-match": "0.4.2",
@@ -9243,29 +9267,34 @@
             },
             "buffer-shims": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
               "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "dev": true,
               "optional": true
             },
             "co": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -9273,22 +9302,26 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "cryptiles": {
               "version": "2.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
               "dev": true,
               "requires": {
                 "boom": "2.10.1"
@@ -9296,7 +9329,8 @@
             },
             "dashdash": {
               "version": "1.14.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9305,7 +9339,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -9313,7 +9348,8 @@
             },
             "debug": {
               "version": "2.6.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9322,30 +9358,35 @@
             },
             "deep-extend": {
               "version": "0.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
               "dev": true,
               "optional": true
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
               "dev": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+              "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
               "dev": true,
               "optional": true
             },
             "ecc-jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9354,24 +9395,28 @@
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
               "dev": true,
               "optional": true
             },
             "extsprintf": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true,
               "optional": true
             },
             "form-data": {
               "version": "2.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9382,12 +9427,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -9398,7 +9445,8 @@
             },
             "fstream-ignore": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9409,7 +9457,8 @@
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9425,7 +9474,8 @@
             },
             "getpass": {
               "version": "0.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9434,7 +9484,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -9442,7 +9493,8 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
@@ -9455,18 +9507,21 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "dev": true
             },
             "har-schema": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
               "dev": true,
               "optional": true
             },
             "har-validator": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9476,13 +9531,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "hawk": {
               "version": "3.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
                 "boom": "2.10.1",
@@ -9493,12 +9550,14 @@
             },
             "hoek": {
               "version": "2.16.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
               "dev": true
             },
             "http-signature": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9509,7 +9568,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
                 "once": "1.4.0",
@@ -9518,18 +9578,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -9537,24 +9600,28 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true,
               "optional": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true,
               "optional": true
             },
             "jodid25519": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9563,19 +9630,22 @@
             },
             "jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
               "dev": true,
               "optional": true
             },
             "json-schema": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
               "dev": true,
               "optional": true
             },
             "json-stable-stringify": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9584,19 +9654,22 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true,
               "optional": true
             },
             "jsonify": {
               "version": "0.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
               "dev": true,
               "optional": true
             },
             "jsprim": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+              "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9608,7 +9681,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -9616,12 +9690,14 @@
             },
             "mime-db": {
               "version": "1.27.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+              "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.15",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
               "dev": true,
               "requires": {
                 "mime-db": "1.27.0"
@@ -9629,7 +9705,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.7"
@@ -9637,12 +9714,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -9650,13 +9729,15 @@
             },
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true,
               "optional": true
             },
             "node-pre-gyp": {
               "version": "0.6.39",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+              "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9675,7 +9756,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9685,7 +9767,8 @@
             },
             "npmlog": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+              "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9697,24 +9780,28 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -9722,19 +9809,22 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9744,35 +9834,41 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             },
             "performance-now": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "punycode": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
               "dev": true,
               "optional": true
             },
             "qs": {
               "version": "6.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9784,7 +9880,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -9792,7 +9889,8 @@
             },
             "readable-stream": {
               "version": "2.2.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
               "dev": true,
               "requires": {
                 "buffer-shims": "1.0.0",
@@ -9806,7 +9904,8 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9836,7 +9935,8 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "dev": true,
               "requires": {
                 "glob": "7.1.2"
@@ -9844,30 +9944,35 @@
             },
             "safe-buffer": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "sntp": {
               "version": "1.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -9875,7 +9980,8 @@
             },
             "sshpk": {
               "version": "1.13.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+              "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9892,7 +9998,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -9900,7 +10007,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -9910,7 +10018,8 @@
             },
             "string_decoder": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.0.1"
@@ -9918,13 +10027,15 @@
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true,
               "optional": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -9932,13 +10043,15 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
@@ -9948,7 +10061,8 @@
             },
             "tar-pack": {
               "version": "3.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9964,7 +10078,8 @@
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9973,7 +10088,8 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9982,30 +10098,35 @@
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
               "dev": true,
               "optional": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true,
               "optional": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             },
             "uuid": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
               "dev": true,
               "optional": true
             },
             "verror": {
               "version": "1.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10014,7 +10135,8 @@
             },
             "wide-align": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10023,7 +10145,8 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             }
           }

--- a/src/decorators/customElement.ts
+++ b/src/decorators/customElement.ts
@@ -1,6 +1,5 @@
 import { CustomElementInitializer } from '../customElements';
 import { Constructor, WidgetProperties } from '../interfaces';
-import registerCustomElement from '../registerCustomElement';
 
 declare const __dojoCustomElements__: boolean;
 
@@ -47,7 +46,7 @@ export function customElement<P extends WidgetProperties = WidgetProperties>({
 }: CustomElementConfig<P>) {
 	return function<T extends Constructor<any>>(target: T) {
 		if (typeof __dojoCustomElements__ !== 'undefined') {
-			registerCustomElement(() => ({
+			target.prototype.__customElementDescriptor = {
 				tagName: tag,
 				widgetConstructor: target,
 				attributes: (attributes || []).map((attributeName) => ({ attributeName })),
@@ -57,7 +56,7 @@ export function customElement<P extends WidgetProperties = WidgetProperties>({
 					eventName: propertyName.replace('on', '').toLowerCase()
 				})),
 				initialization
-			}));
+			};
 		}
 	};
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Rather than registering the generated descriptor immediately within the decorator, `decorators/customElement` now adds the generated descriptor to the class prototype. `cli-build-webpack` injects the appropriate element registration call.

A decorated component can now be built as a custom element:

```sh
$ dojo build webpack --element=HelloWorld.ts --elementPrefix=hello-world
```

**Note:** This depends on dojo/cli-build-webpack#265.

Resolves #837 
