### PR TITLE
Fix customElement property name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,7 +1320,7 @@ interface MyWidgetProperties {
 
 @customElement<MyWidgetProperties>({
 	tag: 'my-widget',
-	attribute: [ 'foo', 'bar' ],
+	attributes: [ 'foo', 'bar' ],
 	events: [ 'onClick' ]
 })
 class MyWidget extends WidgetBase<MyWidgetProperties> {


### PR DESCRIPTION
Fix example to use the correct [property name](https://github.com/dojo/widget-core/blob/master/src/decorators/customElement.ts#L40).  I noticed the error in the same example in the recent [blog post](https://dojo.io/blog/2018/03/11/2018-03-11-Dojo-2-rc1/) and was confused why one name would be singular when the others (`events`, `properties`) were plural.

