### PR TITLE
Pin version of FF for tests

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -71,7 +71,7 @@
 				{ "browserName": "edge" },
 				{ "browserName": "internet explorer", "version": "11" },
 				{ "browserName": "chrome", "platform": "WINDOWS" },
-				{ "browserName": "firefox", "os": "WINDOWS", "os_version": "10" },
+				{ "browserName": "firefox", "os": "Windows", "os_version": "10", "browser_version": "58.0" },
 				{ "browserName": "safari", "version": "10", "platform": "MAC" },
 				{ "browserName": "iPhone", "version": "9.1" }
 			]


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The drag functional tests are failing from FF version 59.0 - I suspect there is an incompatibility between drivers/versions etc somewhere as the test works locally on version 59.0.

Have pinned the browser version to 58.0.
