### PR TITLE
Remove onElementCreated and onElementUpdated hooks

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -106,12 +106,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 
 		widgetInstanceMap.set(this, {
 			dirty: true,
-			onElementCreated: (element: HTMLElement, key: string) => {
-				this.onElementCreated(element, key);
-			},
-			onElementUpdated: (element: HTMLElement, key: string) => {
-				this.onElementUpdated(element, key);
-			},
 			onAttach: (): void => {
 				this.onAttach();
 			},
@@ -145,26 +139,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		}
 
 		return cached as T;
-	}
-
-	/**
-	 * Widget lifecycle method that is called whenever a dom node is created for a VNode.
-	 * Override this method to access the dom nodes that were inserted into the dom.
-	 * @param element The dom node represented by the vdom node.
-	 * @param key The vdom node's key.
-	 */
-	protected onElementCreated(element: Element, key: string | number): void {
-		// Do nothing by default.
-	}
-
-	/**
-	 * Widget lifecycle method that is called whenever a dom node that is associated with a VNode is updated.
-	 * Override this method to access the dom node.
-	 * @param element The dom node represented by the vdom node.
-	 * @param key The vdom node's key.
-	 */
-	protected onElementUpdated(element: Element, key: string | number): void {
-		// Do nothing by default.
 	}
 
 	protected onAttach(): void {

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -19,7 +19,7 @@ export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): D
 			return vNode;
 		}
 
-		protected onElementCreated(element: Element, key: string | number) {
+		protected onAttach() {
 			options.onAttached && options.onAttached();
 		}
 

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -70,8 +70,6 @@ export interface InternalVNode extends VNode {
 export type InternalDNode = InternalVNode | InternalWNode;
 
 export interface WidgetData {
-	onElementCreated: Function;
-	onElementUpdated: Function;
 	onDetach: () => void;
 	onAttach: () => void;
 	parentInvalidate?: Function;
@@ -667,9 +665,6 @@ function initPropertiesAndChildren(
 	if (dnode.properties.key !== null && dnode.properties.key !== undefined) {
 		const instanceData = widgetInstanceMap.get(parentInstance)!;
 		instanceData.nodeHandler.add(domNode as HTMLElement, `${dnode.properties.key}`);
-		projectionOptions.afterRenderCallbacks.push(() => {
-			instanceData.onElementCreated(domNode as HTMLElement, dnode.properties.key!);
-		});
 	}
 	dnode.inserted = true;
 }
@@ -816,9 +811,6 @@ function updateDom(
 			if (dnode.properties.key !== null && dnode.properties.key !== undefined) {
 				const instanceData = widgetInstanceMap.get(parentInstance)!;
 				instanceData.nodeHandler.add(domNode, `${dnode.properties.key}`);
-				projectionOptions.afterRenderCallbacks.push(() => {
-					instanceData.onElementUpdated(domNode as HTMLElement, dnode.properties.key!);
-				});
 			}
 		}
 		if (updated && dnode.properties && dnode.properties.updateAnimation) {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -19,8 +19,6 @@ const projectorStub: any = {
 		add: stub(),
 		addRoot: stub()
 	},
-	onElementCreated: stub(),
-	onElementUpdated: stub(),
 	onAttach: stub(),
 	onDetach: stub(),
 	constructor: {
@@ -62,8 +60,6 @@ describe('vdom', () => {
 	beforeEach(() => {
 		projectorStub.nodeHandler.add.resetHistory();
 		projectorStub.nodeHandler.addRoot.resetHistory();
-		projectorStub.onElementCreated.resetHistory();
-		projectorStub.onElementUpdated.resetHistory();
 		projectorStub.onAttach.resetHistory();
 		projectorStub.onDetach.resetHistory();
 		consoleStub = stub(console, 'warn');
@@ -2578,17 +2574,6 @@ describe('vdom', () => {
 			projection.update(v('div', { key: 0 }));
 			assert.isTrue(projectorStub.nodeHandler.add.called);
 			assert.isTrue(projectorStub.nodeHandler.add.calledWith(projection.domNode.childNodes[0] as Element, '0'));
-		});
-
-		it('on element created and updated callbacks are called for nodes with keys', () => {
-			const projection = dom.create(v('div', { key: 0 }), projectorStub);
-			resolvers.resolve();
-			assert.isTrue(projectorStub.onElementCreated.called);
-			assert.isTrue(projectorStub.onElementCreated.calledWith(projection.domNode.childNodes[0] as Element, 0));
-			projection.update(v('div', { key: 0 }));
-			resolvers.resolve();
-			assert.isTrue(projectorStub.onElementUpdated.called);
-			assert.isTrue(projectorStub.onElementUpdated.calledWith(projection.domNode.childNodes[0] as Element, 0));
 		});
 
 		it('addRoot called on node handler for created widgets with a zero key', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes the `onElementCreated` and `onElementUpdated` escape hatch that provides consumers with DOM nodes for nodes created with a `key`.

Related to #557 
