### PR TITLE
Support text nodes and initialise widget properties from the custom element node

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -236,6 +236,10 @@ export function initializeElement(element: CustomElement) {
 		initialProperties[propertyName] = propertyValue;
 	});
 
+	properties.forEach(({ propertyName, widgetPropertyName }) => {
+		initialProperties[widgetPropertyName || propertyName] = (element as any)[propertyName];
+	});
+
 	let customProperties: PropertyDescriptorMap = {};
 
 	attributes.reduce((properties, attribute) => {
@@ -312,9 +316,9 @@ export function initializeElement(element: CustomElement) {
 
 	return function() {
 		let children: DNode[] = [];
-		let elementChildren = arrayFrom(element.children) as CustomElement[];
+		let elementChildren = element.childNodes ? (arrayFrom(element.childNodes) as CustomElement[]) : [];
 
-		elementChildren.forEach((childNode: CustomElement, index: number) => {
+		elementChildren.forEach((childNode, index) => {
 			const properties = { key: `child-${index}` };
 			if (childrenType === ChildrenType.DOJO) {
 				children.push(w(DomToWidgetWrapper(childNode), properties));
@@ -322,7 +326,7 @@ export function initializeElement(element: CustomElement) {
 				children.push(w(DomWrapper(childNode), properties));
 			}
 		});
-		elementChildren.forEach((childNode: Element) => {
+		elementChildren.forEach((childNode) => {
 			element.removeChild(childNode);
 		});
 

--- a/src/util/DomWrapper.ts
+++ b/src/util/DomWrapper.ts
@@ -11,7 +11,11 @@ export type DomWrapperProperties = VNodeProperties & WidgetProperties;
 
 export type DomWrapper = Constructor<WidgetBase<DomWrapperProperties>>;
 
-export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): DomWrapper {
+function isElement(value: any): value is Element {
+	return value.tagName;
+}
+
+export function DomWrapper(domNode: Element | Text, options: DomWrapperOptions = {}): DomWrapper {
 	return class DomWrapper extends WidgetBase<DomWrapperProperties> {
 		public __render__(): VNode {
 			const vNode = super.__render__() as InternalVNode;
@@ -25,7 +29,8 @@ export function DomWrapper(domNode: Element, options: DomWrapperOptions = {}): D
 
 		protected render(): DNode {
 			const properties = { ...this.properties, key: 'root' };
-			return v(domNode.tagName, properties);
+			const tag = isElement(domNode) ? domNode.tagName : '';
+			return v(tag, properties);
 		}
 	};
 }

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -536,7 +536,7 @@ function checkDistinguishable(
 	parentInstance: DefaultWidgetBaseInterface
 ) {
 	const childNode = childNodes[indexToCheck];
-	if (isVNode(childNode) && childNode.tag === '') {
+	if (isVNode(childNode) && !childNode.tag) {
 		return; // Text nodes need not be distinguishable
 	}
 	const { key } = childNode.properties;
@@ -763,8 +763,8 @@ function createDom(
 			return;
 		}
 		const doc = parentVNode.domNode!.ownerDocument;
-		if (dnode.tag === '') {
-			if (dnode.domNode !== undefined) {
+		if (!dnode.tag && typeof dnode.text === 'string') {
+			if (dnode.domNode !== undefined && dnode.domNode.parentNode) {
 				const newDomNode = dnode.domNode.ownerDocument.createTextNode(dnode.text!);
 				dnode.domNode.parentNode!.replaceChild(newDomNode, dnode.domNode);
 				dnode.domNode = newDomNode;
@@ -837,7 +837,7 @@ function updateDom(
 		const domNode = (dnode.domNode = previous.domNode);
 		let textUpdated = false;
 		let updated = false;
-		if (dnode.tag === '') {
+		if (!dnode.tag && typeof dnode.text === 'string') {
 			if (dnode.text !== previous.text) {
 				const newDomNode = domNode.ownerDocument.createTextNode(dnode.text!);
 				domNode.parentNode!.replaceChild(newDomNode, domNode);

--- a/tests/unit/customElements.ts
+++ b/tests/unit/customElements.ts
@@ -18,40 +18,43 @@ import { InternalVNode } from '../../src/vdom';
 import { Constructor } from '../../src/interfaces';
 import ProjectorMixin from '../../src/mixins/Projector';
 
-function createFakeElement(attributes: any, descriptor: CustomElementDescriptor): any {
+function createFakeElement(attributes: any, properties: any, descriptor: CustomElementDescriptor): any {
 	let widgetInstance: WidgetBase<any> | null;
 	let events: Event[] = [];
 	let removedChildren: any[] = [];
 
 	return {
-		getWidgetInstance: () => widgetInstance!,
-		setWidgetInstance(instance: WidgetBase<any>) {
-			widgetInstance = instance;
-		},
-		getWidgetConstructor: () =>
-			class extends WidgetBase<any> {
-				render() {
-					return v('div');
-				}
+		...properties,
+		...{
+			getWidgetInstance: () => widgetInstance!,
+			setWidgetInstance(instance: WidgetBase<any>) {
+				widgetInstance = instance;
 			},
-		getDescriptor: () => descriptor,
-		children: [],
-		getAttribute(name: string) {
-			return attributes[name] || null;
-		},
-		dispatchEvent(event: Event) {
-			events.push(event);
-		},
-		appendChild: function() {},
-		getEvents() {
-			return events;
-		},
-		ownerDocument: global.document,
-		removeChild(child: any) {
-			removedChildren.push(child);
-		},
-		removedChildren() {
-			return removedChildren;
+			getWidgetConstructor: () =>
+				class extends WidgetBase<any> {
+					render() {
+						return v('div');
+					}
+				},
+			getDescriptor: () => descriptor,
+			childNodes: undefined,
+			getAttribute(name: string) {
+				return attributes[name] || null;
+			},
+			dispatchEvent(event: Event) {
+				events.push(event);
+			},
+			appendChild: function() {},
+			getEvents() {
+				return events;
+			},
+			ownerDocument: global.document,
+			removeChild(child: any) {
+				removedChildren.push(child);
+			},
+			removedChildren() {
+				return removedChildren;
+			}
 		}
 	};
 }
@@ -68,6 +71,7 @@ registerSuite('customElements', {
 					'my-attribute': '2',
 					convert: '4'
 				},
+				{},
 				{
 					tagName: 'test',
 					widgetConstructor: WidgetBase,
@@ -103,6 +107,7 @@ registerSuite('customElements', {
 					a: '1',
 					'my-attribute': '2'
 				},
+				{},
 				{
 					tagName: 'test',
 					widgetConstructor: WidgetBase,
@@ -130,6 +135,7 @@ registerSuite('customElements', {
 					a: '1',
 					'my-attribute': '2'
 				},
+				{},
 				{
 					tagName: 'test',
 					widgetConstructor: WidgetBase,
@@ -155,6 +161,7 @@ registerSuite('customElements', {
 		'attribute changes are sent to widget'() {
 			let element = createFakeElement(
 				{},
+				{},
 				{
 					tagName: 'test',
 					widgetConstructor: WidgetBase,
@@ -178,6 +185,7 @@ registerSuite('customElements', {
 		'unregistered attribute changes do nothing'() {
 			let element = createFakeElement(
 				{},
+				{},
 				{
 					widgetConstructor: WidgetBase,
 					tagName: 'test'
@@ -192,8 +200,39 @@ registerSuite('customElements', {
 		}
 	},
 	properties: {
+		'element properties are set as widget properties'() {
+			let element = createFakeElement(
+				{},
+				{
+					a: '1',
+					'my-attribute': '2',
+					convert: '4'
+				},
+				{
+					tagName: 'test',
+					widgetConstructor: WidgetBase,
+					properties: [
+						{
+							propertyName: 'a'
+						},
+						{
+							propertyName: 'my-attribute',
+							widgetPropertyName: 'b'
+						}
+					]
+				}
+			);
+
+			initializeElement(element)();
+
+			const result = element.getWidgetInstance().properties;
+			assert.strictEqual(result.a, '1');
+			assert.strictEqual(result.b, '2');
+		},
+
 		'property names default to provided name'() {
 			let element = createFakeElement(
+				{},
 				{},
 				{
 					tagName: 'test',
@@ -219,6 +258,7 @@ registerSuite('customElements', {
 		'widget property names can be specified'() {
 			let element = createFakeElement(
 				{},
+				{},
 				{
 					tagName: 'test',
 					widgetConstructor: WidgetBase,
@@ -240,6 +280,7 @@ registerSuite('customElements', {
 		},
 		'properties can transform with getter'() {
 			let element = createFakeElement(
+				{},
 				{},
 				{
 					tagName: 'test',
@@ -264,6 +305,7 @@ registerSuite('customElements', {
 		},
 		'properties can transform with a setter'() {
 			let element = createFakeElement(
+				{},
 				{},
 				{
 					tagName: 'test',
@@ -302,6 +344,7 @@ registerSuite('customElements', {
 			'events are created'() {
 				let element = createFakeElement(
 					{},
+					{},
 					{
 						tagName: 'test',
 						widgetConstructor: WidgetBase,
@@ -333,13 +376,14 @@ registerSuite('customElements', {
 			}
 			let element = createFakeElement(
 				{},
+				{},
 				{
 					tagName: 'test',
 					widgetConstructor: WidgetBase,
 					childrenType: ChildrenType.ELEMENT
 				}
 			);
-			element.children = [
+			element.childNodes = [
 				{
 					key: 'test',
 					parentNode: element,
@@ -360,12 +404,13 @@ registerSuite('customElements', {
 			}
 			let element = createFakeElement(
 				{},
+				{},
 				{
 					tagName: 'test',
 					widgetConstructor: WidgetBase
 				}
 			);
-			element.children = [
+			element.childNodes = [
 				{
 					key: 'test',
 					parentNode: element,
@@ -407,6 +452,7 @@ registerSuite('customElements', {
 	initialization: {
 		'properties are sent to widget'() {
 			let element = createFakeElement(
+				{},
 				{},
 				{
 					tagName: 'test',
@@ -451,6 +497,7 @@ registerSuite('customElements', {
 				sandbox.stub(projector, 'ProjectorMixin').callsFake(TestProjectorMixin);
 
 				let element = createFakeElement(
+					{},
 					{},
 					{
 						tagName: 'test',

--- a/tests/unit/util/DomWrapper.ts
+++ b/tests/unit/util/DomWrapper.ts
@@ -94,6 +94,29 @@ registerSuite('DomWrapper', {
 			assert.isTrue(domNode.classList.contains('classFoo'));
 			assert.equal(domNode.style.color, 'red');
 		},
+		'DomWrapper supports text nodes'() {
+			const domNode = document.createTextNode('text-node');
+			const root = document.createElement('div');
+
+			const DomNode = DomWrapper(domNode);
+			const myTheme = {
+				class1: 'classFoo'
+			};
+
+			@theme(myTheme)
+			class Foo extends ThemedMixin(WidgetBase) {
+				render() {
+					return w(DomNode, {});
+				}
+			}
+			const Projector = ProjectorMixin(Foo);
+			projector = new Projector();
+			projector.append(root);
+			resolvers.resolve();
+			resolvers.resolve();
+			assert.strictEqual(domNode.data, 'text-node');
+			assert.strictEqual(root.childNodes[0], domNode);
+		},
 		onAttached() {
 			let attached = false;
 			const domNode: any = document.createElement('custom-element');


### PR DESCRIPTION
**Type:** bug(s)

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

* Support `TextNodes` as children to custom elements
* Initialise properties when custom element is hydrated

Resolves #849 
Resolves #805 
