### PR TITLE
Allow properties that are functions to be not automagically bound

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -1,5 +1,6 @@
 import Map from '@dojo/shim/Map';
 import WeakMap from '@dojo/shim/WeakMap';
+import Symbol from '@dojo/shim/Symbol';
 import { Handle } from '@dojo/core/interfaces';
 import { v } from './d';
 import { auto } from './diff';
@@ -36,6 +37,8 @@ export type BoundFunctionData = { boundFunc: (...args: any[]) => any; scope: any
 
 const decoratorMap = new Map<Function, Map<string, any[]>>();
 const boundAuto = auto.bind(null);
+
+export const noBind = Symbol.for('dojoNoBind');
 
 /**
  * Main widget base for all widgets to extend
@@ -385,7 +388,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 	 * @param properties properties to check for functions
 	 */
 	private _bindFunctionProperty(property: any, bind: any): any {
-		if (typeof property === 'function' && isWidgetBaseConstructor(property) === false) {
+		if (typeof property === 'function' && !property[noBind] && isWidgetBaseConstructor(property) === false) {
 			if (this._bindFunctionPropertyMap === undefined) {
 				this._bindFunctionPropertyMap = new WeakMap<
 					(...args: any[]) => any,

--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -1,4 +1,4 @@
-import { WidgetBase } from './WidgetBase';
+import { WidgetBase, noBind } from './WidgetBase';
 import { ProjectorMixin } from './mixins/Projector';
 import { from } from '@dojo/shim/array';
 import { w, dom } from './d';
@@ -200,6 +200,9 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 		}
 
 		private _setProperty(propertyName: string, value: any) {
+			if (typeof value === 'function') {
+				value[noBind] = true;
+			}
 			this._properties[propertyName] = value;
 			this._render();
 		}

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -2,7 +2,7 @@ const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { spy, stub, SinonStub } from 'sinon';
 
-import { WidgetBase } from './../../src/WidgetBase';
+import { WidgetBase, noBind } from './../../src/WidgetBase';
 import { v } from './../../src/d';
 import { WIDGET_BASE_TYPE } from './../../src/Registry';
 import { VNode, WidgetMetaConstructor, WidgetMetaBase } from './../../src/interfaces';
@@ -200,6 +200,25 @@ describe('WidgetBase', () => {
 			widget.__setProperties__({ baz });
 			widget.properties.baz && widget.properties.baz();
 			assert.isTrue(widget.called);
+		});
+
+		it('does not bind function properties that carry the dojo no bind symbol', () => {
+			class TestWidget extends BaseTestWidget {
+				public called = false;
+			}
+
+			function baz(this: any) {
+				this.called = true;
+			}
+
+			(baz as any)[noBind] = true;
+
+			const widget = new TestWidget();
+
+			widget.__setCoreProperties__({ bind: widget } as any);
+			widget.__setProperties__({ baz });
+			widget.properties.baz && widget.properties.baz();
+			assert.isFalse(widget.called);
 		});
 
 		it('Does not bind Widget constructor properties', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
When writing widgets using widget-core, we try to automatically bind properties that are functions to the widget scope so users don't have to. This works well within the widget authoring system, but becomes problematic if the function is passed from outside the system, in this case Custom Elements where the function could've come from anywhere. 

To avoid binding external functions, we unfortunately need to tag it with a global symbol so we can differentiate them. If they are tagged with the no bind symbol then WidgetBase will not bind the function at all. I feel a bit uneasy about modifying external functions even if it's just adding a symbol, and in the long run we should perhaps invert the logic so WidgetBase only binds functions that have a `shouldBind` symbol on or similar.