### PR TITLE
Missing brackets in Effect typings

### DIFF
--- a/src/meta/WebAnimation.ts
+++ b/src/meta/WebAnimation.ts
@@ -38,7 +38,7 @@ export interface AnimationTimingProperties {
  */
 export interface AnimationProperties {
 	id: string;
-	effects: (() => AnimationKeyFrame | AnimationKeyFrame)[];
+	effects: ((() => AnimationKeyFrame) | AnimationKeyFrame)[];
 	controls?: AnimationControls;
 	timing?: AnimationTimingProperties;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds missing brackets in WebAnimation Effect typings.
