### PR TITLE
Ensure that vnodes with no tag or text are ignored by the vdom system

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -864,7 +864,7 @@ function updateDom(
 				return textUpdated;
 			}
 		} else {
-			if (dnode.tag.lastIndexOf('svg', 0) === 0) {
+			if (dnode.tag && dnode.tag.lastIndexOf('svg', 0) === 0) {
 				projectionOptions = { ...projectionOptions, ...{ namespace: NAMESPACE_SVG } };
 			}
 			if (previous.children !== dnode.children) {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2379,6 +2379,25 @@ describe('vdom', () => {
 			assert.notEqual(textNode, domNode);
 		});
 
+		it('Should ignore vnode with no tag or text', () => {
+			const domNode = document.createTextNode('text-node');
+			const textVNode: InternalVNode = {
+				tag: undefined as any,
+				properties: {},
+				children: undefined,
+				text: undefined,
+				domNode,
+				type: VNODE
+			};
+			const widget = getWidget(textVNode);
+			const projection = dom.create(widget, { sync: true });
+			let textNode = projection.domNode.childNodes[0] as Text;
+			assert.strictEqual(textNode, domNode);
+			widget.renderResult = { ...textVNode } as any;
+			textNode = projection.domNode.childNodes[0] as Text;
+			assert.strictEqual(textNode, domNode);
+		});
+
 		it('will throw an error when vdom is not sure which node is added', () => {
 			const widgetName = 'span';
 			const widget = getWidget(v('div', [v('span', ['a']), v('span', ['c'])]));


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Guard against a `VNode` that has no tag or or `text`.
