### PR TITLE
Allow widget i18n bundles to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ In the above example, the tabPanel will receive its original `root` class in add
 
 ### Internationalization
 
-Widgets can be internationalized by adding the `I18nMixin` mixin from `@dojo/widget-core/mixins/I18n`. [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. Note that with this pattern it is possible for a widget to obtain its messages from multiple bundles; however, we recommend limiting widgets to a single bundle whenever possible.
+Widgets can be internationalized by adding the `I18nMixin` mixin from `@dojo/widget-core/mixins/I18n`. [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. Note that with this pattern it is possible for a widget to obtain its messages from multiple bundles; however, we strongly recommend limiting widgets to a single bundle whenever possible.
 
 If the bundle supports the widget's current locale, but those locale-specific messages have not yet been loaded, then a bundle of blank message values is returned. Alternatively, the `localizeBundle` method accepts a second boolean argument, which, when `true`, causes the default messages to be returned instead of the blank bundle. The widget will be invalidated once the locale-specific messages have been loaded, triggering a re-render with the localized message content.
 
@@ -582,46 +582,30 @@ class I18nWidget extends MyWidgetBase<I18nWidgetProperties> {
 }
 ```
 
-Once the `I18n` mixin has been added to a widget, the default bundle can be overridden with the `overrideBundle` property. An override bundle can be a complete bundle, in which case it will be used in place of the widget's default bundle, or it can be an object with a `locales` property. In the latter case, a new bundle is created with the default bundle's messages and locale loaders, as well as all with of the new locale loaders. This is useful when you need to provide support for more locales than are supported by the default bundle, or when you want to provide a different set of messages for a particular locale.
-
-Finally, while we recommend against using multiple bundles in the same widget, there may be times when you need to consume a third-party widget that does so. As such, `overrideBundle` can also be a `Map` of default bundles to override bundles.
+Once the `I18n` mixin has been added to a widget, the default bundle can be replaced with the `i18nBundle` property. Further, while we recommend against using multiple bundles in the same widget, there may be times when you need to consume a third-party widget that does so. As such, `i18nBundle` can also be a `Map` of default bundles to override bundles.
 
 ```typescript
 import { Bundle } from '@dojo/i18n/i18n';
 
-// The `OverrideBundle` type is satisfied by either a messages bundle or an object with a
-// `locales` loader object.
-import { OverrideBundle } from '@dojo/widget-core/mixins/I18n';
-
 // A complete bundle to replace WidgetA's message bundle
 import overrideBundleForWidgetA from './nls/widgetA';
 
-// Bundles for WidgetC
-import widgetC1 from 'third-party/nls/widgetC1';
-import overrideBundleForWidgetC from './nls/widgetC';
+// Bundles for WidgetB
+import widgetB1 from 'third-party/nls/widgetB1';
+import overrideBundleForWidgetB from './nls/widgetB';
 
-// WidgetB's bundle does not support Farsi, so add support for that locale:
-const extendedLocalesForWidgetB = {
-	locales: {
-		fa: () => import('./nls/fa/widgetB')
-	}
-};
-
-// WidgetC uses multiple bundles, but only `thirdy-party/nls/widgetC1` needs to be overridden
-const overrideMapForWidgetC = new Map<Bundle<any>, OverrideBundle<any>>();
-map.set(widgetC1, overrideBundleForWidgetC);
+// WidgetB uses multiple bundles, but only `thirdy-party/nls/widgetB1` needs to be overridden
+const overrideMapForWidgetB = new Map<Bundle<any>, Bundle<any>>();
+map.set(widgetB1, overrideBundleForWidgetB);
 
 export class MyWidget extends WidgetBase {
 	protected render() {
 		return [
 			w(WidgetA, {
-				overrideBundle: overrideBundleForWidgetA
+				i18nBundle: overrideBundleForWidgetA
 			}),
 			w(WidgetB) {
-				overrideBundle: extendedLocalesForWidgetB
-			},
-			w(WidgetC) {
-				overrideBundle: overrideMapForWidgetC
+				i18nBundle: overrideMapForWidgetB
 			},
 		];
 	}

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ In the above example, the tabPanel will receive its original `root` class in add
 
 ### Internationalization
 
-Widgets can be internationalized by adding the `I18nMixin` mixin from `@dojo/widget-core/mixins/I18n`. [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`.
+Widgets can be internationalized by adding the `I18nMixin` mixin from `@dojo/widget-core/mixins/I18n`. [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. Note that with this pattern it is possible for a widget to obtain its messages from multiple bundles; however, we recommend limiting widgets to a single bundle whenever possible.
 
 If the bundle supports the widget's current locale, but those locale-specific messages have not yet been loaded, then a bundle of blank message values is returned. Alternatively, the `localizeBundle` method accepts a second boolean argument, which, when `true`, causes the default messages to be returned instead of the blank bundle. The widget will be invalidated once the locale-specific messages have been loaded, triggering a re-render with the localized message content.
 
@@ -579,6 +579,52 @@ class I18nWidget extends MyWidgetBase<I18nWidgetProperties> {
             })
         ]);
     }
+}
+```
+
+Once the `I18n` mixin has been added to a widget, the default bundle can be overridden with the `overrideBundle` property. An override bundle can be a complete bundle, in which case it will be used in place of the widget's default bundle, or it can be an object with a `locales` property. In the latter case, a new bundle is created with the default bundle's messages and locale loaders, as well as all with of the new locale loaders. This is useful when you need to provide support for more locales than are supported by the default bundle, or when you want to provide a different set of messages for a particular locale.
+
+Finally, while we recommend against using multiple bundles in the same widget, there may be times when you need to consume a third-party widget that does so. As such, `overrideBundle` can also be a `Map` of default bundles to override bundles.
+
+```typescript
+import { Bundle } from '@dojo/i18n/i18n';
+
+// The `OverrideBundle` type is satisfied by either a messages bundle or an object with a
+// `locales` loader object.
+import { OverrideBundle } from '@dojo/widget-core/mixins/I18n';
+
+// A complete bundle to replace WidgetA's message bundle
+import overrideBundleForWidgetA from './nls/widgetA';
+
+// Bundles for WidgetC
+import widgetC1 from 'third-party/nls/widgetC1';
+import overrideBundleForWidgetC from './nls/widgetC';
+
+// WidgetB's bundle does not support Farsi, so add support for that locale:
+const extendedLocalesForWidgetB = {
+	locales: {
+		fa: () => import('./nls/fa/widgetB')
+	}
+};
+
+// WidgetC uses multiple bundles, but only `thirdy-party/nls/widgetC1` needs to be overridden
+const overrideMapForWidgetC = new Map<Bundle<any>, OverrideBundle<any>>();
+map.set(widgetC1, overrideBundleForWidgetC);
+
+export class MyWidget extends WidgetBase {
+	protected render() {
+		return [
+			w(WidgetA, {
+				overrideBundle: overrideBundleForWidgetA
+			}),
+			w(WidgetB) {
+				overrideBundle: extendedLocalesForWidgetB
+			},
+			w(WidgetC) {
+				overrideBundle: overrideMapForWidgetC
+			},
+		];
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -604,9 +604,9 @@ export class MyWidget extends WidgetBase {
 			w(WidgetA, {
 				i18nBundle: overrideBundleForWidgetA
 			}),
-			w(WidgetB) {
+			w(WidgetB, {
 				i18nBundle: overrideMapForWidgetB
-			},
+			}),
 		];
 	}
 }

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -136,11 +136,11 @@ registerSuite('mixins/I18nMixin', {
 			}
 		},
 		'.localizeBundle() with an override': {
-			'Uses the `overrideBundle` property'(this: any) {
+			'Uses the `i18nBundle` property'(this: any) {
 				const dfd = this.async();
 
 				localized = new Localized();
-				localized.__setProperties__({ overrideBundle });
+				localized.__setProperties__({ i18nBundle: overrideBundle });
 
 				switchLocale('es');
 				localized.localizeBundle(bundle);
@@ -153,10 +153,13 @@ registerSuite('mixins/I18nMixin', {
 					})
 				);
 			},
-			'Merges locales with the base bundle when the override contains no messages'(this: any) {
+			'Allows `i18nBundle` to be a `Map`'(this: any) {
 				const dfd = this.async();
+				const i18nBundleMap = new Map<any, any>();
+				i18nBundleMap.set(bundle, overrideBundle);
+
 				localized = new Localized();
-				localized.__setProperties__({ overrideBundle: { locales: overrideBundle.locales } });
+				localized.__setProperties__({ i18nBundle: i18nBundleMap });
 
 				switchLocale('es');
 				localized.localizeBundle(bundle);
@@ -169,47 +172,12 @@ registerSuite('mixins/I18nMixin', {
 					})
 				);
 			},
-			'Preserves existing locale loaders when the override contains no messages'(this: any) {
+			'Uses the base bundle when the `i18nBundle` map does not contain an override'(this: any) {
 				const dfd = this.async();
-				localized = new Localized();
-				localized.__setProperties__({ overrideBundle: { locales: overrideBundle.locales } });
-
-				switchLocale('fr');
-				localized.localizeBundle(bundle);
-				setTimeout(
-					dfd.callback(() => {
-						const { format, messages } = localized.localizeBundle(bundle);
-						assert.strictEqual(messages.hello, 'Bonjour');
-						assert.strictEqual(messages.goodbye, 'Au revoir');
-						assert.strictEqual(format('welcome', { name: 'Jean' }), 'Bienvenue, Jean!');
-					})
-				);
-			},
-			'Allows `overrideBundle` to be a `Map`'(this: any) {
-				const dfd = this.async();
-				const overrideBundleMap = new Map<any, any>();
-				overrideBundleMap.set(bundle, overrideBundle);
+				const i18nBundleMap = new Map<any, any>();
 
 				localized = new Localized();
-				localized.__setProperties__({ overrideBundle: overrideBundleMap });
-
-				switchLocale('es');
-				localized.localizeBundle(bundle);
-				setTimeout(
-					dfd.callback(() => {
-						const { format, messages } = localized.localizeBundle(bundle);
-						assert.strictEqual(messages.hello, 'Hola');
-						assert.strictEqual(messages.goodbye, 'Adiós');
-						assert.strictEqual(format('welcome', { name: 'Jean' }), 'Bienvenido, Jean');
-					})
-				);
-			},
-			'Uses the base bundle when the `overrideBundle` map does not contain an override'(this: any) {
-				const dfd = this.async();
-				const overrideBundleMap = new Map<any, any>();
-
-				localized = new Localized();
-				localized.__setProperties__({ overrideBundle: overrideBundleMap });
+				localized.__setProperties__({ i18nBundle: i18nBundleMap });
 
 				switchLocale('es');
 				localized.localizeBundle(bundle);

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -136,25 +136,23 @@ registerSuite('mixins/I18nMixin', {
 			}
 		},
 		'.localizeBundle() with an override': {
-			'Uses the `i18nBundle` property'(this: any) {
-				const dfd = this.async();
-
+			'Uses the `i18nBundle` property'() {
 				localized = new Localized();
 				localized.__setProperties__({ i18nBundle: overrideBundle });
 
 				switchLocale('es');
 				localized.localizeBundle(bundle);
-				setTimeout(
-					dfd.callback(() => {
+
+				return i18n(bundle, 'es')
+					.then(() => i18n(overrideBundle, 'es'))
+					.then(() => {
 						const { format, messages } = localized.localizeBundle(bundle);
 						assert.strictEqual(messages.hello, 'Hola');
 						assert.strictEqual(messages.goodbye, 'Adiós');
 						assert.strictEqual(format('welcome', { name: 'Jean' }), 'Bienvenido, Jean');
-					})
-				);
+					});
 			},
-			'Allows `i18nBundle` to be a `Map`'(this: any) {
-				const dfd = this.async();
+			'Allows `i18nBundle` to be a `Map`'() {
 				const i18nBundleMap = new Map<any, any>();
 				i18nBundleMap.set(bundle, overrideBundle);
 
@@ -163,17 +161,16 @@ registerSuite('mixins/I18nMixin', {
 
 				switchLocale('es');
 				localized.localizeBundle(bundle);
-				setTimeout(
-					dfd.callback(() => {
+				return i18n(bundle, 'es')
+					.then(() => i18n(overrideBundle, 'es'))
+					.then(() => {
 						const { format, messages } = localized.localizeBundle(bundle);
 						assert.strictEqual(messages.hello, 'Hola');
 						assert.strictEqual(messages.goodbye, 'Adiós');
 						assert.strictEqual(format('welcome', { name: 'Jean' }), 'Bienvenido, Jean');
-					})
-				);
+					});
 			},
-			'Uses the base bundle when the `i18nBundle` map does not contain an override'(this: any) {
-				const dfd = this.async();
+			'Uses the base bundle when the `i18nBundle` map does not contain an override'() {
 				const i18nBundleMap = new Map<any, any>();
 
 				localized = new Localized();
@@ -181,14 +178,14 @@ registerSuite('mixins/I18nMixin', {
 
 				switchLocale('es');
 				localized.localizeBundle(bundle);
-				setTimeout(
-					dfd.callback(() => {
+				return i18n(bundle, 'es')
+					.then(() => i18n(overrideBundle, 'es'))
+					.then(() => {
 						const { format, messages } = localized.localizeBundle(bundle);
 						assert.strictEqual(messages.hello, 'Hello');
 						assert.strictEqual(messages.goodbye, 'Goodbye');
 						assert.strictEqual(format('hello'), 'Hello');
-					})
-				);
+					});
 			}
 		},
 		'locale data can be injected by defining an Injector with a registry': {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Add an `overrideBundle` property to the `I18n` mixin properties allowing the base bundle to be overridden, or specific bundles to be overridden in the event that a widget derives its messages from multiple bundles. `overrideBundle` can a complete bundle, an object with a `locales` loader object that will be merged with the widget's default bundle, or a `Map` of default bundles to override values.

Resolves #901 
