### PR TITLE
Decorate function cannot be used with the return of `render`

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -46,17 +46,11 @@ export function isVNode(child: DNode): child is VNode {
  * If no predicate is supplied then the modifier will be executed on all nodes.
  */
 export function decorate<T extends DNode>(
-	dNodes: DNode,
+	dNodes: DNode | DNode[],
 	modifier: (dNode: T) => void,
 	predicate: (dNode: DNode) => dNode is T
-): DNode;
-export function decorate<T extends DNode>(
-	dNodes: DNode[],
-	modifier: (dNode: T) => void,
-	predicate: (dNode: DNode) => dNode is T
-): DNode[];
-export function decorate(dNodes: DNode, modifier: (dNode: DNode) => void): DNode;
-export function decorate(dNodes: DNode[], modifier: (dNode: DNode) => void): DNode[];
+): DNode | DNode[];
+export function decorate(dNodes: DNode | DNode[], modifier: (dNode: DNode) => void): DNode | DNode[];
 export function decorate(
 	dNodes: DNode | DNode[],
 	modifier: (dNode: DNode) => void,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fix the typings of decorate so that it accepts the return value type ('DNode | DNode[]`) from `render` and `__render__` which is a common usage.
