### PR TITLE
Run deferred properties before checking nodes for equality

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -549,7 +549,10 @@ function updateChildren(
 	while (newIndex < newChildrenLength) {
 		const oldChild = oldIndex < oldChildrenLength ? oldChildren[oldIndex] : undefined;
 		const newChild = newChildren[newIndex];
-
+		if (isVNode(newChild) && typeof newChild.deferredPropertiesCallback === 'function') {
+			newChild.inserted = isVNode(oldChild) && oldChild.inserted;
+			addDeferredProperties(newChild, projectionOptions);
+		}
 		if (oldChild !== undefined && same(oldChild, newChild)) {
 			textUpdated = updateDom(oldChild, newChild, projectionOptions, parentVNode, parentInstance) || textUpdated;
 			oldIndex++;
@@ -782,7 +785,6 @@ function updateDom(
 		const domNode = (dnode.domNode = previous.domNode);
 		let textUpdated = false;
 		let updated = false;
-		dnode.inserted = previous.inserted;
 		if (dnode.tag === '') {
 			if (dnode.text !== previous.text) {
 				const newDomNode = domNode.ownerDocument.createTextNode(dnode.text!);
@@ -800,10 +802,6 @@ function updateDom(
 				dnode.children = children;
 				updated =
 					updateChildren(dnode, previous.children, children, parentInstance, projectionOptions) || updated;
-			}
-
-			if (typeof dnode.deferredPropertiesCallback === 'function') {
-				addDeferredProperties(dnode, projectionOptions);
 			}
 
 			updated = updateProperties(domNode, previous.properties, dnode.properties, projectionOptions) || updated;

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -1767,7 +1767,8 @@ describe('vdom', () => {
 				const div = v('div', (inserted) => {
 					return {
 						inserted,
-						deferredCallbackCount: ++deferredCallbackCount
+						deferredCallbackCount: ++deferredCallbackCount,
+						key: 'prop'
 					};
 				});
 				(div.properties as any).renderCount = renderCount;
@@ -1790,6 +1791,7 @@ describe('vdom', () => {
 
 			projection.update(renderFunction());
 
+			assert.strictEqual(projection.domNode.childNodes[0], element);
 			assert.strictEqual(element.deferredCallbackCount, 3);
 			assert.strictEqual(element.renderCount, 2);
 			assert.isTrue(element.inserted);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Moves the initial deferred properties call to before nodes are compared for equality.

Resolves #842 
