### PR TITLE
Remove inject listener when widget is destroyed

### DIFF
--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -43,7 +43,7 @@ export interface InjectConfig {
  */
 export function inject({ name, getProperties }: InjectConfig) {
 	return handleDecorator((target, propertyKey) => {
-		beforeProperties(function(this: WidgetBase, properties: any) {
+		beforeProperties(function(this: WidgetBase & { own: Function }, properties: any) {
 			const injector = this.registry.getInjector(name);
 			if (injector) {
 				const registeredInjectors = registeredInjectorsMap.get(this) || [];
@@ -51,9 +51,11 @@ export function inject({ name, getProperties }: InjectConfig) {
 					registeredInjectorsMap.set(this, registeredInjectors);
 				}
 				if (registeredInjectors.indexOf(injector) === -1) {
-					injector.on('invalidate', () => {
-						this.invalidate();
-					});
+					this.own(
+						injector.on('invalidate', () => {
+							this.invalidate();
+						})
+					);
 					registeredInjectors.push(injector);
 				}
 				return getProperties(injector.get(), properties);

--- a/tests/unit/decorators/inject.ts
+++ b/tests/unit/decorators/inject.ts
@@ -71,6 +71,32 @@ registerSuite('decorators/inject', {
 			widget.__setProperties__({});
 			assert.strictEqual(widget.properties.foo, 'bar');
 			assert.strictEqual(widget.properties.bar, 'foo');
+		},
+		'invalidate listeners are removed when widget is destroyed'() {
+			function getProperties(payload: any, properties: WidgetProperties): WidgetProperties {
+				return payload;
+			}
+			let invalidateCounter = 0;
+			@inject({ name: 'inject-one', getProperties: getProperties })
+			class TestWidget extends WidgetBase<any> {
+				destroy() {
+					super.destroy();
+				}
+				invalidate() {
+					invalidateCounter++;
+					super.invalidate();
+				}
+			}
+			const widget = new TestWidget();
+			widget.__setCoreProperties__({ bind: widget, baseRegistry: registry });
+			widget.__setProperties__({});
+			injectorOne.set({});
+			assert.strictEqual(invalidateCounter, 3);
+			injectorOne.set({});
+			assert.strictEqual(invalidateCounter, 4);
+			widget.destroy();
+			injectorOne.set({});
+			assert.strictEqual(invalidateCounter, 4);
 		}
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Moves `own` and `destroy` from `Projector` to `WidgetBase` (is then inherited from `WidgetBase` for the `Projector`) and the inject listeners are `own`ed so that they are removed when the widget is destroyed.

Resolves #891 
