### PR TITLE
Ensure properties are set when they differ from the previous properties

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -388,7 +388,7 @@ function updateProperties(
 				if (propValue !== previousValue) {
 					propertiesUpdated = true;
 				}
-			} else if (propValue !== previousValue) {
+			} else if (propName !== 'key' && propValue !== previousValue) {
 				const type = typeof propValue;
 				if (type === 'function' && propName.lastIndexOf('on', 0) === 0 && includesEventsAndAttributes) {
 					updateEvent(
@@ -401,11 +401,12 @@ function updateProperties(
 					);
 				} else if (type === 'string' && propName !== 'innerHTML' && includesEventsAndAttributes) {
 					updateAttribute(domNode, propName, propValue, projectionOptions);
-				} else {
+				} else if (propName === 'scrollLeft' || propName === 'scrollTop') {
 					if ((domNode as any)[propName] !== propValue) {
-						// Comparison is here for side-effects in Edge with scrollLeft and scrollTop
 						(domNode as any)[propName] = propValue;
 					}
+				} else {
+					(domNode as any)[propName] = propValue;
 				}
 				propertiesUpdated = true;
 			}

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -1593,6 +1593,20 @@ describe('vdom', () => {
 	});
 
 	describe('properties', () => {
+		it('does not add "key" to the dom node', () => {
+			const widget = getWidget(v('div', { key: '1' }));
+			const projection = dom.create(widget, { sync: true });
+			const div = projection.domNode.childNodes[0] as HTMLElement;
+			assert.isNull(div.getAttribute('key'));
+		});
+
+		it('sets properties even when the default DOM node value matches', () => {
+			const widget = getWidget(v('div', { tabIndex: -1 }));
+			const projection = dom.create(widget, { sync: true });
+			const div = projection.domNode.childNodes[0] as HTMLElement;
+			assert.strictEqual(div.getAttribute('tabindex'), '-1');
+		});
+
 		it('updates attributes', () => {
 			const widget = getWidget(v('a', { href: '#1' }));
 			const projection = dom.create(widget, { sync: true });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that properties are set even if the the domNode already has the same value (defaulted), move the domNode property value lookup to only happen for the two identified edge cases.

Also prevent `key` from being added to the domNode attributes.