### PR TITLE
Use diffType `dom` for custom elements

### DIFF
--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -5,6 +5,7 @@ import { w, dom } from './d';
 import global from '@dojo/shim/global';
 import Registry from './Registry';
 import { registerThemeInjector } from './mixins/Themed';
+import { alwaysRender } from './decorators/alwaysRender';
 
 export enum CustomElementChildType {
 	DOJO = 'DOJO',
@@ -13,7 +14,8 @@ export enum CustomElementChildType {
 }
 
 export function DomToWidgetWrapper(domNode: HTMLElement): any {
-	return class DomToWidgetWrapper extends WidgetBase<any> {
+	@alwaysRender()
+	class DomToWidgetWrapper extends WidgetBase<any> {
 		protected render() {
 			const properties = Object.keys(this.properties).reduce(
 				(props, key: string) => {
@@ -26,13 +28,15 @@ export function DomToWidgetWrapper(domNode: HTMLElement): any {
 				},
 				{} as any
 			);
-			return dom({ node: domNode, props: properties });
+			return dom({ node: domNode, props: properties, diffType: 'dom' });
 		}
 
 		static get domNode() {
 			return domNode;
 		}
-	};
+	}
+
+	return DomToWidgetWrapper;
 }
 
 export function create(descriptor: any, WidgetConstructor: any): any {
@@ -108,7 +112,7 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 					childNode.addEventListener('dojo-ce-connected', () => this._render());
 					this._children.push(DomToWidgetWrapper(childNode as HTMLElement));
 				} else {
-					this._children.push(dom({ node: childNode as HTMLElement }));
+					this._children.push(dom({ node: childNode as HTMLElement, diffType: 'dom' }));
 				}
 			});
 

--- a/tests/unit/registerCustomElement.ts
+++ b/tests/unit/registerCustomElement.ts
@@ -154,7 +154,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with child dojo element', () => {
-		const BarA = createTestWidget({ properties: ['parentProp'] });
+		const BarA = createTestWidget({});
 		const CustomElementA = create((BarA.prototype as any).__customElementDescriptor, BarA);
 		customElements.define('bar-a', CustomElementA);
 		const BarB = createTestWidget({ attributes: ['myAttr'], properties: ['myProp'], events: ['onBar'] });

--- a/tests/unit/registerCustomElement.ts
+++ b/tests/unit/registerCustomElement.ts
@@ -154,7 +154,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with child dojo element', () => {
-		const BarA = createTestWidget({});
+		const BarA = createTestWidget({ properties: ['parentProp'] });
 		const CustomElementA = create((BarA.prototype as any).__customElementDescriptor, BarA);
 		customElements.define('bar-a', CustomElementA);
 		const BarB = createTestWidget({ attributes: ['myAttr'], properties: ['myProp'], events: ['onBar'] });
@@ -162,11 +162,16 @@ describe('registerCustomElement', () => {
 		customElements.define('bar-b', CustomElementB);
 		element = document.createElement('bar-a');
 		const barB = document.createElement('bar-b');
+		let childRenderCounter = 0;
+		element.addEventListener('dojo-ce-render', () => {
+			childRenderCounter++;
+		});
 		element.appendChild(barB);
 		document.body.appendChild(element);
 		(barB as any).myProp = 'set property on child';
-
 		resolvers.resolve();
+
+		assert.strictEqual(2, childRenderCounter);
 
 		const container = element.querySelector('.children');
 		const children = (container as any).children;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

To ensure that custom elements needless re-render, use the `dom` diffType to check against the existing DOM property values
