### PR TITLE
Ensure registry items are placed in the correct order once they are loaded

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -114,6 +114,9 @@ function same(dnode1: InternalDNode, dnode2: InternalDNode) {
 		}
 		return true;
 	} else if (isWNode(dnode1) && isWNode(dnode2)) {
+		if (dnode1.instance === undefined && typeof dnode2.widgetConstructor === 'string') {
+			return false;
+		}
 		if (dnode1.widgetConstructor !== dnode2.widgetConstructor) {
 			return false;
 		}
@@ -866,29 +869,25 @@ function updateDom(
 ) {
 	if (isWNode(dnode)) {
 		const { instance } = previous;
-		if (instance) {
-			const { parentVNode, dnode: node } = instanceMap.get(instance)!;
-			const previousRendered = node ? node.rendered : previous.rendered;
-			const instanceData = widgetInstanceMap.get(instance)!;
-			instanceData.rendering = true;
-			instance.__setCoreProperties__(dnode.coreProperties);
-			instance.__setChildren__(dnode.children);
-			instance.__setProperties__(dnode.properties);
-			dnode.instance = instance;
-			instanceMap.set(instance, { dnode, parentVNode });
-			if (instanceData.dirty === true) {
-				const rendered = instance.__render__();
-				instanceData.rendering = false;
-				dnode.rendered = filterAndDecorateChildren(rendered, instance);
-				updateChildren(parentVNode, previousRendered, dnode.rendered, instance, projectionOptions);
-			} else {
-				instanceData.rendering = false;
-				dnode.rendered = previousRendered;
-			}
-			instanceData.nodeHandler.addRoot();
+		const { parentVNode, dnode: node } = instanceMap.get(instance)!;
+		const previousRendered = node ? node.rendered : previous.rendered;
+		const instanceData = widgetInstanceMap.get(instance)!;
+		instanceData.rendering = true;
+		instance.__setCoreProperties__(dnode.coreProperties);
+		instance.__setChildren__(dnode.children);
+		instance.__setProperties__(dnode.properties);
+		dnode.instance = instance;
+		instanceMap.set(instance, { dnode, parentVNode });
+		if (instanceData.dirty === true) {
+			const rendered = instance.__render__();
+			instanceData.rendering = false;
+			dnode.rendered = filterAndDecorateChildren(rendered, instance);
+			updateChildren(parentVNode, previousRendered, dnode.rendered, instance, projectionOptions);
 		} else {
-			createDom(dnode, parentVNode, undefined, projectionOptions, parentInstance);
+			instanceData.rendering = false;
+			dnode.rendered = previousRendered;
 		}
+		instanceData.nodeHandler.addRoot();
 	} else {
 		if (previous === dnode) {
 			return false;

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -390,6 +390,46 @@ describe('vdom', () => {
 			assert.strictEqual(headerTwoText.data, 'bar');
 		});
 
+		it('registry items', () => {
+			let resolver = () => {};
+			const baseRegistry = new Registry();
+			class Widget extends WidgetBase {
+				render() {
+					return v('div', ['Hello, world!']);
+				}
+			}
+			class RegistryWidget extends WidgetBase {
+				render() {
+					return v('div', ['Registry, World!']);
+				}
+			}
+			const promise = new Promise<any>((resolve) => {
+				resolver = () => {
+					resolve(RegistryWidget);
+				};
+			});
+			baseRegistry.define('registry-item', promise);
+			class App extends WidgetBase {
+				render() {
+					return [w('registry-item', {}), w(Widget, {})];
+				}
+			}
+			const widget = new App();
+			widget.__setCoreProperties__({ bind: widget, baseRegistry });
+			const projection = dom.create(widget);
+			resolvers.resolve();
+			const root = projection.domNode as HTMLElement;
+			assert.lengthOf(root.childNodes, 1);
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'Hello, world!');
+			resolver();
+			return promise.then(() => {
+				resolvers.resolve();
+				assert.lengthOf(root.childNodes, 2);
+				assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'Registry, world!');
+				assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'Hello, world!');
+			});
+		});
+
 		it('should invalidate when a registry items is loaded', () => {
 			const baseRegistry = new Registry();
 

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -400,7 +400,7 @@ describe('vdom', () => {
 			}
 			class RegistryWidget extends WidgetBase {
 				render() {
-					return v('div', ['Registry, World!']);
+					return v('div', ['Registry, world!']);
 				}
 			}
 			const promise = new Promise<any>((resolve) => {
@@ -416,14 +416,12 @@ describe('vdom', () => {
 			}
 			const widget = new App();
 			widget.__setCoreProperties__({ bind: widget, baseRegistry });
-			const projection = dom.create(widget);
-			resolvers.resolve();
+			const projection = dom.create(widget, { sync: true });
 			const root = projection.domNode as HTMLElement;
 			assert.lengthOf(root.childNodes, 1);
 			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'Hello, world!');
 			resolver();
 			return promise.then(() => {
-				resolvers.resolve();
 				assert.lengthOf(root.childNodes, 2);
 				assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'Registry, world!');
 				assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'Hello, world!');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fixes an issue with placing registry items on a subsequent render in which they have been loaded in the registry since the previous render. It does this by never considering WNodes as the the same in the comparison if they previous has not got an instance and the current has a string `widgetConstructor`.

Resolves #887 
