### PR TITLE
Render immediately if the child widget instance of custom element is available

### DIFF
--- a/src/customElements.ts
+++ b/src/customElements.ts
@@ -153,10 +153,13 @@ export function DomToWidgetWrapper(domNode: CustomElement): DomToWidgetWrapper {
 
 		constructor() {
 			super();
-			domNode.addEventListener('connected', () => {
-				this._widgetInstance = domNode.getWidgetInstance();
-				this.invalidate();
-			});
+			this._widgetInstance = domNode.getWidgetInstance && domNode.getWidgetInstance();
+			if (!this._widgetInstance) {
+				domNode.addEventListener('connected', () => {
+					this._widgetInstance = domNode.getWidgetInstance();
+					this.invalidate();
+				});
+			}
 		}
 
 		public __render__(): VNode {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Check for child node instance immediately and only listen to child connected event if it hasn't been initialised.

Resolves #850 
