### PR TITLE
Support registry factory for custom elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widget-core",
-  "version": "0.10.0",
+  "version": "0.10.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,9 +35,9 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.6.tgz",
-      "integrity": "sha512-c9wdqJmUiGae2bCVnkki7lS2OwKHHUnOBAD8tju1rlNmXLrCONY1/1oNtOX9NZk+/KUIEZfqM/wVNninxJwYqA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.7.tgz",
+      "integrity": "sha512-3R/n4a1/17acl9S5Wtay/0rcKzUqtVVJkCLPrGZq4NmRzWop09Unryqg/GV0Y1V7SbcILHKBL7bOTEfrpVX63g==",
       "dev": true,
       "requires": {
         "intersection-observer": "0.4.2",
@@ -64,7 +64,7 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.6",
+        "@dojo/shim": "0.2.7",
         "decompress": "4.2.0",
         "semver": "5.4.1",
         "tslib": "1.8.1"
@@ -87,7 +87,7 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.6",
+        "@dojo/shim": "0.2.7",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
         "tslib": "1.8.1"
@@ -112,7 +112,7 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/chai": {
@@ -127,7 +127,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/diff": {
@@ -160,7 +160,7 @@
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/fs-extra": {
@@ -169,7 +169,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/glob": {
@@ -180,7 +180,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/grunt": {
@@ -189,7 +189,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/handlebars": {
@@ -291,7 +291,7 @@
       "dev": true,
       "requires": {
         "@types/jquery": "3.3.1",
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/jszip": {
@@ -301,9 +301,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.105",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.105.tgz",
-      "integrity": "sha512-LB5PKR4QNoDrgcl4H8JdhBMp9wHWp0OATkU9EHzuXKiutRwbvsyYmqPUaMSWmdCycJoKHtdAWh47/zSe/GZ1yA==",
+      "version": "4.14.106",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.106.tgz",
+      "integrity": "sha512-tOSvCVrvSqFZ4A/qrqqm6p37GZoawsZtoR0SJhlF7EonNZUgrn8FfT+RNQ11h+NUpMt6QVe36033f3qEKBwfWA==",
       "dev": true
     },
     "@types/marked": {
@@ -331,9 +331,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
-      "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.0.tgz",
+      "integrity": "sha512-h3YZbOq2+ZoDFI1z8Zx0Ck/xRWkOESVaLdgLdd/c25mMQ1Y2CAkILu9ny5A15S5f32gGcQdaUIZ2jzYr8D7IFg==",
       "dev": true
     },
     "@types/platform": {
@@ -354,7 +354,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/selenium-webdriver": {
@@ -385,7 +385,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/sinon": {
@@ -417,7 +417,7 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "9.6.0"
       }
     },
     "@types/yargs": {
@@ -2454,7 +2454,7 @@
       "requires": {
         "globby": "6.1.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "p-map": "1.2.0",
         "pify": "3.0.0",
         "rimraf": "2.6.2"
@@ -3278,7 +3278,7 @@
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "safe-buffer": "5.1.1",
         "timed-out": "4.0.1",
         "unzip-response": "2.0.1",
@@ -3920,7 +3920,7 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.6",
+        "@dojo/shim": "0.2.7",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
@@ -3935,7 +3935,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.105",
+        "@types/lodash": "4.14.106",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -4269,9 +4269,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -5290,9 +5290,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -5342,9 +5342,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
-      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.18.tgz",
+      "integrity": "sha512-49i2QYhfULqaXzNZpxC808PisuCTGT2fgG0zrzdCI9N3rIfAWfW0nggvbXr6zvpynZdOG5+9xNxdzP0kwZnERw==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -6630,7 +6630,7 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.20",
+        "postcss": "6.0.21",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
@@ -6661,9 +6661,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.20",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -6829,7 +6829,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.20"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6859,9 +6859,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.20",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -6893,7 +6893,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.20"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6923,9 +6923,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.20",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -6957,7 +6957,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.20"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6987,9 +6987,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.20",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -7021,7 +7021,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.20"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7051,9 +7051,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.20",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -10097,7 +10097,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.105",
+        "@types/lodash": "4.14.106",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -10105,7 +10105,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.5",
-        "marked": "0.3.17",
+        "marked": "0.3.18",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",

--- a/src/decorators/customElement.ts
+++ b/src/decorators/customElement.ts
@@ -1,5 +1,6 @@
 import { Constructor, WidgetProperties } from '../interfaces';
 import { CustomElementChildType } from '../registerCustomElement';
+import Registry from '../Registry';
 
 export type CustomElementPropertyNames<P extends object> = ((keyof P) | (keyof WidgetProperties))[];
 
@@ -28,6 +29,8 @@ export interface CustomElementConfig<P extends object = { [index: string]: any }
 	events?: CustomElementPropertyNames<P>;
 
 	childType?: CustomElementChildType;
+
+	registryFactory?: () => Registry;
 }
 
 /**
@@ -39,7 +42,8 @@ export function customElement<P extends object = { [index: string]: any }>({
 	properties = [],
 	attributes = [],
 	events = [],
-	childType = CustomElementChildType.DOJO
+	childType = CustomElementChildType.DOJO,
+	registryFactory = () => new Registry()
 }: CustomElementConfig<P>) {
 	return function<T extends Constructor<any>>(target: T) {
 		target.prototype.__customElementDescriptor = {
@@ -47,7 +51,8 @@ export function customElement<P extends object = { [index: string]: any }>({
 			attributes,
 			properties,
 			events,
-			childType
+			childType,
+			registryFactory
 		};
 	};
 }

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -3,7 +3,6 @@ import { ProjectorMixin } from './mixins/Projector';
 import { from } from '@dojo/shim/array';
 import { w, dom } from './d';
 import global from '@dojo/shim/global';
-import Registry from './Registry';
 import { registerThemeInjector } from './mixins/Themed';
 import { alwaysRender } from './decorators/alwaysRender';
 
@@ -40,7 +39,7 @@ export function DomToWidgetWrapper(domNode: HTMLElement): any {
 }
 
 export function create(descriptor: any, WidgetConstructor: any): any {
-	const { attributes, childType } = descriptor;
+	const { attributes, childType, registryFactory } = descriptor;
 	const attributeMap: any = {};
 
 	attributes.forEach((propertyName: string) => {
@@ -125,7 +124,7 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 					return w(WidgetConstructor, widgetProperties, renderChildren());
 				}
 			};
-			const registry = new Registry();
+			const registry = registryFactory();
 			const themeContext = registerThemeInjector(this._getTheme(), registry);
 			global.addEventListener('dojo-theme-set', () => themeContext.set(this._getTheme()));
 			const Projector = ProjectorMixin(Wrapper);

--- a/tests/unit/decorators/customElement.ts
+++ b/tests/unit/decorators/customElement.ts
@@ -11,11 +11,16 @@ interface CustomElementWidgetProperties {
 	onClick: () => void;
 }
 
+function registryFactory() {
+	return {} as any;
+}
+
 @customElement<CustomElementWidgetProperties>({
 	tag: 'custom-element',
 	attributes: ['key', 'label', 'labelSuffix'],
 	properties: ['label'],
-	events: ['onClick']
+	events: ['onClick'],
+	registryFactory
 })
 export class CustomElementWidget extends WidgetBase<CustomElementWidgetProperties> {}
 
@@ -26,7 +31,8 @@ describe('@customElement', () => {
 			attributes: ['key', 'label', 'labelSuffix'],
 			properties: ['label'],
 			events: ['onClick'],
-			childType: CustomElementChildType.DOJO
+			childType: CustomElementChildType.DOJO,
+			registryFactory
 		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds `registryFactory` to `@customElement` options so that a custom registry can be passed for custom elements. It is optional, if not passed then an internal registry is created as before.
