### PR TITLE
Default base registry and enable defining/getting injectors on base registry

### DIFF
--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -41,7 +41,7 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 	}
 
 	public defineInjector(label: RegistryLabel, injector: Injector): void {
-		this._registry.defineInjector(label, injector);
+		this.baseRegistry && this.baseRegistry.defineInjector(label, injector);
 	}
 
 	public has(label: RegistryLabel): boolean {
@@ -59,8 +59,8 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 		return this._get(label, globalPrecedence, 'get', this._registryWidgetLabelMap);
 	}
 
-	public getInjector<T extends Injector>(label: RegistryLabel, globalPrecedence: boolean = false): T | null {
-		return this._get(label, globalPrecedence, 'getInjector', this._registryInjectorLabelMap);
+	public getInjector<T extends Injector>(label: RegistryLabel): T | null {
+		return this._get(label, true, 'getInjector', this._registryInjectorLabelMap);
 	}
 
 	private _get(

--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -97,6 +97,9 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		this._properties = <P>{};
 		this._boundRenderFunc = this.render.bind(this);
 		this._boundInvalidate = this.invalidate.bind(this);
+		this._registry = new RegistryHandler();
+		this.own(this._registry);
+		this.own(this._registry.on('invalidate', this._boundInvalidate));
 
 		widgetInstanceMap.set(this, {
 			dirty: true,
@@ -158,11 +161,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		const instanceData = widgetInstanceMap.get(this)!;
 
 		if (instanceData.coreProperties.baseRegistry !== baseRegistry) {
-			if (this._registry === undefined) {
-				this._registry = new RegistryHandler();
-				this.own(this._registry);
-				this.own(this._registry.on('invalidate', this._boundInvalidate));
-			}
 			this._registry.base = baseRegistry;
 			this.invalidate();
 		}
@@ -405,11 +403,6 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	}
 
 	public get registry(): RegistryHandler {
-		if (this._registry === undefined) {
-			this._registry = new RegistryHandler();
-			this.own(this._registry);
-			this.own(this._registry.on('invalidate', this._boundInvalidate));
-		}
 		return this._registry;
 	}
 

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -117,7 +117,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		private _attachHandle: Handle;
 		private _projectionOptions: Partial<ProjectionOptions>;
 		private _projection: Projection | undefined;
-		private _baseRegistry: Registry = new Registry();
 
 		constructor(...args: any[]) {
 			super(...args);
@@ -200,8 +199,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		}
 
 		public __setProperties__(properties: this['properties']): void {
-			const baseRegistry = properties.registry ? properties.registry : this._baseRegistry;
-			super.__setCoreProperties__({ bind: this, baseRegistry });
+			this.__setCoreProperties__({ bind: this, baseRegistry: properties.registry || this.baseRegistry });
 			super.__setProperties__(properties);
 		}
 

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -6,9 +6,6 @@ import { afterRender } from './../decorators/afterRender';
 import { v } from './../d';
 import { Registry } from './../Registry';
 import { dom } from './../vdom';
-import { reference } from '../diff';
-import diffProperty from '../decorators/diffProperty';
-import { beforeProperties } from '../decorators/beforeProperties';
 
 /**
  * Represents the attach state of the projector
@@ -131,7 +128,6 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this.root = document.body;
 			this.projectorState = ProjectorAttachState.Detached;
-			super.__setCoreProperties__({ bind: this, baseRegistry: this._baseRegistry });
 		}
 
 		public append(root?: Element): Handle {
@@ -203,10 +199,10 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 			this.__setProperties__(properties);
 		}
 
-		@diffProperty('registry', reference)
-		protected onRegistryChange(oldProperty: any, { registry }: ProjectorProperties) {
-			registry = registry ? registry : this._baseRegistry;
-			super.__setCoreProperties__({ bind: this, baseRegistry: registry });
+		public __setProperties__(properties: this['properties']): void {
+			const baseRegistry = properties.registry ? properties.registry : this._baseRegistry;
+			super.__setCoreProperties__({ bind: this, baseRegistry });
+			super.__setProperties__(properties);
 		}
 
 		public toHtml(): string {

--- a/src/mixins/Projector.ts
+++ b/src/mixins/Projector.ts
@@ -8,6 +8,7 @@ import { Registry } from './../Registry';
 import { dom } from './../vdom';
 import { reference } from '../diff';
 import diffProperty from '../decorators/diffProperty';
+import { beforeProperties } from '../decorators/beforeProperties';
 
 /**
  * Represents the attach state of the projector
@@ -119,6 +120,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 		private _attachHandle: Handle;
 		private _projectionOptions: Partial<ProjectionOptions>;
 		private _projection: Projection | undefined;
+		private _baseRegistry: Registry = new Registry();
 
 		constructor(...args: any[]) {
 			super(...args);
@@ -129,7 +131,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 			this.root = document.body;
 			this.projectorState = ProjectorAttachState.Detached;
-			super.__setCoreProperties__({ bind: this, baseRegistry: new Registry() });
+			super.__setCoreProperties__({ bind: this, baseRegistry: this._baseRegistry });
 		}
 
 		public append(root?: Element): Handle {
@@ -203,6 +205,7 @@ export function ProjectorMixin<P, T extends Constructor<WidgetBase<P>>>(Base: T)
 
 		@diffProperty('registry', reference)
 		protected onRegistryChange(oldProperty: any, { registry }: ProjectorProperties) {
+			registry = registry ? registry : this._baseRegistry;
 			super.__setCoreProperties__({ bind: this, baseRegistry: registry });
 		}
 

--- a/tests/unit/RegistryHandler.ts
+++ b/tests/unit/RegistryHandler.ts
@@ -193,24 +193,6 @@ registerSuite('RegistryHandler', {
 				assert.equal(registryHandler.getInjector('foo'), globalInjector);
 				assert.equal(registryHandler.getInjector(foo), globalInjector);
 			},
-			local() {
-				const registryHandler = new RegistryHandler();
-				registryHandler.base = registry;
-				const localInjector = new Injector({});
-				registryHandler.defineInjector('foo', localInjector);
-				registryHandler.defineInjector(foo, localInjector);
-				assert.equal(registryHandler.getInjector('foo'), localInjector);
-				assert.equal(registryHandler.getInjector(foo), localInjector);
-			},
-			'with global precedence'() {
-				const registryHandler = new RegistryHandler();
-				registryHandler.base = registry;
-				const localInjector = new Injector({});
-				registryHandler.defineInjector('foo', localInjector);
-				registryHandler.defineInjector(foo, localInjector);
-				assert.equal(registryHandler.getInjector('foo', true), globalInjector);
-				assert.equal(registryHandler.getInjector(foo, true), globalInjector);
-			},
 			'invalidates when registry emits loaded event (only once)'() {
 				const registryHandler = new RegistryHandler();
 				const registry = new Registry();
@@ -225,23 +207,6 @@ registerSuite('RegistryHandler', {
 				registryHandler.getInjector('global');
 				registry.defineInjector('global', globalInjector);
 				assert.strictEqual(invalidateCount, 1);
-			},
-			'invalidates when primary registry emits loaded event even when widget is loaded in secondary registry'() {
-				const registryHandler = new RegistryHandler();
-				const registry = new Registry();
-				const localInjector = new Injector({});
-				registryHandler.base = registry;
-				let invalidateCount = 0;
-				registryHandler.on('invalidate', () => {
-					invalidateCount++;
-				});
-
-				registryHandler.getInjector('global');
-				registryHandler.getInjector('global');
-				registry.defineInjector('global', globalInjector);
-				assert.strictEqual(invalidateCount, 1);
-				registryHandler.defineInjector('global', localInjector);
-				assert.strictEqual(invalidateCount, 2);
 			},
 			'no loaded event listeners once the widget is fully loaded (into primary registry)'() {
 				const registryHandler = new RegistryHandler();
@@ -258,36 +223,6 @@ registerSuite('RegistryHandler', {
 				registry.emit({ type: 'global', action: 'other' });
 				assert.strictEqual(invalidateCount, 1);
 			},
-			'no `invalidate` events emitted once the with registry with the highest precedence has loaded'() {
-				const registryHandler = new RegistryHandler();
-				const registry = new Registry();
-				registryHandler.base = registry;
-				const localInjector = new Injector({});
-				let invalidateCount = 0;
-				registryHandler.on('invalidate', () => {
-					invalidateCount++;
-				});
-				registryHandler.getInjector('injector');
-				registryHandler.defineInjector('injector', localInjector);
-				assert.strictEqual(invalidateCount, 1);
-				registry.defineInjector('injector', globalInjector);
-				assert.strictEqual(invalidateCount, 1);
-			},
-			'no `invalidate` events emitted once the with registry with the highest precedence has loaded - with global'() {
-				const registryHandler = new RegistryHandler();
-				const registry = new Registry();
-				registryHandler.base = registry;
-				const localInjector = new Injector({});
-				let invalidateCount = 0;
-				registryHandler.on('invalidate', () => {
-					invalidateCount++;
-				});
-				registryHandler.getInjector('injector', true);
-				registry.defineInjector('injector', globalInjector);
-				assert.strictEqual(invalidateCount, 1);
-				registryHandler.defineInjector('injector', localInjector);
-				assert.strictEqual(invalidateCount, 1);
-			},
 			'ignores unknown event actions'() {
 				const registryHandler = new RegistryHandler();
 				const registry = new Registry();
@@ -300,7 +235,7 @@ registerSuite('RegistryHandler', {
 				registryHandler.getInjector('global');
 				registry.emit({ type: 'global', action: 'other' });
 				assert.strictEqual(invalidateCount, 0);
-				registryHandler.getInjector('global', true);
+				registryHandler.getInjector('global');
 				registry.emit({ type: 'global', action: 'other' });
 				assert.strictEqual(invalidateCount, 0);
 			}

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -92,7 +92,8 @@ describe('WidgetBase', () => {
 	it('updated core properties available on instance data', () => {
 		const child = new BaseTestWidget();
 		const instanceData = widgetInstanceMap.get(child)!;
-		assert.deepEqual(instanceData.coreProperties, {});
+		assert.strictEqual(instanceData.coreProperties.bind, child);
+		assert.isOk(instanceData.coreProperties.baseRegistry);
 		child.__setCoreProperties__({ bind: child, baseRegistry: 'base' });
 		assert.deepEqual(instanceData.coreProperties, { bind: child, baseRegistry: 'base' });
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Create a default base registry and enhance registry functionality to allow injectors to be set against the base registry.

Resolves #895 
