### PR TITLE
Only perform merge for initial render

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -97,6 +97,8 @@ interface ProjectorState {
 	nodeMap: WeakMap<Node, WeakMap<Function, EventListener>>;
 	renderScheduled?: number;
 	renderQueue: RenderQueue[];
+	merge: boolean;
+	mergeElement?: Node;
 }
 
 export const widgetInstanceMap = new WeakMap<any, WidgetData>();
@@ -707,7 +709,8 @@ function addChildren(
 		return;
 	}
 
-	if (projectionOptions.merge && childNodes === undefined) {
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
+	if (projectorState.merge && childNodes === undefined) {
 		childNodes = arrayFrom(parentVNode.domNode!.childNodes) as (Element | Text)[];
 	}
 
@@ -717,7 +720,7 @@ function addChildren(
 		const child = children[i];
 
 		if (isVNode(child)) {
-			if (projectionOptions.merge && childNodes) {
+			if (projectorState.merge && childNodes) {
 				let domElement: Element | undefined = undefined;
 				while (child.domNode === undefined && childNodes.length > 0) {
 					domElement = childNodes.shift() as Element;
@@ -771,9 +774,9 @@ function createDom(
 	childNodes?: (Element | Text)[]
 ) {
 	let domNode: Element | Text | undefined;
+	const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 	if (isWNode(dnode)) {
 		let { widgetConstructor } = dnode;
-		const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 		const parentInstanceData = widgetInstanceMap.get(parentInstance)!;
 		if (!isWidgetBaseConstructor<DefaultWidgetBaseInterface>(widgetConstructor)) {
 			const item = parentInstanceData.registry().get<DefaultWidgetBaseInterface>(widgetConstructor);
@@ -809,9 +812,9 @@ function createDom(
 			instanceData.onAttach();
 		});
 	} else {
-		if (projectionOptions.merge && projectionOptions.mergeElement !== undefined) {
+		if (projectorState.merge && projectorState.mergeElement !== undefined) {
 			domNode = dnode.domNode = projectionOptions.mergeElement;
-			projectionOptions.mergeElement = undefined;
+			projectorState.mergeElement = undefined;
 			initPropertiesAndChildren(domNode!, dnode, parentInstance, projectionOptions);
 			return;
 		}
@@ -1058,7 +1061,9 @@ export const dom = {
 			deferredRenderCallbacks: [],
 			nodeMap: new WeakMap(),
 			renderScheduled: undefined,
-			renderQueue: []
+			renderQueue: [],
+			merge: projectionOptions.merge || false,
+			mergeElement: projectionOptions.mergeElement
 		};
 		projectorStateMap.set(instance, projectorState);
 
@@ -1093,6 +1098,9 @@ export const dom = {
 	): Projection {
 		projectionOptions.merge = true;
 		projectionOptions.mergeElement = element;
-		return this.append(element.parentNode as Element, instance, projectionOptions);
+		const projection = this.append(element.parentNode as Element, instance, projectionOptions);
+		const projectorState = projectorStateMap.get(instance)!;
+		projectorState.merge = false;
+		return projection;
 	}
 };

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -1484,6 +1484,44 @@ describe('vdom', () => {
 
 				document.body.removeChild(iframe);
 			});
+
+			it('Should only merge on the first render', () => {
+				const iframe = document.createElement('iframe');
+				document.body.appendChild(iframe);
+				iframe.contentDocument.write(`<div>Loading</div>`);
+				iframe.contentDocument.close();
+				const root = iframe.contentDocument.body.firstChild as HTMLElement;
+
+				class Bar extends WidgetBase<any> {
+					render() {
+						return v('div', [`Item ${this.properties.id}`]);
+					}
+				}
+
+				class Foo extends WidgetBase {
+					private _renderCount = 0;
+
+					render() {
+						let nodes;
+						if (this._renderCount === 0) {
+							nodes = v('div', ['Loading']);
+						} else {
+							nodes = v('div', [w(Bar, { id: '1' }), w(Bar, { id: '2' }), w(Bar, { id: '3' })]);
+						}
+						this._renderCount++;
+						return nodes;
+					}
+				}
+				const widget = new Foo();
+				dom.merge(root, widget, { sync: true });
+				assert.lengthOf(root.childNodes, 1);
+				widget.invalidate();
+				assert.strictEqual(root.childNodes.length, 3);
+				assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'Item 1');
+				assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'Item 2');
+				assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'Item 3');
+				document.body.removeChild(iframe);
+			});
 		});
 	});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Sets the `merge` flag to `false` after the initial render to ensure subsequent nodes are rendered correctly.

Resolves #889 
