### PR TITLE
Handle properties prefixed with on for Custom Elements

### DIFF
--- a/src/registerCustomElement.ts
+++ b/src/registerCustomElement.ts
@@ -71,7 +71,14 @@ export function create(descriptor: any, WidgetConstructor: any): any {
 					this._properties[propertyName] = value;
 				}
 
-				domProperties[filteredPropertyName] = {
+				if (filteredPropertyName !== propertyName) {
+					domProperties[filteredPropertyName] = {
+						get: () => this._getProperty(propertyName),
+						set: (value: any) => this._setProperty(propertyName, value)
+					};
+				}
+
+				domProperties[propertyName] = {
 					get: () => this._getProperty(propertyName),
 					set: (value: any) => this._setProperty(propertyName, value)
 				};

--- a/tests/unit/registerCustomElement.ts
+++ b/tests/unit/registerCustomElement.ts
@@ -32,7 +32,7 @@ function createTestWidget(options: any) {
 		events,
 		childType
 	})
-	@diffProperty('myExternalFunction', reference)
+	@diffProperty('onExternalFunction', reference)
 	class Bar extends WidgetBase<any> {
 		private _called = false;
 
@@ -57,9 +57,9 @@ function createTestWidget(options: any) {
 					childProp = (child as any).properties.myProp = 'can write prop to dom node';
 				}
 			}
-			const { myProp = '', myAttr = '', myExternalFunction } = this.properties;
-			if (myExternalFunction) {
-				myExternalFunction('hello');
+			const { myProp = '', myAttr = '', onExternalFunction } = this.properties;
+			if (onExternalFunction) {
+				onExternalFunction('hello');
 			}
 			return v('div', [
 				v('button', { classes: ['event'], onclick: this._onClick }),
@@ -298,7 +298,7 @@ describe('registerCustomElement', () => {
 	});
 
 	it('custom element with function property', () => {
-		const Widget = createTestWidget({ properties: ['myExternalFunction'] });
+		const Widget = createTestWidget({ properties: ['onExternalFunction'] });
 		const CustomElement = create((Widget.prototype as any).__customElementDescriptor, Widget);
 		customElements.define('function-property-element', CustomElement);
 		element = document.createElement('function-property-element');
@@ -307,7 +307,7 @@ describe('registerCustomElement', () => {
 		let functionText = '';
 		let scope: any;
 
-		(element as any).myExternalFunction = function(text: string) {
+		(element as any).onExternalFunction = function(text: string) {
 			functionText = text;
 			scope = this;
 		};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
We did not correctly support function properties (not events) with a prefix of `on`.
