### PR TITLE
Execute animations for nodes when a widget is added or removed

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -553,12 +553,7 @@ function nodeToRemove(dnode: InternalDNode, transitions: TransitionStrategy, pro
 	if (isWNode(dnode)) {
 		const rendered = dnode.rendered || emptyArray;
 		for (let i = 0; i < rendered.length; i++) {
-			const child = rendered[i];
-			if (isVNode(child)) {
-				child.domNode!.parentNode!.removeChild(child.domNode!);
-			} else {
-				nodeToRemove(child, transitions, projectionOptions);
-			}
+			nodeToRemove(rendered[i], transitions, projectionOptions);
 		}
 	} else {
 		const domNode = dnode.domNode;

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -735,7 +735,7 @@ function addChildren(
 	if (projectorState.merge && childNodes === undefined) {
 		childNodes = arrayFrom(parentVNode.domNode!.childNodes) as (Element | Text)[];
 	}
-
+	const transitions = projectionOptions.transitions!;
 	projectionOptions = { ...projectionOptions, depth: projectionOptions.depth + 1 };
 
 	for (let i = 0; i < children.length; i++) {
@@ -755,6 +755,7 @@ function addChildren(
 		} else {
 			createDom(child, parentVNode, insertBefore, projectionOptions, parentInstance, childNodes);
 		}
+		nodeAdded(child, transitions);
 	}
 }
 

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -3542,6 +3542,36 @@ describe('vdom', () => {
 				);
 			});
 
+			it('Should run exit animations when a widget is removed', () => {
+				const transitionStrategy = { enter: stub(), exit: stub() };
+				class Child extends WidgetBase {
+					render() {
+						return v('div', { exitAnimation: 'exit' });
+					}
+				}
+				class Parent extends WidgetBase {
+					items = [w(Child, { key: '1' }), w(Child, { key: '2' })];
+
+					removeItem() {
+						this.items = [this.items[0]];
+						this.invalidate();
+					}
+
+					render() {
+						return v('div', [...this.items]);
+					}
+				}
+				const widget = new Parent();
+				const projection = dom.create(widget, {
+					transitions: transitionStrategy,
+					sync: true
+				});
+				const node = (projection.domNode.childNodes[0] as Element).children[1];
+				widget.removeItem();
+				console.log(transitionStrategy.exit.called);
+				assert.isTrue(transitionStrategy.exit.calledWithExactly(node, match({}), 'exit', match({})));
+			});
+
 			it('will complain about a missing transitionStrategy', () => {
 				const widget = getWidget(v('div'));
 				dom.create(widget, { sync: true });

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -3501,6 +3501,47 @@ describe('vdom', () => {
 				assert.lengthOf((projection.domNode.childNodes[0] as Element).childNodes, 0);
 			});
 
+			it('Should run enter animations when a widget is added', () => {
+				const transitionStrategy = { enter: stub(), exit: stub() };
+				class Child extends WidgetBase {
+					render() {
+						return v('div', { enterAnimation: 'enter' });
+					}
+				}
+				class Parent extends WidgetBase {
+					items = [w(Child, { key: '1' })];
+
+					addItem() {
+						this.items = [...this.items, w(Child, { key: '2' })];
+						this.invalidate();
+					}
+
+					render() {
+						return v('div', [...this.items]);
+					}
+				}
+				const widget = new Parent();
+				const projection = dom.create(widget, {
+					transitions: transitionStrategy,
+					sync: true
+				});
+				assert.isTrue(
+					transitionStrategy.enter.calledWithExactly(
+						(projection.domNode.childNodes[0] as Element).children[0],
+						match({}),
+						'enter'
+					)
+				);
+				widget.addItem();
+				assert.isTrue(
+					transitionStrategy.enter.calledWithExactly(
+						(projection.domNode.childNodes[0] as Element).children[1],
+						match({}),
+						'enter'
+					)
+				);
+			});
+
 			it('will complain about a missing transitionStrategy', () => {
 				const widget = getWidget(v('div'));
 				dom.create(widget, { sync: true });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that animations are called for DOM nodes within a widget, when the widget is added or removed.

Resolves #919 

