### PR TITLE
Functional Factory Injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ class MyClass extends WidgetBase {
 
 ### Containers & Injectors
 
-There is built-in support for side-loading/injecting values into sections of the widget tree and mapping them to a widget's properties. This is achieved by registering an injector factory with a `registry` and setting the registry as a property on the application's `projector` to ensure that is available to your application.
+There is built-in support for side-loading/injecting values into sections of the widget tree and mapping them to a widget's properties. This is achieved by registering an injector factory with a `registry` and setting the registry as a property on the application's `projector` to ensure the registry instance is available to your application.
 
 Create a factory function for a function that returns the required `payload`.
 
@@ -864,12 +864,12 @@ registry.defineInjector('my-injector', () => {
 });
 ```
 
-The injector factory gets passed an `invalidator` function that can be called when something has changed that requires connected widgets to `invalidate`.
+The injector factory gets passed an `invalidator` function that can get called when something has changed that requires connected widgets to `invalidate`.
 
 ```ts
 registry.defineInjector('my-injector', (invalidator) => {
-    // This could be a store, but for this example is simply an instance
-    // that accepts the injector and calls it when any of it's internal
+    // This could be a store, but for this example it is simply an instance
+    // that accepts the `invalidator` and calls it when any of its internal
     // state has changed.
     const appContext = new AppContext(invalidator);
     return () => appContext;

--- a/README.md
+++ b/README.md
@@ -688,11 +688,14 @@ A main registry can be provided to the `projector`, which will be automatically 
 import { Registry } from '@dojo/widget-core/Registry';
 
 import { MyWidget } from './MyWidget';
-import { MyInjector } from './MyInjector';
+import { MyAppContext } from './MyAppContext';
 
 const registry = new Registry();
 registry.define('my-widget', MyWidget);
-registry.defineInjector('my-injector', MyInjector);
+registry.defineInjector('my-injector', (invalidator) => {
+	const appContext = new MyAppContext(invalidator);
+	return () => appContext;
+});
 // ... Mixin and create Projector ...
 
 projector.setProperties({ registry });
@@ -851,18 +854,32 @@ class MyClass extends WidgetBase {
 
 ### Containers & Injectors
 
-There is built-in support for side-loading/injecting values into sections of the widget tree and mapping them to a widget's properties. This is achieved by registering a `@dojo/widget-core/Injector` instance against a `registry` that is available to your application (i.e. set on the projector instance, `projector.setProperties({ registry })`).
+There is built-in support for side-loading/injecting values into sections of the widget tree and mapping them to a widget's properties. This is achieved by registering an injector factory with a `registry` and setting the registry as a property on the application's `projector` to ensure that is available to your application.
 
-Create an `Injector` instance and pass the `payload` that needs to be injected to the constructor:
+Create a factory function for a function that returns the required `payload`.
 
 ```ts
-const injector = new Injector({ foo: 'baz' });
-registry.defineInjector('my-injector', injector);
+registry.defineInjector('my-injector', () => {
+    return () => ({ foo: 'bar' });
+});
 ```
 
-To connect the registered `injector` to a widget, we can use the `Container` HOC (higher order component) provided by `widget-core`. The `Container` accepts a widget `constructor`, `injector` label, and `getProperties` mapping function as arguments and returns a new class that returns the passed widget from its `render` function.
+The injector factory gets passed an `invalidator` function that can be called when something has changed that requires connected widgets to `invalidate`.
 
-`getProperties` receives the `payload` from an `injector` and `properties` from the container HOC component. These are used to map into the wrapped widget's properties.
+```ts
+registry.defineInjector('my-injector', (invalidator) => {
+    // This could be a store, but for this example is simply an instance
+    // that accepts the injector and calls it when any of it's internal
+    // state has changed.
+    const appContext = new AppContext(invalidator);
+    return () => appContext;
+});
+
+```
+
+To connect the registered `payload` to a widget, we can use the `Container` HOC (higher order component) provided by `widget-core`. The `Container` accepts a widget `constructor`, `injector` label, and `getProperties` mapping function as arguments and returns a new class that returns the passed widget from its `render` function.
+
+`getProperties` receives the `payload` return from the injector function and the `properties` passed to the container HOC component. These are used to map into the wrapped widget's properties.
 
 ```ts
 import { Container } from '@dojo/widget-core/Container';

--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ registry.defineInjector('my-injector', (invalidator) => {
 
 To connect the registered `payload` to a widget, we can use the `Container` HOC (higher order component) provided by `widget-core`. The `Container` accepts a widget `constructor`, `injector` label, and `getProperties` mapping function as arguments and returns a new class that returns the passed widget from its `render` function.
 
-`getProperties` receives the `payload` return from the injector function and the `properties` passed to the container HOC component. These are used to map into the wrapped widget's properties.
+`getProperties` receives the `payload` returned from the injector function and the `properties` passed to the container HOC component. These are used to map into the wrapped widget's properties.
 
 ```ts
 import { Container } from '@dojo/widget-core/Container';

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -7,10 +7,15 @@ export type InjectorEventMap = {
 
 export class Injector<T = any> extends Evented<InjectorEventMap> {
 	private _payload: T;
+	private _invalidator: undefined | (() => void);
 
 	constructor(payload: T) {
 		super();
 		this._payload = payload;
+	}
+
+	public setInvalidator(invalidator: () => void) {
+		this._invalidator = invalidator;
 	}
 
 	public get(): T {
@@ -19,7 +24,9 @@ export class Injector<T = any> extends Evented<InjectorEventMap> {
 
 	public set(payload: T): void {
 		this._payload = payload;
-		this.emit({ type: 'invalidate' });
+		if (this._invalidator) {
+			this._invalidator();
+		}
 	}
 }
 

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -157,7 +157,7 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 		}
 	}
 
-	public defineInjector(label: RegistryLabel, item: InjectorFactory): void {
+	public defineInjector(label: RegistryLabel, injectorFactory: InjectorFactory): void {
 		if (this._injectorRegistry === undefined) {
 			this._injectorRegistry = new Map();
 		}
@@ -169,7 +169,7 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 		const invalidator = new Evented();
 
 		const injectorItem: InjectorItem = {
-			injector: item(() => invalidator.emit({ type: 'invalidate' })),
+			injector: injectorFactory(() => invalidator.emit({ type: 'invalidate' })),
 			invalidator
 		};
 

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -65,7 +65,7 @@ export interface RegistryInterface {
 	 * @param label The label of the injector to register
 	 * @param registryItem The injector factory
 	 */
-	defineInjector(label: RegistryLabel, registryItem: InjectorFactory): void;
+	defineInjector(label: RegistryLabel, injectorFactory: InjectorFactory): void;
 
 	/**
 	 * Return an Injector registry item for the given label, null if an entry doesn't exist

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -3,8 +3,14 @@ import Map from '@dojo/shim/Map';
 import Symbol from '@dojo/shim/Symbol';
 import { EventObject } from '@dojo/core/interfaces';
 import { Evented } from '@dojo/core/Evented';
-import { Constructor, RegistryLabel, WidgetBaseConstructor, WidgetBaseInterface } from './interfaces';
-import { Injector } from './Injector';
+import {
+	Constructor,
+	InjectorFactory,
+	InjectorItem,
+	RegistryLabel,
+	WidgetBaseConstructor,
+	WidgetBaseInterface
+} from './interfaces';
 
 export type WidgetBaseConstructorFunction = () => Promise<WidgetBaseConstructor>;
 
@@ -23,9 +29,8 @@ export const WIDGET_BASE_TYPE = Symbol('Widget Base');
 
 export interface RegistryEventObject extends EventObject<RegistryLabel> {
 	action: string;
-	item: WidgetBaseConstructor | Injector;
+	item: WidgetBaseConstructor | InjectorFactory;
 }
-
 /**
  * Widget Registry Interface
  */
@@ -58,9 +63,9 @@ export interface RegistryInterface {
 	 * Define an Injector against a label
 	 *
 	 * @param label The label of the injector to register
-	 * @param registryItem The injector to define
+	 * @param registryItem The injector factory
 	 */
-	defineInjector(label: RegistryLabel, registryItem: Injector): void;
+	defineInjector(label: RegistryLabel, registryItem: InjectorFactory): void;
 
 	/**
 	 * Return an Injector registry item for the given label, null if an entry doesn't exist
@@ -68,7 +73,7 @@ export interface RegistryInterface {
 	 * @param label The label of the injector to return
 	 * @returns The RegistryItem for the widgetLabel, `null` if no entry exists
 	 */
-	getInjector<T extends Injector>(label: RegistryLabel): T | null;
+	getInjector<T>(label: RegistryLabel): InjectorItem<T> | null;
 
 	/**
 	 * Returns a boolean if an injector for the label exists
@@ -112,12 +117,12 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 	 */
 	private _widgetRegistry: Map<RegistryLabel, RegistryItem> | undefined;
 
-	private _injectorRegistry: Map<RegistryLabel, Injector> | undefined;
+	private _injectorRegistry: Map<RegistryLabel, InjectorItem> | undefined;
 
 	/**
 	 * Emit loaded event for registry label
 	 */
-	private emitLoadedEvent(widgetLabel: RegistryLabel, item: WidgetBaseConstructor | Injector): void {
+	private emitLoadedEvent(widgetLabel: RegistryLabel, item: WidgetBaseConstructor | InjectorItem): void {
 		this.emit({
 			type: widgetLabel,
 			action: 'loaded',
@@ -152,7 +157,7 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 		}
 	}
 
-	public defineInjector(label: RegistryLabel, item: Injector): void {
+	public defineInjector(label: RegistryLabel, item: InjectorFactory): void {
 		if (this._injectorRegistry === undefined) {
 			this._injectorRegistry = new Map();
 		}
@@ -161,8 +166,15 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 			throw new Error(`injector has already been registered for '${label.toString()}'`);
 		}
 
-		this._injectorRegistry.set(label, item);
-		this.emitLoadedEvent(label, item);
+		const invalidator = new Evented();
+
+		const injectorItem: InjectorItem = {
+			injector: item(() => invalidator.emit({ type: 'invalidate' })),
+			invalidator
+		};
+
+		this._injectorRegistry.set(label, injectorItem);
+		this.emitLoadedEvent(label, injectorItem);
 	}
 
 	public get<T extends WidgetBaseInterface = WidgetBaseInterface>(label: RegistryLabel): Constructor<T> | null {
@@ -201,12 +213,12 @@ export class Registry extends Evented<{}, RegistryLabel, RegistryEventObject> im
 		return null;
 	}
 
-	public getInjector<T extends Injector>(label: RegistryLabel): T | null {
+	public getInjector<T>(label: RegistryLabel): InjectorItem<T> | null {
 		if (!this._injectorRegistry || !this.hasInjector(label)) {
 			return null;
 		}
 
-		return this._injectorRegistry.get(label) as T;
+		return this._injectorRegistry.get(label)!;
 	}
 
 	public has(label: RegistryLabel): boolean {

--- a/src/RegistryHandler.ts
+++ b/src/RegistryHandler.ts
@@ -1,9 +1,8 @@
 import { Map } from '@dojo/shim/Map';
 import { Evented } from '@dojo/core/Evented';
 import { EventObject } from '@dojo/core/interfaces';
-import { Constructor, RegistryLabel, WidgetBaseInterface } from './interfaces';
+import { Constructor, InjectorFactory, InjectorItem, RegistryLabel, WidgetBaseInterface } from './interfaces';
 import { Registry, RegistryEventObject, RegistryItem } from './Registry';
-import { Injector } from './Injector';
 
 export type RegistryHandlerEventMap = {
 	invalidate: EventObject<'invalidate'>;
@@ -40,7 +39,7 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 		this._registry.define(label, widget);
 	}
 
-	public defineInjector(label: RegistryLabel, injector: Injector): void {
+	public defineInjector(label: RegistryLabel, injector: InjectorFactory): void {
 		this._registry.defineInjector(label, injector);
 	}
 
@@ -59,7 +58,7 @@ export class RegistryHandler extends Evented<RegistryHandlerEventMap> {
 		return this._get(label, globalPrecedence, 'get', this._registryWidgetLabelMap);
 	}
 
-	public getInjector<T extends Injector>(label: RegistryLabel, globalPrecedence: boolean = false): T | null {
+	public getInjector<T>(label: RegistryLabel, globalPrecedence: boolean = false): InjectorItem<T> | null {
 		return this._get(label, globalPrecedence, 'getInjector', this._registryInjectorLabelMap);
 	}
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -231,6 +231,21 @@ export interface VNodeProperties {
  */
 export type RegistryLabel = string | symbol;
 
+export type InjectorPayload = () => any;
+
+/**
+ * Factory that returns an injector function
+ */
+export type InjectorFactory = (invalidator: () => void) => InjectorPayload;
+
+/**
+ * The injector item created for a registered Injector factory
+ */
+export interface InjectorItem<T = any> {
+	injector: () => T;
+	invalidator: Evented;
+}
+
 /**
  * Base widget properties
  */

--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -87,7 +87,10 @@ export interface I18nMixin {
 
 export function registerI18nInjector(localeData: LocaleData, registry: Registry): Injector {
 	const injector = new Injector(localeData);
-	registry.defineInjector(INJECTOR_KEY, injector);
+	registry.defineInjector(INJECTOR_KEY, (invalidator) => {
+		injector.setInvalidator(invalidator);
+		return () => injector.get();
+	});
 	return injector;
 }
 

--- a/src/mixins/Themed.ts
+++ b/src/mixins/Themed.ts
@@ -82,7 +82,10 @@ function createThemeClassesLookup(classes: ClassNames[]): ClassNames {
  */
 export function registerThemeInjector(theme: any, themeRegistry: Registry): Injector {
 	const themeInjector = new Injector(theme);
-	themeRegistry.defineInjector(INJECTED_THEME_KEY, themeInjector);
+	themeRegistry.defineInjector(INJECTED_THEME_KEY, (invalidator) => {
+		themeInjector.setInvalidator(invalidator);
+		return () => themeInjector.get();
+	});
 	return themeInjector;
 }
 

--- a/tests/unit/Injector.ts
+++ b/tests/unit/Injector.ts
@@ -1,5 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
+import { stub } from 'sinon';
 
 import { Injector } from './../../src/Injector';
 
@@ -10,14 +11,12 @@ registerSuite('Injector', {
 		assert.strictEqual(injector.get(), payload);
 	},
 	set() {
-		let invalidateCalled = false;
 		const payload = {};
 		const injector = new Injector(payload);
+		const invalidatorStub = stub();
+		injector.setInvalidator(invalidatorStub);
 		assert.strictEqual(injector.get(), payload);
-		injector.on('invalidate', () => {
-			invalidateCalled = true;
-		});
 		injector.set({});
-		assert.isTrue(invalidateCalled);
+		assert.isTrue(invalidatorStub.calledOnce);
 	}
 });

--- a/tests/unit/Registry.ts
+++ b/tests/unit/Registry.ts
@@ -3,9 +3,9 @@ const { assert } = intern.getPlugin('chai');
 import Registry, { ESMDefaultWidgetBase } from './../../src/Registry';
 import { WidgetBase } from './../../src/WidgetBase';
 import Promise from '@dojo/shim/Promise';
-import { Injector } from './../../src/Injector';
 
-const testInjector = new Injector({});
+const testPayload = () => ({});
+const testInjector = () => testPayload;
 
 registerSuite('Registry', {
 	api() {
@@ -228,15 +228,15 @@ registerSuite('Registry', {
 			'get a registered injector'() {
 				const factoryRegistry = new Registry();
 				factoryRegistry.defineInjector('my-injector', testInjector);
-				const injector = factoryRegistry.getInjector('my-injector');
-				assert.strictEqual(injector, testInjector);
+				const injectorItem = factoryRegistry.getInjector('my-injector')!;
+				assert.strictEqual(injectorItem.injector, testPayload);
 			},
 			'get a registered injector with a Symbol'() {
 				const symbolLabel = Symbol();
 				const factoryRegistry = new Registry();
 				factoryRegistry.defineInjector(symbolLabel, testInjector);
-				const injector = factoryRegistry.getInjector(symbolLabel);
-				assert.strictEqual(injector, testInjector);
+				const injectorItem = factoryRegistry.getInjector(symbolLabel)!;
+				assert.strictEqual(injectorItem.injector, testPayload);
 			},
 			'returns null when injector is not registered'() {
 				const symbolLabel = Symbol();
@@ -248,7 +248,7 @@ registerSuite('Registry', {
 	},
 	'Support injectors and widgets with the same label'() {
 		const factoryRegistry = new Registry();
-		const injector = new Injector({});
+		const injector = () => () => ({});
 		assert.isFalse(factoryRegistry.hasInjector('my-item'));
 		assert.isFalse(factoryRegistry.has('my-item'));
 		factoryRegistry.defineInjector('my-item', injector);

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -291,12 +291,13 @@ describe('WidgetBase', () => {
 	describe('__setCoreProperties__', () => {
 		it('new baseRegistry is added to RegistryHandler and triggers an invalidation', () => {
 			const baseRegistry = new Registry();
-			baseRegistry.defineInjector('label', 'item' as any);
+			const injector = () => 'item';
+			baseRegistry.defineInjector('label', () => injector);
 			const widget = new BaseTestWidget();
 			const invalidateSpy = spy(widget, 'invalidate');
 			widget.__setCoreProperties__({ bind: widget, baseRegistry });
 			assert.isTrue(invalidateSpy.calledOnce);
-			assert.strictEqual(widget.registry.getInjector('label'), 'item' as any);
+			assert.strictEqual(widget.registry.getInjector('label')!.injector, injector);
 		});
 
 		it('The same baseRegistry does not causes an invalidation', () => {
@@ -310,13 +311,14 @@ describe('WidgetBase', () => {
 
 		it('different baseRegistry replaces the RegistryHandlers baseRegistry and triggers an invalidation', () => {
 			const baseRegistry = new Registry();
-			baseRegistry.defineInjector('label', 'item' as any);
+			const injector = () => 'item';
+			baseRegistry.defineInjector('label', () => injector);
 			const widget = new BaseTestWidget();
 			widget.__setCoreProperties__({ bind: widget, baseRegistry: new Registry() });
 			assert.isNull(widget.registry.getInjector('label'));
 			const invalidateSpy = spy(widget, 'invalidate');
 			widget.__setCoreProperties__({ bind: widget, baseRegistry });
-			assert.strictEqual(widget.registry.getInjector('label'), 'item' as any);
+			assert.strictEqual(widget.registry.getInjector('label')!.injector, injector);
 			assert.isTrue(invalidateSpy.called);
 		});
 	});

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -1,8 +1,8 @@
-import './afterRender';
-import './alwaysRender';
-import './beforeProperties';
-import './beforeRender';
-import './customElement';
-import './diffProperty';
+// import './afterRender';
+// import './alwaysRender';
+// import './beforeProperties';
+// import './beforeRender';
+// import './customElement';
+// import './diffProperty';
 import './inject';
-import './registry';
+// import './registry';

--- a/tests/unit/decorators/all.ts
+++ b/tests/unit/decorators/all.ts
@@ -1,8 +1,8 @@
-// import './afterRender';
-// import './alwaysRender';
-// import './beforeProperties';
-// import './beforeRender';
-// import './customElement';
-// import './diffProperty';
+import './afterRender';
+import './alwaysRender';
+import './beforeProperties';
+import './beforeRender';
+import './customElement';
+import './diffProperty';
 import './inject';
-// import './registry';
+import './registry';

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -2,7 +2,6 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import i18n, { invalidate, switchLocale, systemLocale } from '@dojo/i18n/i18n';
 import { INJECTOR_KEY, I18nMixin, I18nProperties, registerI18nInjector } from '../../../src/mixins/I18n';
-import { Injector } from '../../../src/Injector';
 import { Registry } from '../../../src/Registry';
 import { WidgetBase } from '../../../src/WidgetBase';
 import bundle from '../../support/nls/greetings';
@@ -122,7 +121,7 @@ registerSuite('mixins/I18nMixin', {
 		},
 		'locale data can be injected by defining an Injector with a registry': {
 			'defaults to the injector data'() {
-				const injector = new Injector({ locale: 'ar', rtl: true });
+				const injector = () => () => ({ locale: 'ar', rtl: true });
 				const registry = new Registry();
 
 				registry.defineInjector(INJECTOR_KEY, injector);
@@ -136,7 +135,7 @@ registerSuite('mixins/I18nMixin', {
 			},
 
 			'does not override property values'() {
-				const injector = new Injector({ locale: 'ar', rtl: true });
+				const injector = () => () => ({ locale: 'ar', rtl: true });
 				const registry = new Registry();
 
 				registry.defineInjector(INJECTOR_KEY, injector);

--- a/tests/unit/mixins/Themed.ts
+++ b/tests/unit/mixins/Themed.ts
@@ -7,7 +7,6 @@ import {
 	INJECTED_THEME_KEY,
 	registerThemeInjector
 } from '../../../src/mixins/Themed';
-import { Injector } from './../../../src/Injector';
 import { WidgetBase } from '../../../src/WidgetBase';
 import { Registry } from '../../../src/Registry';
 import { v } from '../../../src/d';
@@ -202,7 +201,7 @@ registerSuite('ThemedMixin', {
 		},
 		'injecting a theme': {
 			'theme can be injected by defining a ThemeInjector with registry'() {
-				const injector = new Injector(testTheme1);
+				const injector = () => () => testTheme1;
 				testRegistry.defineInjector(INJECTED_THEME_KEY, injector);
 				class InjectedTheme extends TestWidget {
 					render() {
@@ -216,7 +215,7 @@ registerSuite('ThemedMixin', {
 				assert.deepEqual(renderResult.properties.classes, 'theme1Class1');
 			},
 			'theme will not be injected if a theme has been passed via a property'() {
-				const injector = new Injector(testTheme1);
+				const injector = () => () => testTheme1;
 				testRegistry.defineInjector(INJECTED_THEME_KEY, injector);
 				class InjectedTheme extends TestWidget {
 					render() {

--- a/tests/unit/registerCustomElement.ts
+++ b/tests/unit/registerCustomElement.ts
@@ -4,7 +4,6 @@ import diffProperty from '../../src/decorators/diffProperty';
 import customElement from '../../src/decorators/customElement';
 import WidgetBase from '../../src/WidgetBase';
 import Container from '../../src/Container';
-import Injector from '../../src/Injector';
 import Registry from '../../src/Registry';
 import { v, w } from '../../src/d';
 import register, { create, CustomElementChildType } from '../../src/registerCustomElement';
@@ -272,7 +271,7 @@ describe('registerCustomElement', () => {
 		});
 
 		const registry = new Registry();
-		const injector = new Injector({ text: 'foo' });
+		const injector = () => () => ({ text: 'foo' });
 		registry.defineInjector('state', injector);
 
 		@customElement<any>({


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR
* [ ] Any required updates included in the readme

**Description:**

It has been identified that the ergonomics around using an `Injector` class as the base type when defining an injector in a registry can be awkward. 

* It requires consumers to deal with `Evented.emit()`, unlike everywhere else in Dojo 2, where we tend to provide abstractions on top of listening and emitting events.
* Additionally it was awkward to just provide a static payload that never needed to be reset.
* It encouraged consumers to extend the `Injector` class and make it stateful which was never the intention.

This change moves to accepting a functional factory that gets provided an invalidator and returns a function that when called will return the intended payload to be injected into the registered widgets.

```ts
registry.defineInjector('state', (invalidator: () => void) => {
    const applicationContext = new ApplicationContext(invalidator);
    return () => applicationContext;
});
```

If the payload never changes then the `invalidator` function can just be ignored.

```ts
registry.defineInjector('state', () => {
    return () => ({ foo: 'bar' });
});
```

Resolves #911 