### PR TITLE
Default `dir` property to zero length string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.9.2",
+  "version": "0.9.3-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -33,7 +33,7 @@ export interface I18nProperties extends LocaleData, WidgetProperties {}
  * An internal helper interface for defining locale and text direction attributes on widget nodes.
  */
 interface I18nVNodeProperties extends VNodeProperties {
-	dir: string | null;
+	dir: string;
 	lang: string | null;
 }
 
@@ -110,7 +110,7 @@ export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & 
 				modifier: (node, breaker) => {
 					const { locale, rtl } = this.properties;
 					const properties: I18nVNodeProperties = {
-						dir: null,
+						dir: '',
 						lang: null
 					};
 					if (typeof rtl === 'boolean') {

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -191,7 +191,7 @@ registerSuite('mixins/I18nMixin', {
 
 				const result = localized.__render__();
 				assert.isOk(result);
-				assert.isNull(result.properties!['dir']);
+				assert.strictEqual(result.properties.dir, '');
 			},
 
 			'The `dir` attribute is added to the first VNode in the render'() {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -8,6 +8,7 @@ import { dom, InternalVNode, InternalWNode, widgetInstanceMap, RenderResult } fr
 import { dom as d, v, w, VNODE } from '../../src/d';
 import { VNode } from '../../src/interfaces';
 import { WidgetBase } from '../../src/WidgetBase';
+import { I18nMixin } from '../../src/mixins/I18n';
 import { Registry } from '../../src/Registry';
 
 let consoleStub: SinonStub;
@@ -3334,5 +3335,21 @@ describe('vdom', () => {
 			assert.isTrue(focusSpy.notCalled);
 			document.body.removeChild(input);
 		});
+	});
+
+	describe('i18n Mixin', () => {
+		class MyWidget extends I18nMixin(WidgetBase) {
+			render() {
+				return v('span');
+			}
+		}
+		const widget = new MyWidget();
+		const projection = dom.create(widget, { sync: true });
+		const root = projection.domNode.childNodes[0] as HTMLElement;
+		assert.strictEqual(root.dir, '');
+		widget.__setProperties__({ rtl: true });
+		assert.strictEqual(root.dir, 'rtl');
+		widget.__setProperties__({ rtl: false });
+		assert.strictEqual(root.dir, 'ltr');
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Default `dir` to `''` over `null` as edge and IE11 throws an error when it is set to anything other than the allowed enums (`''`, `ltr`, `rtl` and `auto`)

Resolves #879 
