### PR TITLE
Reorder the overloads for v() so that it gives error information against VNodeProperties

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -143,8 +143,8 @@ export function w<W extends WidgetBaseInterface>(
 /**
  * Wrapper function for calls to create VNodes.
  */
-export function v(tag: string, properties: VNodeProperties | DeferredVirtualProperties, children?: DNode[]): VNode;
 export function v(tag: string, children: undefined | DNode[]): VNode;
+export function v(tag: string, properties: DeferredVirtualProperties | VNodeProperties, children?: DNode[]): VNode;
 export function v(tag: string): VNode;
 export function v(
 	tag: string,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The common usage for `v()` is to use `VNodeProperties` over deferred properties, this re-orders the overloads so that it gives error information against `VNodeProperties`.

Resolves #843 
