### PR TITLE
Extract projector state from projection options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -69,16 +69,12 @@ export interface ProjectorOptions {
 
 export interface ProjectionOptions extends ProjectorOptions {
 	namespace?: string;
-	deferredRenderCallbacks: Function[];
-	afterRenderCallbacks: Function[];
 	merge: boolean;
 	sync: boolean;
 	mergeElement?: Element;
-	nodeMap: WeakMap<Node, WeakMap<Function, EventListener>>;
 	rootNode: Element;
 	depth: number;
 	projectorInstance: DefaultWidgetBaseInterface;
-	renderScheduled?: number;
 }
 
 export interface Projection {

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -103,7 +103,6 @@ interface ProjectorState {
 export const widgetInstanceMap = new WeakMap<any, WidgetData>();
 
 const instanceMap = new WeakMap<DefaultWidgetBaseInterface, InstanceMapData>();
-// const renderQueueMap = new WeakMap<DefaultWidgetBaseInterface, RenderQueue[]>();
 const projectorStateMap = new WeakMap<DefaultWidgetBaseInterface, ProjectorState>();
 const projectionRenderScheduledMap = new Map<number, number | undefined>();
 let projectionRenderScheduledCounter = 0;

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -17,7 +17,6 @@ import { isWidgetBaseConstructor } from './Registry';
 import WeakMap from '@dojo/shim/WeakMap';
 import NodeHandler from './NodeHandler';
 import RegistryHandler from './RegistryHandler';
-import { Map } from '@dojo/shim/Map';
 
 const NAMESPACE_W3 = 'http://www.w3.org/';
 const NAMESPACE_SVG = NAMESPACE_W3 + '2000/svg';
@@ -104,8 +103,6 @@ export const widgetInstanceMap = new WeakMap<any, WidgetData>();
 
 const instanceMap = new WeakMap<DefaultWidgetBaseInterface, InstanceMapData>();
 const projectorStateMap = new WeakMap<DefaultWidgetBaseInterface, ProjectorState>();
-const projectionRenderScheduledMap = new Map<number, number | undefined>();
-let projectionRenderScheduledCounter = 0;
 
 function same(dnode1: InternalDNode, dnode2: InternalDNode) {
 	if (isVNode(dnode1) && isVNode(dnode2)) {
@@ -136,8 +133,6 @@ function getProjectionOptions(
 	projectorOptions: Partial<ProjectionOptions>,
 	projectorInstance: DefaultWidgetBaseInterface
 ): ProjectionOptions {
-	const renderScheduled = projectionRenderScheduledCounter++;
-	projectionRenderScheduledMap.set(renderScheduled, undefined);
 	const defaults: Partial<ProjectionOptions> = {
 		namespace: undefined,
 		styleApplyer: function(domNode: HTMLElement, styleName: string, value: string) {

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -17,6 +17,7 @@ import { isWidgetBaseConstructor } from './Registry';
 import WeakMap from '@dojo/shim/WeakMap';
 import NodeHandler from './NodeHandler';
 import RegistryHandler from './RegistryHandler';
+import { Map } from '@dojo/shim/Map';
 
 const NAMESPACE_W3 = 'http://www.w3.org/';
 const NAMESPACE_SVG = NAMESPACE_W3 + '2000/svg';
@@ -91,10 +92,20 @@ export interface WidgetData {
 	inputProperties: any;
 }
 
+interface ProjectorState {
+	deferredRenderCallbacks: Function[];
+	afterRenderCallbacks: Function[];
+	nodeMap: WeakMap<Node, WeakMap<Function, EventListener>>;
+	renderScheduled?: number;
+}
+
 export const widgetInstanceMap = new WeakMap<any, WidgetData>();
 
 const instanceMap = new WeakMap<DefaultWidgetBaseInterface, InstanceMapData>();
 const renderQueueMap = new WeakMap<DefaultWidgetBaseInterface, RenderQueue[]>();
+const projectorStateMap = new WeakMap<DefaultWidgetBaseInterface, ProjectorState>();
+const projectionRenderScheduledMap = new Map<number, number | undefined>();
+let projectionRenderScheduledCounter = 0;
 
 function same(dnode1: InternalDNode, dnode2: InternalDNode) {
 	if (isVNode(dnode1) && isVNode(dnode2)) {
@@ -125,7 +136,9 @@ function getProjectionOptions(
 	projectorOptions: Partial<ProjectionOptions>,
 	projectorInstance: DefaultWidgetBaseInterface
 ): ProjectionOptions {
-	const defaults = {
+	const renderScheduled = projectionRenderScheduledCounter++;
+	projectionRenderScheduledMap.set(renderScheduled, undefined);
+	const defaults: Partial<ProjectionOptions> = {
 		namespace: undefined,
 		styleApplyer: function(domNode: HTMLElement, styleName: string, value: string) {
 			(domNode.style as any)[styleName] = value;
@@ -134,13 +147,9 @@ function getProjectionOptions(
 			enter: missingTransition,
 			exit: missingTransition
 		},
-		deferredRenderCallbacks: [],
-		afterRenderCallbacks: [],
-		nodeMap: new WeakMap(),
 		depth: 0,
 		merge: false,
-		renderScheduled: undefined,
-		renderQueue: [],
+		sync: false,
 		projectorInstance
 	};
 	return { ...defaults, ...projectorOptions } as ProjectionOptions;
@@ -160,7 +169,8 @@ function updateEvent(
 	bind: any,
 	previousValue?: Function
 ) {
-	const eventMap = projectionOptions.nodeMap.get(domNode) || new WeakMap();
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
+	const eventMap = projectorState.nodeMap.get(domNode) || new WeakMap();
 
 	if (previousValue) {
 		const previousEvent = eventMap.get(previousValue);
@@ -178,7 +188,7 @@ function updateEvent(
 
 	domNode.addEventListener(eventName, callback);
 	eventMap.set(currentValue, callback);
-	projectionOptions.nodeMap.set(domNode, eventMap);
+	projectorState.nodeMap.set(domNode, eventMap);
 }
 
 function addClasses(domNode: Element, classes: SupportedClassName) {
@@ -238,7 +248,8 @@ function focusNode(propValue: any, previousValue: any, domNode: Element, project
 		result = propValue && !previousValue;
 	}
 	if (result === true) {
-		projectionOptions.deferredRenderCallbacks.push(() => {
+		const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
+		projectorState.deferredRenderCallbacks.push(() => {
 			(domNode as HTMLElement).focus();
 		});
 	}
@@ -251,7 +262,8 @@ function removeOrphanedEvents(
 	projectionOptions: ProjectionOptions,
 	onlyEvents: boolean = false
 ) {
-	const eventMap = projectionOptions.nodeMap.get(domNode);
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
+	const eventMap = projectorState.nodeMap.get(domNode);
 	if (eventMap) {
 		Object.keys(previousProperties).forEach((propName) => {
 			const isEvent = propName.substr(0, 2) === 'on' || onlyEvents;
@@ -610,6 +622,7 @@ function updateChildren(
 	const oldChildrenLength = oldChildren.length;
 	const newChildrenLength = newChildren.length;
 	const transitions = projectionOptions.transitions!;
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 	projectionOptions = { ...projectionOptions, depth: projectionOptions.depth + 1 };
 	let oldIndex = 0;
 	let newIndex = 0;
@@ -631,7 +644,7 @@ function updateChildren(
 				for (i = oldIndex; i < findOldIndex; i++) {
 					const oldChild = oldChildren[i];
 					const indexToCheck = i;
-					projectionOptions.afterRenderCallbacks.push(() => {
+					projectorState.afterRenderCallbacks.push(() => {
 						callOnDetach(oldChild, parentInstance);
 						checkDistinguishable(oldChildren, indexToCheck, parentInstance);
 					});
@@ -665,7 +678,7 @@ function updateChildren(
 				createDom(newChild, parentVNode, insertBefore, projectionOptions, parentInstance);
 				nodeAdded(newChild, transitions);
 				const indexToCheck = newIndex;
-				projectionOptions.afterRenderCallbacks.push(() => {
+				projectorState.afterRenderCallbacks.push(() => {
 					checkDistinguishable(newChildren, indexToCheck, parentInstance);
 				});
 			}
@@ -677,7 +690,7 @@ function updateChildren(
 		for (i = oldIndex; i < oldChildrenLength; i++) {
 			const oldChild = oldChildren[i];
 			const indexToCheck = i;
-			projectionOptions.afterRenderCallbacks.push(() => {
+			projectorState.afterRenderCallbacks.push(() => {
 				callOnDetach(oldChild, parentInstance);
 				checkDistinguishable(oldChildren, indexToCheck, parentInstance);
 			});
@@ -765,6 +778,7 @@ function createDom(
 	let domNode: Element | Text | undefined;
 	if (isWNode(dnode)) {
 		let { widgetConstructor } = dnode;
+		const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 		const parentInstanceData = widgetInstanceMap.get(parentInstance)!;
 		if (!isWidgetBaseConstructor<DefaultWidgetBaseInterface>(widgetConstructor)) {
 			const item = parentInstanceData.registry().get<DefaultWidgetBaseInterface>(widgetConstructor);
@@ -788,8 +802,8 @@ function createDom(
 		instance.__setCoreProperties__(dnode.coreProperties);
 		instance.__setChildren__(dnode.children);
 		instance.__setProperties__(dnode.properties);
-		instanceData.rendering = false;
 		const rendered = instance.__render__();
+		instanceData.rendering = false;
 		if (rendered) {
 			const filteredRendered = filterAndDecorateChildren(rendered, instance);
 			dnode.rendered = filteredRendered;
@@ -797,7 +811,7 @@ function createDom(
 		}
 		instanceMap.set(instance, { dnode, parentVNode });
 		instanceData.nodeHandler.addRoot();
-		projectionOptions.afterRenderCallbacks.push(() => {
+		projectorState.afterRenderCallbacks.push(() => {
 			instanceData.onAttach();
 		});
 	} else {
@@ -866,14 +880,15 @@ function updateDom(
 			instance.__setCoreProperties__(dnode.coreProperties);
 			instance.__setChildren__(dnode.children);
 			instance.__setProperties__(dnode.properties);
-			instanceData.rendering = false;
 			dnode.instance = instance;
 			instanceMap.set(instance, { dnode, parentVNode });
 			if (instanceData.dirty === true) {
 				const rendered = instance.__render__();
+				instanceData.rendering = false;
 				dnode.rendered = filterAndDecorateChildren(rendered, instance);
 				updateChildren(parentVNode, previousRendered, dnode.rendered, instance, projectionOptions);
 			} else {
+				instanceData.rendering = false;
 				dnode.rendered = previousRendered;
 			}
 			instanceData.nodeHandler.addRoot();
@@ -950,8 +965,9 @@ function addDeferredProperties(vnode: InternalVNode, projectionOptions: Projecti
 	// transfer any properties that have been passed - as these must be decorated properties
 	vnode.decoratedDeferredProperties = vnode.properties;
 	const properties = vnode.deferredPropertiesCallback!(!!vnode.inserted);
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 	vnode.properties = { ...properties, ...vnode.decoratedDeferredProperties };
-	projectionOptions.deferredRenderCallbacks.push(() => {
+	projectorState.deferredRenderCallbacks.push(() => {
 		const properties = {
 			...vnode.deferredPropertiesCallback!(!!vnode.inserted),
 			...vnode.decoratedDeferredProperties
@@ -962,16 +978,17 @@ function addDeferredProperties(vnode: InternalVNode, projectionOptions: Projecti
 }
 
 function runDeferredRenderCallbacks(projectionOptions: ProjectionOptions) {
-	if (projectionOptions.deferredRenderCallbacks.length) {
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
+	if (projectorState.deferredRenderCallbacks.length) {
 		if (projectionOptions.sync) {
-			while (projectionOptions.deferredRenderCallbacks.length) {
-				const callback = projectionOptions.deferredRenderCallbacks.shift();
+			while (projectorState.deferredRenderCallbacks.length) {
+				const callback = projectorState.deferredRenderCallbacks.shift();
 				callback && callback();
 			}
 		} else {
 			global.requestAnimationFrame(() => {
-				while (projectionOptions.deferredRenderCallbacks.length) {
-					const callback = projectionOptions.deferredRenderCallbacks.shift();
+				while (projectorState.deferredRenderCallbacks.length) {
+					const callback = projectorState.deferredRenderCallbacks.shift();
 					callback && callback();
 				}
 			});
@@ -980,23 +997,24 @@ function runDeferredRenderCallbacks(projectionOptions: ProjectionOptions) {
 }
 
 function runAfterRenderCallbacks(projectionOptions: ProjectionOptions) {
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 	if (projectionOptions.sync) {
-		while (projectionOptions.afterRenderCallbacks.length) {
-			const callback = projectionOptions.afterRenderCallbacks.shift();
+		while (projectorState.afterRenderCallbacks.length) {
+			const callback = projectorState.afterRenderCallbacks.shift();
 			callback && callback();
 		}
 	} else {
 		if (global.requestIdleCallback) {
 			global.requestIdleCallback(() => {
-				while (projectionOptions.afterRenderCallbacks.length) {
-					const callback = projectionOptions.afterRenderCallbacks.shift();
+				while (projectorState.afterRenderCallbacks.length) {
+					const callback = projectorState.afterRenderCallbacks.shift();
 					callback && callback();
 				}
 			});
 		} else {
 			setTimeout(() => {
-				while (projectionOptions.afterRenderCallbacks.length) {
-					const callback = projectionOptions.afterRenderCallbacks.shift();
+				while (projectorState.afterRenderCallbacks.length) {
+					const callback = projectorState.afterRenderCallbacks.shift();
 					callback && callback();
 				}
 			});
@@ -1005,17 +1023,19 @@ function runAfterRenderCallbacks(projectionOptions: ProjectionOptions) {
 }
 
 function scheduleRender(projectionOptions: ProjectionOptions) {
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 	if (projectionOptions.sync) {
 		render(projectionOptions);
-	} else if (projectionOptions.renderScheduled === undefined) {
-		projectionOptions.renderScheduled = global.requestAnimationFrame(() => {
+	} else if (projectorState.renderScheduled === undefined) {
+		projectorState.renderScheduled = global.requestAnimationFrame(() => {
 			render(projectionOptions);
 		});
 	}
 }
 
 function render(projectionOptions: ProjectionOptions) {
-	projectionOptions.renderScheduled = undefined;
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
+	projectorState.renderScheduled = undefined;
 	const renderQueue = renderQueueMap.get(projectionOptions.projectorInstance)!;
 	const renders = [...renderQueue];
 	renderQueueMap.set(projectionOptions.projectorInstance, []);
@@ -1039,6 +1059,13 @@ export const dom = {
 	): Projection {
 		const instanceData = widgetInstanceMap.get(instance)!;
 		const finalProjectorOptions = getProjectionOptions(projectionOptions, instance);
+		const projectorState: ProjectorState = {
+			afterRenderCallbacks: [],
+			deferredRenderCallbacks: [],
+			nodeMap: new WeakMap(),
+			renderScheduled: undefined
+		};
+		projectorStateMap.set(instance, projectorState);
 
 		finalProjectorOptions.rootNode = parentNode;
 		const parentVNode = toParentVNode(finalProjectorOptions.rootNode);
@@ -1055,7 +1082,7 @@ export const dom = {
 			}
 		};
 		updateDom(node, node, finalProjectorOptions, parentVNode, instance);
-		finalProjectorOptions.afterRenderCallbacks.push(() => {
+		projectorState.afterRenderCallbacks.push(() => {
 			instanceData.onAttach();
 		});
 		runDeferredRenderCallbacks(finalProjectorOptions);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Projector state should not be able to get into an inconsistent state across the widget tree. This change extracts all top level projector state to a separate map to ensure that cannot occur.

Resolves #882 