### PR TITLE
Allow generic for properties on custom element to not extend WidgetProperties

### DIFF
--- a/src/decorators/customElement.ts
+++ b/src/decorators/customElement.ts
@@ -1,10 +1,12 @@
 import { CustomElementInitializer } from '../customElements';
 import { Constructor, WidgetProperties } from '../interfaces';
 
+export type CustomElementPropertyNames<P extends object> = ((keyof P) | (keyof WidgetProperties))[];
+
 /**
  * Defines the custom element configuration used by the customElement decorator
  */
-export interface CustomElementConfig<P extends WidgetProperties> {
+export interface CustomElementConfig<P extends object = { [index: string]: any }> {
 	/**
 	 * The tag of the custom element
 	 */
@@ -13,17 +15,17 @@ export interface CustomElementConfig<P extends WidgetProperties> {
 	/**
 	 * List of widget properties to expose as properties on the custom element
 	 */
-	properties?: (keyof P)[];
+	properties?: CustomElementPropertyNames<P>;
 
 	/**
 	 * List of attributes on the custom element to map to widget properties
 	 */
-	attributes?: (keyof P)[];
+	attributes?: CustomElementPropertyNames<P>;
 
 	/**
 	 * List of events to expose
 	 */
-	events?: (keyof P)[];
+	events?: CustomElementPropertyNames<P>;
 
 	/**
 	 * Initialization function called before the widget is created (for custom property setting)
@@ -35,7 +37,7 @@ export interface CustomElementConfig<P extends WidgetProperties> {
  * This Decorator is provided properties that define the behavior of a custom element, and
  * registers that custom element.
  */
-export function customElement<P extends WidgetProperties = WidgetProperties>({
+export function customElement<P extends object = { [index: string]: any }>({
 	tag,
 	properties,
 	attributes,

--- a/tests/functional/decorators/customElement.ts
+++ b/tests/functional/decorators/customElement.ts
@@ -1,10 +1,9 @@
 import { WidgetBase } from '../../../src/WidgetBase';
-import { WidgetProperties } from '../../../src/interfaces';
 import { v } from '../../../src/d';
 import customElement from '../../../src/decorators/customElement';
 import registerCustomElement from '../../../src/registerCustomElement';
 
-interface TestButtonProperties extends WidgetProperties {
+interface TestButtonProperties {
 	label: string;
 	labelSuffix: string;
 	onClick: () => void;

--- a/tests/unit/decorators/customElement.ts
+++ b/tests/unit/decorators/customElement.ts
@@ -3,9 +3,8 @@ const { assert } = intern.getPlugin('chai');
 
 import { customElement } from '../../../src/decorators/customElement';
 import { WidgetBase } from '../../../src/WidgetBase';
-import { WidgetProperties } from '../../../src/interfaces';
 
-interface CustomElementWidgetProperties extends WidgetProperties {
+interface CustomElementWidgetProperties {
 	label: string;
 	labelSuffix: string;
 	onClick: () => void;
@@ -15,7 +14,7 @@ function initialization() {}
 
 @customElement<CustomElementWidgetProperties>({
 	tag: 'custom-element',
-	attributes: ['label', 'labelSuffix'],
+	attributes: ['key', 'label', 'labelSuffix'],
 	properties: ['label'],
 	events: ['onClick'],
 	initialization
@@ -27,7 +26,7 @@ describe('@customElement', () => {
 		assert.deepEqual((CustomElementWidget.prototype as any).__customElementDescriptor, {
 			tagName: 'custom-element',
 			widgetConstructor: CustomElementWidget,
-			attributes: [{ attributeName: 'label' }, { attributeName: 'labelSuffix' }],
+			attributes: [{ attributeName: 'key' }, { attributeName: 'label' }, { attributeName: 'labelSuffix' }],
 			properties: [{ propertyName: 'label' }],
 			events: [{ propertyName: 'onClick', eventName: 'click' }],
 			initialization

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -3029,7 +3029,6 @@ describe('vdom', () => {
 
 		it('Should focus if function for focus returns true', () => {
 			const shouldFocus = () => {
-				console.log('here2');
 				return true;
 			};
 			const widget = getWidget(


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Update the types so that `WidgetProperties` is implicitly added to the allowed keys when using the custom element decorator.

Resolves #855 
