### PR TITLE
Support `focus` on `VNodeProperties`

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -89,6 +89,8 @@ export type SupportedClassName = string | null | undefined;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
+export type FocusFunction = () => boolean;
+
 export interface VNodeProperties {
 	/**
 	 * The animation to perform when this node is added to an already existing parent.
@@ -202,6 +204,11 @@ export interface VNodeProperties {
 	 * Note: if you use innerHTML, cannot protect you from XSS vulnerabilities and you must make sure that the innerHTML value is safe.
 	 */
 	readonly innerHTML?: string;
+
+	/**
+	 * determines if the node should be focused
+	 */
+	readonly focus?: boolean | FocusFunction;
 
 	/**
 	 * Everything that is not explicitly listed (properties and attributes that are either uncommon or custom).

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -203,6 +203,20 @@ function removeClasses(domNode: Element, classes: SupportedClassName) {
 	}
 }
 
+function focusNode(propValue: any, previousValue: any, domNode: Element, projectionOptions: ProjectionOptions): void {
+	let result;
+	if (typeof propValue === 'function') {
+		result = propValue();
+	} else {
+		result = propValue && !previousValue;
+	}
+	if (result === true) {
+		projectionOptions.deferredRenderCallbacks.push(() => {
+			(domNode as HTMLElement).focus();
+		});
+	}
+}
+
 function setProperties(domNode: Element, properties: VNodeProperties, projectionOptions: ProjectionOptions) {
 	const propNames = Object.keys(properties);
 	const propCount = propNames.length;
@@ -211,13 +225,15 @@ function setProperties(domNode: Element, properties: VNodeProperties, projection
 		let propValue = properties[propName];
 		if (propName === 'classes') {
 			const currentClasses = Array.isArray(propValue) ? propValue : [propValue];
-			if (!(domNode as Element).className) {
-				(domNode as Element).className = currentClasses.join(' ').trim();
+			if (!domNode.className) {
+				domNode.className = currentClasses.join(' ').trim();
 			} else {
 				for (let i = 0; i < currentClasses.length; i++) {
-					addClasses(domNode as Element, currentClasses[i]);
+					addClasses(domNode, currentClasses[i]);
 				}
 			}
+		} else if (propName === 'focus') {
+			focusNode(propValue, false, domNode, projectionOptions);
 		} else if (propName === 'styles') {
 			const styleNames = Object.keys(propValue);
 			const styleCount = styleNames.length;
@@ -320,6 +336,8 @@ function updateProperties(
 					addClasses(domNode, currentClasses[i]);
 				}
 			}
+		} else if (propName === 'focus') {
+			focusNode(propValue, previousValue, domNode, projectionOptions);
 		} else if (propName === 'styles') {
 			const styleNames = Object.keys(propValue);
 			const styleCount = styleNames.length;

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2937,66 +2937,54 @@ describe('vdom', () => {
 
 	describe('focus', () => {
 		it('focus is only called once when set to true', () => {
-			const onFocusStub = stub();
-			const projection = dom.append(
-				document.body,
+			const widget = getWidget(
 				v('input', {
-					focus: true,
-					onfocus: onFocusStub
-				}),
-				projectorStub,
-				{ sync: true }
+					focus: true
+				})
 			);
-			resolvers.resolve();
-			assert.isTrue(onFocusStub.calledOnce);
+			const projection = dom.append(document.body, widget);
 			const input = projection.domNode.lastChild as HTMLElement;
 			const focusSpy = spy(input, 'focus');
-			projection.update(v('input', { focus: true, onfocus: onFocusStub }));
 			resolvers.resolve();
-			assert.isTrue(focusSpy.notCalled);
-			assert.isTrue(onFocusStub.calledOnce);
+			assert.isTrue(focusSpy.calledOnce);
+			widget.renderResult = v('input', { focus: true });
+			assert.isTrue(focusSpy.calledOnce);
 			document.body.removeChild(input);
 		});
 
 		it('focus is called when focus property is set to true from false', () => {
-			const onFocusStub = stub();
-			const projection = dom.append(
-				document.body,
+			const widget = getWidget(
 				v('input', {
-					focus: false,
-					onfocus: onFocusStub
-				}),
-				projectorStub
+					focus: false
+				})
 			);
+			const projection = dom.append(document.body, widget);
 			const input = projection.domNode.lastChild as HTMLElement;
 			const focusSpy = spy(input, 'focus');
 			resolvers.resolve();
 			assert.isTrue(focusSpy.notCalled);
-			assert.isTrue(onFocusStub.notCalled);
-			projection.update(v('input', { focus: true, onfocus: onFocusStub }));
+			widget.renderResult = v('input', { focus: true });
 			resolvers.resolve();
 			assert.isTrue(focusSpy.calledOnce);
-			assert.isTrue(onFocusStub.calledOnce);
 			document.body.removeChild(input);
 		});
 
 		it('Should focus if function for focus returns true', () => {
-			const shouldFocus = () => true;
-			const onFocusStub = stub();
-			const projection = dom.append(
-				document.body,
+			const shouldFocus = () => {
+				console.log('here2');
+				return true;
+			};
+			const widget = getWidget(
 				v('input', {
-					focus: shouldFocus,
-					onfocus: onFocusStub
-				}),
-				projectorStub
+					focus: shouldFocus
+				})
 			);
+			const projection = dom.append(document.body, widget);
 			const input = projection.domNode.lastChild as HTMLElement;
 			const focusSpy = spy(input, 'focus');
 			resolvers.resolve();
 			assert.isTrue(focusSpy.calledOnce);
-			assert.isTrue(onFocusStub.calledOnce);
-			projection.update(v('input', { focus: shouldFocus, onfocus: onFocusStub }));
+			widget.renderResult = v('input', { focus: shouldFocus });
 			resolvers.resolve();
 			assert.isTrue(focusSpy.calledTwice);
 			document.body.removeChild(input);
@@ -3004,24 +2992,19 @@ describe('vdom', () => {
 
 		it('Should never focus if function for focus returns false', () => {
 			const shouldFocus = () => false;
-			const onFocusStub = stub();
-			const projection = dom.append(
-				document.body,
+			const widget = getWidget(
 				v('input', {
-					focus: shouldFocus,
-					onfocus: onFocusStub
-				}),
-				projectorStub
+					focus: shouldFocus
+				})
 			);
+			const projection = dom.append(document.body, widget);
 			const input = projection.domNode.lastChild as HTMLElement;
 			const focusSpy = spy(input, 'focus');
 			resolvers.resolve();
 			assert.isTrue(focusSpy.notCalled);
-			assert.isTrue(onFocusStub.notCalled);
-			projection.update(v('input', { focus: shouldFocus, onfocus: onFocusStub }));
+			widget.renderResult = v('input', { focus: shouldFocus });
 			resolvers.resolve();
 			assert.isTrue(focusSpy.notCalled);
-			assert.isTrue(onFocusStub.notCalled);
 			document.body.removeChild(input);
 		});
 	});

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2934,4 +2934,95 @@ describe('vdom', () => {
 			});
 		});
 	});
+
+	describe('focus', () => {
+		it('focus is only called once when set to true', () => {
+			const onFocusStub = stub();
+			const projection = dom.append(
+				document.body,
+				v('input', {
+					focus: true,
+					onfocus: onFocusStub
+				}),
+				projectorStub,
+				{ sync: true }
+			);
+			resolvers.resolve();
+			assert.isTrue(onFocusStub.calledOnce);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const focusSpy = spy(input, 'focus');
+			projection.update(v('input', { focus: true, onfocus: onFocusStub }));
+			resolvers.resolve();
+			assert.isTrue(focusSpy.notCalled);
+			assert.isTrue(onFocusStub.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('focus is called when focus property is set to true from false', () => {
+			const onFocusStub = stub();
+			const projection = dom.append(
+				document.body,
+				v('input', {
+					focus: false,
+					onfocus: onFocusStub
+				}),
+				projectorStub
+			);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const focusSpy = spy(input, 'focus');
+			resolvers.resolve();
+			assert.isTrue(focusSpy.notCalled);
+			assert.isTrue(onFocusStub.notCalled);
+			projection.update(v('input', { focus: true, onfocus: onFocusStub }));
+			resolvers.resolve();
+			assert.isTrue(focusSpy.calledOnce);
+			assert.isTrue(onFocusStub.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('Should focus if function for focus returns true', () => {
+			const shouldFocus = () => true;
+			const onFocusStub = stub();
+			const projection = dom.append(
+				document.body,
+				v('input', {
+					focus: shouldFocus,
+					onfocus: onFocusStub
+				}),
+				projectorStub
+			);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const focusSpy = spy(input, 'focus');
+			resolvers.resolve();
+			assert.isTrue(focusSpy.calledOnce);
+			assert.isTrue(onFocusStub.calledOnce);
+			projection.update(v('input', { focus: shouldFocus, onfocus: onFocusStub }));
+			resolvers.resolve();
+			assert.isTrue(focusSpy.calledTwice);
+			document.body.removeChild(input);
+		});
+
+		it('Should never focus if function for focus returns false', () => {
+			const shouldFocus = () => false;
+			const onFocusStub = stub();
+			const projection = dom.append(
+				document.body,
+				v('input', {
+					focus: shouldFocus,
+					onfocus: onFocusStub
+				}),
+				projectorStub
+			);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const focusSpy = spy(input, 'focus');
+			resolvers.resolve();
+			assert.isTrue(focusSpy.notCalled);
+			assert.isTrue(onFocusStub.notCalled);
+			projection.update(v('input', { focus: shouldFocus, onfocus: onFocusStub }));
+			resolvers.resolve();
+			assert.isTrue(focusSpy.notCalled);
+			assert.isTrue(onFocusStub.notCalled);
+			document.body.removeChild(input);
+		});
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support in `vdom` for a focus property that calls focus on the next rAF if the property is `true` and was `false` in the previous render or the function returns `true`

Resolves #847 
