### PR TITLE
Fix incorrect typings for WebAnimations

### DIFF
--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -33,16 +33,12 @@ export interface AnimationTimingProperties {
 	iterationStart?: number;
 }
 
-export interface Effects extends AnimationKeyFrame {}
-export type EffectsFunction = () => Effects;
-export type EffectsOrEffectsFunction = EffectsFunction | Effects;
-
 /**
  * Animation propertiues that can be passed as vdom property `animate`
  */
 export interface AnimationProperties {
 	id: string;
-	effects: EffectsOrEffectsFunction[];
+	effects: (() => AnimationKeyFrame | AnimationKeyFrame)[];
 	controls?: AnimationControls;
 	timing?: AnimationTimingProperties;
 }

--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -45,8 +45,6 @@ export interface AnimationProperties {
 
 export type AnimationPropertiesFunction = () => AnimationProperties;
 
-export type AnimationPropertiesOrAnimationPropertiesFunction = AnimationProperties | AnimationPropertiesFunction;
-
 /**
  * Info returned by the `get` function on WebAnimation meta
  */
@@ -120,8 +118,9 @@ export class WebAnimations extends Base {
 	animate(
 		key: string,
 		animateProperties:
-			| AnimationPropertiesOrAnimationPropertiesFunction
-			| AnimationPropertiesOrAnimationPropertiesFunction[]
+			| AnimationProperties
+			| AnimationPropertiesFunction
+			| (AnimationProperties | AnimationPropertiesFunction)[]
 	) {
 		const node = this.getNode(key) as HTMLElement;
 

--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -43,6 +43,10 @@ export interface AnimationProperties {
 	timing?: AnimationTimingProperties;
 }
 
+export type AnimationPropertiesFunction = () => AnimationProperties;
+
+export type AnimationPropertiesOrAnimationPropertiesFunction = AnimationProperties | AnimationPropertiesFunction;
+
 /**
  * Info returned by the `get` function on WebAnimation meta
  */
@@ -113,7 +117,12 @@ export class WebAnimations extends Base {
 		}
 	}
 
-	animate(key: string, animateProperties: AnimationProperties | AnimationProperties[]) {
+	animate(
+		key: string,
+		animateProperties:
+			| AnimationPropertiesOrAnimationPropertiesFunction
+			| AnimationPropertiesOrAnimationPropertiesFunction[]
+	) {
 		const node = this.getNode(key) as HTMLElement;
 
 		if (node) {

--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -33,12 +33,16 @@ export interface AnimationTimingProperties {
 	iterationStart?: number;
 }
 
+export interface Effects extends AnimationKeyFrame {}
+export type EffectsFunction = () => Effects;
+export type EffectsOrEffectsFunction = EffectsFunction | Effects;
+
 /**
  * Animation propertiues that can be passed as vdom property `animate`
  */
 export interface AnimationProperties {
 	id: string;
-	effects: any[];
+	effects: EffectsOrEffectsFunction[];
 	controls?: AnimationControls;
 	timing?: AnimationTimingProperties;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Changes AnimationProperties to allow array of functions or properties.
- Types the `effects` array (currently any)

Resolves #814 
