### PR TITLE
Allow consumer to break from the decorate function and support shallow

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -38,18 +38,23 @@ export function isVNode(child: DNode): child is VNode {
 	return Boolean(child && typeof child !== 'string' && child.type === VNODE);
 }
 
-export interface DecorateBreak {
-	(): void;
-}
-
+/**
+ * Interface for the decorate modifier
+ */
 export interface Modifier<T extends DNode> {
-	(dNode: T, breaker: DecorateBreak): void;
+	(dNode: T, breaker: () => void): void;
 }
 
+/**
+ * The predicate function for decorate
+ */
 export interface Predicate<T extends DNode> {
 	(dNode: DNode): dNode is T;
 }
 
+/**
+ * Decorator options
+ */
 export interface DecorateOptions<T extends DNode> {
 	modifier: Modifier<T>;
 	predicate?: Predicate<T>;

--- a/src/d.ts
+++ b/src/d.ts
@@ -65,10 +65,8 @@ export interface DecorateOptions<T extends DNode> {
  * If no predicate is supplied then the modifier will be executed on all nodes. A `breaker` function is passed to the
  * modifier which will drain the nodes array and exit the decoration.
  *
- * When `shallow` is set to `true` the only the top node or nodes will be decorated.
- *
- * @param dNodes A DNode or array of DNodes for decoration.
- * @param options Options that provide the modifier and an optional predicate and shallow flag
+ * When the `shallow` options is set to `true` the only the top node or nodes will be decorated (only supported using
+ * `DecorateOptions`).
  */
 export function decorate<T extends DNode>(dNodes: DNode, options: DecorateOptions<T>): DNode;
 export function decorate<T extends DNode>(dNodes: DNode[], options: DecorateOptions<T>): DNode[];

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -8,6 +8,7 @@ import { Constructor, DNode, WidgetProperties, VNodeProperties } from './../inte
 import { Injector } from './../Injector';
 import { Registry } from './../Registry';
 import { WidgetBase } from './../WidgetBase';
+import { decorate } from '../main';
 
 export const INJECTOR_KEY = Symbol('i18n');
 
@@ -105,23 +106,25 @@ export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & 
 		}
 
 		@afterRender()
-		protected renderDecorator(result: DNode): DNode {
-			if (isVNode(result)) {
-				const { locale, rtl } = this.properties;
-				const properties: I18nVNodeProperties = {
-					dir: null,
-					lang: null
-				};
-
-				if (typeof rtl === 'boolean') {
-					properties['dir'] = rtl ? 'rtl' : 'ltr';
-				}
-				if (locale) {
-					properties['lang'] = locale;
-				}
-
-				assign(result.properties, properties);
-			}
+		protected renderDecorator(result: DNode | DNode[]): DNode | DNode[] {
+			decorate(result, {
+				modifier: (node, breaker) => {
+					const { locale, rtl } = this.properties;
+					const properties: I18nVNodeProperties = {
+						dir: null,
+						lang: null
+					};
+					if (typeof rtl === 'boolean') {
+						properties['dir'] = rtl ? 'rtl' : 'ltr';
+					}
+					if (locale) {
+						properties['lang'] = locale;
+					}
+					node.properties = { ...node.properties, ...properties };
+					breaker();
+				},
+				predicate: isVNode
+			});
 			return result;
 		}
 

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -180,7 +180,7 @@ registerSuite('d', {
 			};
 			const node = testWidget.render();
 			assert.isOk(node);
-			decorate(node, { modifier, predicate });
+			decorate(node, modifier, predicate);
 			if (node) {
 				const children = node.children as any[];
 				assert.isUndefined(children[0].properties['decorated']);
@@ -204,7 +204,7 @@ registerSuite('d', {
 			};
 			const children: any = (<VNode>testWidget.render()).children;
 			assert.isOk(children);
-			decorate(children, { modifier });
+			decorate(children, modifier);
 			if (children) {
 				assert.strictEqual(children[0].properties['id'], 'id');
 				assert.strictEqual(children[1].properties['id'], 'id');

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -7,10 +7,16 @@ import { Registry } from '../../../src/Registry';
 import { WidgetBase } from '../../../src/WidgetBase';
 import bundle from '../../support/nls/greetings';
 import { fetchCldrData } from '../../support/util';
-import { w } from './../../../src/d';
+import { v, w } from './../../../src/d';
 import { ThemedMixin } from './../../../src/mixins/Themed';
 
 class Localized extends I18nMixin(ThemedMixin(WidgetBase))<I18nProperties> {}
+
+class LocalizedWithWidget extends I18nMixin(ThemedMixin(WidgetBase))<I18nProperties> {
+	render() {
+		return w(Localized, {}, [v('div', {})]);
+	}
+}
 
 let localized: any;
 
@@ -186,6 +192,16 @@ registerSuite('mixins/I18nMixin', {
 				const result = localized.__render__();
 				assert.isOk(result);
 				assert.isNull(result.properties!['dir']);
+			},
+
+			'The `dir` attribute is added to the first VNode in the render'() {
+				localized = new LocalizedWithWidget();
+				localized.__setProperties__({ rtl: false });
+
+				const result = localized.__render__();
+				assert.isOk(result);
+				assert.isUndefined(result.properties!['dir']);
+				assert.strictEqual(result.children[0].properties!['dir'], 'ltr');
 			}
 		}
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

* Support for a `breaker` function that can be called in a modifier to drain the queued nodes and exit decoration.
* Supports a `shallow` flag passed in the `DecorateOptions` (new API) to indicate that the `predicate` and `modifier` should only be run against the top level node or nodes.
* Backwards compatible with the existing API, however the existing API does not support the new `shallow` functionality.

Utilises the breaker for `i18n` to break after adding the `i18n` properties to the first `VNode` found.

Resolves #685 
Resolves #846 
