### PR TITLE
invalidate Focus meta on focusout events

### DIFF
--- a/src/meta/Focus.ts
+++ b/src/meta/Focus.ts
@@ -38,18 +38,20 @@ export class Focus extends Base {
 		node && (node as HTMLElement).focus();
 	}
 
-	private _onFocus = () => {
+	private _onFocusChange = () => {
 		this._activeElement = global.document.activeElement;
 		this.invalidate();
 	};
 
 	private _createListener() {
-		global.document.addEventListener('focusin', this._onFocus);
+		global.document.addEventListener('focusin', this._onFocusChange);
+		global.document.addEventListener('focusout', this._onFocusChange);
 		this.own(createHandle(this._removeListener.bind(this)));
 	}
 
 	private _removeListener() {
-		global.document.removeEventListener('focusin', this._onFocus);
+		global.document.removeEventListener('focusin', this._onFocusChange);
+		global.document.removeEventListener('focusout', this._onFocusChange);
 	}
 }
 

--- a/tests/unit/meta/Focus.ts
+++ b/tests/unit/meta/Focus.ts
@@ -106,6 +106,15 @@ describe('meta - Focus', () => {
 			global.document.dispatchEvent(focusEvent);
 			assert.isTrue(invalidateStub.calledOnce);
 		});
+		it('will invalidate on blur events', () => {
+			const blurEvent = global.document.createEvent('Event');
+			blurEvent.initEvent('focusout', true, true);
+			nodeHandler.add(element, 'root');
+
+			focus.get('root');
+			global.document.dispatchEvent(blurEvent);
+			assert.isTrue(invalidateStub.calledOnce);
+		});
 		it('updates the saved activeElement value on focus events', (test) => {
 			if (!isNode) {
 				test.skip('test requires activeElement stub');
@@ -132,22 +141,28 @@ describe('meta - Focus', () => {
 			assert.equal(focusResults.active, false);
 			assert.equal(focusResults.containsFocus, true);
 		});
-		it('removes the focus listener when the meta is destroyed', (test) => {
+		it('removes the focus and blur listeners when the meta is destroyed', (test) => {
 			if (!isNode) {
 				test.skip('test requires activeElement stub');
 			}
 			const focusEvent = global.document.createEvent('Event');
+			const blurEvent = global.document.createEvent('Event');
 			focusEvent.initEvent('focusin', true, true);
+			blurEvent.initEvent('focusout', true, true);
 			nodeHandler.add(element, 'root');
 
 			focus.get('root');
 			global.document.dispatchEvent(focusEvent);
 			assert.isTrue(activeGetter.called, 'focus handler calls activeElement');
+			activeGetter.resetHistory();
+			global.document.dispatchEvent(blurEvent);
+			assert.isTrue(activeGetter.called, 'blur handler calls activeElement');
 
 			focus.destroy();
 			activeGetter.resetHistory();
 			global.document.dispatchEvent(focusEvent);
-			assert.isFalse(activeGetter.called, 'focus handler is removed');
+			global.document.dispatchEvent(blurEvent);
+			assert.isFalse(activeGetter.called, 'focus and blur handlers removed');
 		});
 	});
 


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Realized invalidating only on `focusin` events misses certain types of blur (e.g. tabbing out of the document into browser chrome, or when focus shifts to `body` in the time between mousedown and mouseup events)
