### PR TITLE
fix typings for registry.define using imports

### DIFF
--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -91,7 +91,7 @@ export function isWidgetBaseConstructor<T extends WidgetBaseInterface>(item: any
 
 export interface ESMDefaultWidgetBase<T> {
 	default: Constructor<T>;
-	__esModule: boolean;
+	__esModule?: boolean;
 }
 
 export function isWidgetConstructorDefaultExport<T>(item: any): item is ESMDefaultWidgetBase<T> {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

`import()` returns a promise of an object with `default`, but currently the typings are expecting `__esModule` as well which means the following fails for typings.:

```ts
registry.define('widget', () => import('./Widget'));
```
