### PR TITLE
Optimize algorithm using for updating children

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -643,8 +643,7 @@ function updateChildren(
 		}
 
 		const findOldIndex = findIndexOfChild(oldChildren, newChild, oldIndex + 1);
-
-		if (!oldChild || findOldIndex === -1) {
+		const addChild = () => {
 			let insertBefore: Element | Text | undefined = undefined;
 			let child: InternalDNode = oldChildren[oldIndex];
 			if (child) {
@@ -671,57 +670,32 @@ function updateChildren(
 			projectorState.afterRenderCallbacks.push(() => {
 				checkDistinguishable(newChildren, indexToCheck, parentInstance);
 			});
+		};
+
+		if (!oldChild || findOldIndex === -1) {
+			addChild();
 			newIndex++;
 			continue;
 		}
 
-		const findNewIndex = findIndexOfChild(newChildren, oldChild, newIndex + 1);
-
-		if (findNewIndex === -1) {
+		const removeChild = () => {
 			const indexToCheck = oldIndex;
 			projectorState.afterRenderCallbacks.push(() => {
 				callOnDetach(oldChild, parentInstance);
 				checkDistinguishable(oldChildren, indexToCheck, parentInstance);
 			});
 			nodeToRemove(oldChild, transitions, projectionOptions);
+		};
+		const findNewIndex = findIndexOfChild(newChildren, oldChild, newIndex + 1);
+
+		if (findNewIndex === -1) {
+			removeChild();
 			oldIndex++;
-			// newIndex++;
 			continue;
 		}
 
-		// new and old exist but have moved
-		let insertBefore: Element | Text | undefined = undefined;
-		let child: InternalDNode = oldChildren[oldIndex];
-		if (child) {
-			let nextIndex = oldIndex + 1;
-			while (insertBefore === undefined) {
-				if (isWNode(child)) {
-					if (child.rendered) {
-						child = child.rendered[0];
-					} else if (oldChildren[nextIndex]) {
-						child = oldChildren[nextIndex];
-						nextIndex++;
-					} else {
-						break;
-					}
-				} else {
-					insertBefore = child.domNode;
-				}
-			}
-		}
-
-		createDom(newChild, parentVNode, insertBefore, projectionOptions, parentInstance);
-		nodeAdded(newChild, transitions);
-		const newIndexToCheck = newIndex;
-		const oldIndexToCheck = oldIndex;
-		projectorState.afterRenderCallbacks.push(() => {
-			checkDistinguishable(newChildren, newIndexToCheck, parentInstance);
-		});
-		projectorState.afterRenderCallbacks.push(() => {
-			callOnDetach(oldChild, parentInstance);
-			checkDistinguishable(oldChildren, oldIndexToCheck, parentInstance);
-		});
-		nodeToRemove(oldChild, transitions, projectionOptions);
+		addChild();
+		removeChild();
 		oldIndex++;
 		newIndex++;
 	}

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -638,51 +638,91 @@ function updateChildren(
 		if (oldChild !== undefined && same(oldChild, newChild)) {
 			textUpdated = updateDom(oldChild, newChild, projectionOptions, parentVNode, parentInstance) || textUpdated;
 			oldIndex++;
-		} else {
-			const findOldIndex = findIndexOfChild(oldChildren, newChild, oldIndex + 1);
-			if (findOldIndex >= 0) {
-				for (i = oldIndex; i < findOldIndex; i++) {
-					const oldChild = oldChildren[i];
-					const indexToCheck = i;
-					projectorState.afterRenderCallbacks.push(() => {
-						callOnDetach(oldChild, parentInstance);
-						checkDistinguishable(oldChildren, indexToCheck, parentInstance);
-					});
-					nodeToRemove(oldChildren[i], transitions, projectionOptions);
-				}
-				textUpdated =
-					updateDom(oldChildren[findOldIndex], newChild, projectionOptions, parentVNode, parentInstance) ||
-					textUpdated;
-				oldIndex = findOldIndex + 1;
-			} else {
-				let insertBefore: Element | Text | undefined = undefined;
-				let child: InternalDNode = oldChildren[oldIndex];
-				if (child) {
-					let nextIndex = oldIndex + 1;
-					while (insertBefore === undefined) {
-						if (isWNode(child)) {
-							if (child.rendered) {
-								child = child.rendered[0];
-							} else if (oldChildren[nextIndex]) {
-								child = oldChildren[nextIndex];
-								nextIndex++;
-							} else {
-								break;
-							}
+			newIndex++;
+			continue;
+		}
+
+		const findOldIndex = findIndexOfChild(oldChildren, newChild, oldIndex + 1);
+
+		if (!oldChild || findOldIndex === -1) {
+			let insertBefore: Element | Text | undefined = undefined;
+			let child: InternalDNode = oldChildren[oldIndex];
+			if (child) {
+				let nextIndex = oldIndex + 1;
+				while (insertBefore === undefined) {
+					if (isWNode(child)) {
+						if (child.rendered) {
+							child = child.rendered[0];
+						} else if (oldChildren[nextIndex]) {
+							child = oldChildren[nextIndex];
+							nextIndex++;
 						} else {
-							insertBefore = child.domNode;
+							break;
 						}
+					} else {
+						insertBefore = child.domNode;
 					}
 				}
+			}
 
-				createDom(newChild, parentVNode, insertBefore, projectionOptions, parentInstance);
-				nodeAdded(newChild, transitions);
-				const indexToCheck = newIndex;
-				projectorState.afterRenderCallbacks.push(() => {
-					checkDistinguishable(newChildren, indexToCheck, parentInstance);
-				});
+			createDom(newChild, parentVNode, insertBefore, projectionOptions, parentInstance);
+			nodeAdded(newChild, transitions);
+			const indexToCheck = newIndex;
+			projectorState.afterRenderCallbacks.push(() => {
+				checkDistinguishable(newChildren, indexToCheck, parentInstance);
+			});
+			newIndex++;
+			continue;
+		}
+
+		const findNewIndex = findIndexOfChild(newChildren, oldChild, newIndex + 1);
+
+		if (findNewIndex === -1) {
+			const indexToCheck = oldIndex;
+			projectorState.afterRenderCallbacks.push(() => {
+				callOnDetach(oldChild, parentInstance);
+				checkDistinguishable(oldChildren, indexToCheck, parentInstance);
+			});
+			nodeToRemove(oldChild, transitions, projectionOptions);
+			oldIndex++;
+			// newIndex++;
+			continue;
+		}
+
+		// new and old exist but have moved
+		let insertBefore: Element | Text | undefined = undefined;
+		let child: InternalDNode = oldChildren[oldIndex];
+		if (child) {
+			let nextIndex = oldIndex + 1;
+			while (insertBefore === undefined) {
+				if (isWNode(child)) {
+					if (child.rendered) {
+						child = child.rendered[0];
+					} else if (oldChildren[nextIndex]) {
+						child = oldChildren[nextIndex];
+						nextIndex++;
+					} else {
+						break;
+					}
+				} else {
+					insertBefore = child.domNode;
+				}
 			}
 		}
+
+		createDom(newChild, parentVNode, insertBefore, projectionOptions, parentInstance);
+		nodeAdded(newChild, transitions);
+		const newIndexToCheck = newIndex;
+		const oldIndexToCheck = oldIndex;
+		projectorState.afterRenderCallbacks.push(() => {
+			checkDistinguishable(newChildren, newIndexToCheck, parentInstance);
+		});
+		projectorState.afterRenderCallbacks.push(() => {
+			callOnDetach(oldChild, parentInstance);
+			checkDistinguishable(oldChildren, oldIndexToCheck, parentInstance);
+		});
+		nodeToRemove(oldChild, transitions, projectionOptions);
+		oldIndex++;
 		newIndex++;
 	}
 	if (oldChildrenLength > oldIndex) {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2710,7 +2710,7 @@ describe('vdom', () => {
 				v('span', { key: '13', id: '13' })
 			]);
 
-			assert.lengthOf(root.childNodes, 13);
+			assert.lengthOf(root.childNodes, 16);
 			assert.strictEqual(root.childNodes[0], childOne);
 			assert.notEqual(root.childNodes[1], childTwo);
 			assert.notEqual(root.childNodes[1], childEight);
@@ -2718,6 +2718,7 @@ describe('vdom', () => {
 			assert.notEqual(root.childNodes[2], childNine);
 			assert.notEqual(root.childNodes[3], childFour);
 			assert.notEqual(root.childNodes[3], childTen);
+			assert.isNull(childFive.parentNode);
 			assert.strictEqual(root.childNodes[4], childSix);
 			assert.strictEqual(root.childNodes[9], childSeven);
 			assert.notEqual(root.childNodes[10], childEight);

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2701,7 +2701,7 @@ describe('vdom', () => {
 				v('span', { key: '16', id: '16' }),
 				v('span', { key: '17', id: '17' }),
 				v('span', { key: '18', id: '18' }),
-				v('span', { key: '7', id: '7' }),
+				v('span', { key: '7', id: '7', href: 'href' }),
 				v('span', { key: '2', id: '2' }),
 				v('span', { key: '3', id: '3' }),
 				v('span', { key: '4', id: '4' }),
@@ -2721,6 +2721,7 @@ describe('vdom', () => {
 			assert.isNull(childFive.parentNode);
 			assert.strictEqual(root.childNodes[4], childSix);
 			assert.strictEqual(root.childNodes[9], childSeven);
+			assert.strictEqual((root.childNodes[9] as HTMLElement).getAttribute('href'), 'href');
 			assert.notEqual(root.childNodes[10], childEight);
 			assert.notEqual(root.childNodes[10], childTwo);
 			assert.notEqual(root.childNodes[11], childNine);

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2659,6 +2659,77 @@ describe('vdom', () => {
 			assert.strictEqual(div.childNodes[2], lastSpan);
 		});
 
+		it('Can update, insert and remove only affected nodes', () => {
+			const widget = getWidget(
+				v('div', [
+					v('span', { key: '1', id: '1' }),
+					v('span', { key: '2', id: '2' }),
+					v('span', { key: '3', id: '3' }),
+					v('span', { key: '4', id: '4' }),
+					v('span', { key: '5', id: '5' }),
+					v('span', { key: '6', id: '6' }),
+					v('span', { key: '7', id: '7' }),
+					v('span', { key: '8', id: '8' }),
+					v('span', { key: '9', id: '9' }),
+					v('span', { key: '10', id: '10' }),
+					v('span', { key: '11', id: '11' }),
+					v('span', { key: '12', id: '12' })
+				])
+			);
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0] as Element;
+			const childOne = root.childNodes[0] as HTMLSpanElement;
+			const childTwo = root.childNodes[1] as HTMLSpanElement;
+			const childThree = root.childNodes[2] as HTMLSpanElement;
+			const childFour = root.childNodes[3] as HTMLSpanElement;
+			const childFive = root.childNodes[4] as HTMLSpanElement;
+			const childSix = root.childNodes[5] as HTMLSpanElement;
+			const childSeven = root.childNodes[6] as HTMLSpanElement;
+			const childEight = root.childNodes[7] as HTMLSpanElement;
+			const childNine = root.childNodes[8] as HTMLSpanElement;
+			const childTen = root.childNodes[9] as HTMLSpanElement;
+			const childEleven = root.childNodes[10] as HTMLSpanElement;
+			const childTwelve = root.childNodes[11] as HTMLSpanElement;
+
+			widget.renderResult = v('div', [
+				v('span', { key: '1', id: '1' }),
+				v('span', { key: '8', id: '8' }),
+				v('span', { key: '9', id: '9' }),
+				v('span', { key: '10', id: '10' }),
+				v('span', { key: '6', id: '6' }),
+				v('span', { key: '15', id: '15' }),
+				v('span', { key: '16', id: '16' }),
+				v('span', { key: '17', id: '17' }),
+				v('span', { key: '18', id: '18' }),
+				v('span', { key: '7', id: '7' }),
+				v('span', { key: '2', id: '2' }),
+				v('span', { key: '3', id: '3' }),
+				v('span', { key: '4', id: '4' }),
+				v('span', { key: '11', id: '11' }),
+				v('span', { key: '12', id: '12' }),
+				v('span', { key: '13', id: '13' })
+			]);
+
+			assert.lengthOf(root.childNodes, 13);
+			assert.strictEqual(root.childNodes[0], childOne);
+			assert.notEqual(root.childNodes[1], childTwo);
+			assert.notEqual(root.childNodes[1], childEight);
+			assert.notEqual(root.childNodes[2], childThree);
+			assert.notEqual(root.childNodes[2], childNine);
+			assert.notEqual(root.childNodes[3], childFour);
+			assert.notEqual(root.childNodes[3], childTen);
+			assert.strictEqual(root.childNodes[4], childSix);
+			assert.strictEqual(root.childNodes[9], childSeven);
+			assert.notEqual(root.childNodes[10], childEight);
+			assert.notEqual(root.childNodes[10], childTwo);
+			assert.notEqual(root.childNodes[11], childNine);
+			assert.notEqual(root.childNodes[11], childThree);
+			assert.notEqual(root.childNodes[12], childTen);
+			assert.notEqual(root.childNodes[12], childFour);
+			assert.strictEqual(root.childNodes[13], childEleven);
+			assert.strictEqual(root.childNodes[14], childTwelve);
+		});
+
 		it('can update single text nodes', () => {
 			const widget = getWidget(v('span', ['']));
 			const projection = dom.create(widget, { sync: true });

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2732,6 +2732,87 @@ describe('vdom', () => {
 			assert.strictEqual(root.childNodes[14], childTwelve);
 		});
 
+		it('Can update, insert and remove only affected nodes from widgets', () => {
+			class Foo extends WidgetBase<{ id?: string; href?: string }> {
+				render() {
+					const { key, id, href } = this.properties;
+					let properties = href ? { key, id, href } : { key, id };
+					return v('span', properties);
+				}
+			}
+
+			const widget = getWidget(
+				v('div', [
+					w(Foo, { key: '1', id: '1' }),
+					w(Foo, { key: '2', id: '2' }),
+					w(Foo, { key: '3', id: '3' }),
+					w(Foo, { key: '4', id: '4' }),
+					w(Foo, { key: '5', id: '5' }),
+					w(Foo, { key: '6', id: '6' }),
+					w(Foo, { key: '7', id: '7' }),
+					w(Foo, { key: '8', id: '8' }),
+					w(Foo, { key: '9', id: '9' }),
+					w(Foo, { key: '10', id: '10' }),
+					w(Foo, { key: '11', id: '11' }),
+					w(Foo, { key: '12', id: '12' })
+				])
+			);
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0] as Element;
+			const childOne = root.childNodes[0] as HTMLSpanElement;
+			const childTwo = root.childNodes[1] as HTMLSpanElement;
+			const childThree = root.childNodes[2] as HTMLSpanElement;
+			const childFour = root.childNodes[3] as HTMLSpanElement;
+			const childFive = root.childNodes[4] as HTMLSpanElement;
+			const childSix = root.childNodes[5] as HTMLSpanElement;
+			const childSeven = root.childNodes[6] as HTMLSpanElement;
+			const childEight = root.childNodes[7] as HTMLSpanElement;
+			const childNine = root.childNodes[8] as HTMLSpanElement;
+			const childTen = root.childNodes[9] as HTMLSpanElement;
+			const childEleven = root.childNodes[10] as HTMLSpanElement;
+			const childTwelve = root.childNodes[11] as HTMLSpanElement;
+
+			widget.renderResult = v('div', [
+				w(Foo, { key: '1', id: '1' }),
+				w(Foo, { key: '8', id: '8' }),
+				w(Foo, { key: '9', id: '9' }),
+				w(Foo, { key: '10', id: '10' }),
+				w(Foo, { key: '6', id: '6' }),
+				w(Foo, { key: '15', id: '15' }),
+				w(Foo, { key: '16', id: '16' }),
+				w(Foo, { key: '17', id: '17' }),
+				w(Foo, { key: '18', id: '18' }),
+				w(Foo, { key: '7', id: '7', href: 'href' }),
+				w(Foo, { key: '2', id: '2' }),
+				w(Foo, { key: '3', id: '3' }),
+				w(Foo, { key: '4', id: '4' }),
+				w(Foo, { key: '11', id: '11' }),
+				w(Foo, { key: '12', id: '12' }),
+				w(Foo, { key: '13', id: '13' })
+			]);
+
+			assert.lengthOf(root.childNodes, 16);
+			assert.strictEqual(root.childNodes[0], childOne);
+			assert.notEqual(root.childNodes[1], childTwo);
+			assert.notEqual(root.childNodes[1], childEight);
+			assert.notEqual(root.childNodes[2], childThree);
+			assert.notEqual(root.childNodes[2], childNine);
+			assert.notEqual(root.childNodes[3], childFour);
+			assert.notEqual(root.childNodes[3], childTen);
+			assert.isNull(childFive.parentNode);
+			assert.strictEqual(root.childNodes[4], childSix);
+			assert.strictEqual(root.childNodes[9], childSeven);
+			assert.strictEqual((root.childNodes[9] as HTMLElement).getAttribute('href'), 'href');
+			assert.notEqual(root.childNodes[10], childEight);
+			assert.notEqual(root.childNodes[10], childTwo);
+			assert.notEqual(root.childNodes[11], childNine);
+			assert.notEqual(root.childNodes[11], childThree);
+			assert.notEqual(root.childNodes[12], childTen);
+			assert.notEqual(root.childNodes[12], childFour);
+			assert.strictEqual(root.childNodes[13], childEleven);
+			assert.strictEqual(root.childNodes[14], childTwelve);
+		});
+
 		it('can update single text nodes', () => {
 			const widget = getWidget(v('span', ['']));
 			const projection = dom.create(widget, { sync: true });

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2638,7 +2638,7 @@ describe('vdom', () => {
 			widget.renderResult = v('div', [v('span', { key: 'b' }), v('span', { key: 'a' })]);
 
 			assert.lengthOf(div.childNodes, 2);
-			assert.strictEqual(div.childNodes[0], lastSpan);
+			assert.notStrictEqual(div.childNodes[0], lastSpan);
 			assert.notStrictEqual(div.childNodes[1], firstSpan);
 		});
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Updates the algorithm used to update, insert, remove and move nodes during `updateChildren` so that only affected nodes are actually removed.

Currently when a node is moved, the algorithm will remove all child nodes up to the index of the moved node in the old children list.

Consider 6 child nodes rendered: `[1, 2, 3, 4, 5, 6]`

If node `5` is moved to between after node `2` the current algorithm will remove nodes `3` and `4` even though they still exist in the new children list.

This change ensures that the system does not remove nodes that still exist in the new children.

**Swapping row 2 and row 7**

Existing behaviour:

![existing-node-move](https://user-images.githubusercontent.com/1982678/37039399-4a79de80-214f-11e8-942b-9fa2167058c4.gif)

Updated behaviour:

![updated-node-move](https://user-images.githubusercontent.com/1982678/37039411-55ac9630-214f-11e8-9ae9-48827555fbd8.gif)

Moving row from end of list to beginning and inserting 4 rows:

Existing Behaviour:

![origina-inserting-and-moving-rows](https://user-images.githubusercontent.com/1982678/37041245-a3b03662-2153-11e8-8075-a64e2d9c4706.gif)

Updated Behaviour:

![updated-inserting-and-moving-rows](https://user-images.githubusercontent.com/1982678/37041248-a635bb50-2153-11e8-8737-ada6f90cdde1.gif)

Benchmark:

<img width="219" alt="interactive_results" src="https://user-images.githubusercontent.com/1982678/37043226-05b3be84-2158-11e8-9562-1bb621f5a71b.png">

Resolves #886 
