### PR TITLE
Fixes vdom issues with selecting insert before and rendering widgets after they have been destroyed

### DIFF
--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -6,7 +6,7 @@ import sendEvent from './../support/sendEvent';
 
 import { dom, InternalVNode, InternalWNode, widgetInstanceMap, RenderResult } from '../../src/vdom';
 import { dom as d, v, w, VNODE } from '../../src/d';
-import { VNode } from '../../src/interfaces';
+import { VNode, DNode } from '../../src/interfaces';
 import { WidgetBase } from '../../src/WidgetBase';
 import { I18nMixin } from '../../src/mixins/I18n';
 import { Registry } from '../../src/Registry';
@@ -654,6 +654,123 @@ describe('vdom', () => {
 			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'bar');
 			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'second');
 			assert.strictEqual(root.childNodes[4].childNodes[0].data, 'bar');
+		});
+
+		it('should only insert before nodes that are not orphaned', () => {
+			class Parent extends WidgetBase {
+				private items: DNode[] = [w(ChildOne, {}), w(ChildTwo, {})];
+				render() {
+					return v('div', this.items);
+				}
+
+				swap() {
+					this.items = [w(ChildThree, {})];
+					this.invalidate();
+				}
+			}
+
+			let hideOne: Function;
+			class ChildOne extends WidgetBase {
+				private _show = true;
+
+				render() {
+					return this._show ? w(Widget, { num: 1 }) : null;
+				}
+
+				hide() {
+					this._show = false;
+					this.invalidate();
+				}
+
+				constructor() {
+					super();
+					hideOne = this.hide.bind(this);
+				}
+			}
+
+			let hideTwo: Function;
+			class ChildTwo extends WidgetBase {
+				private _show = true;
+
+				render() {
+					return this._show ? w(Widget, { num: 2 }) : null;
+				}
+
+				hide() {
+					this._show = false;
+					this.invalidate();
+				}
+
+				constructor() {
+					super();
+					hideTwo = this.hide.bind(this);
+				}
+			}
+
+			class ChildThree extends WidgetBase {
+				render() {
+					return w(Widget, { num: 3 });
+				}
+			}
+
+			class Widget extends WidgetBase<any> {
+				render() {
+					return v('div', [`hello ${this.properties.num}`]);
+				}
+			}
+
+			const widget = new Parent();
+			const projection = dom.create(widget, { sync: true });
+			hideOne!();
+			hideTwo!();
+			widget.swap();
+			const root: any = projection.domNode.childNodes[0];
+			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'hello 3');
+		});
+
+		it('Should not render widgets that have been detached', () => {
+			class ChildOne extends WidgetBase {
+				render() {
+					return 'Child One';
+				}
+			}
+
+			let childTwoInvalidate: Function;
+			let renderResult: DNode = null;
+			class ChildTwo extends WidgetBase {
+				constructor() {
+					super();
+					childTwoInvalidate = this.invalidate.bind(this);
+				}
+
+				render() {
+					return renderResult;
+				}
+			}
+
+			class Parent extends WidgetBase {
+				private _items: any[] = [w(ChildTwo, {})];
+				render() {
+					return v('main', this._items);
+				}
+
+				switch() {
+					this._items = [w(ChildOne, {})];
+					this.invalidate();
+				}
+			}
+
+			const widget = new Parent();
+			const projection = dom.create(widget);
+			resolvers.resolve();
+			renderResult = v('span', ['me']);
+			childTwoInvalidate!();
+			resolvers.resolve();
+			widget.switch();
+			childTwoInvalidate!();
+			resolvers.resolve();
+			assert.lengthOf(projection.domNode.childNodes[0]!.childNodes, 1);
+			assert.strictEqual((projection.domNode.childNodes[0]!.childNodes[0] as Text).data, 'Client 1');
 		});
 
 		it('should allow a widget returned from render', () => {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -770,7 +770,7 @@ describe('vdom', () => {
 			childTwoInvalidate!();
 			resolvers.resolve();
 			assert.lengthOf(projection.domNode.childNodes[0]!.childNodes, 1);
-			assert.strictEqual((projection.domNode.childNodes[0]!.childNodes[0] as Text).data, 'Client 1');
+			assert.strictEqual((projection.domNode.childNodes[0]!.childNodes[0] as Text).data, 'Child One');
 		});
 
 		it('should allow a widget returned from render', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

`vdom.ts` was processing widgets that had been detached by a previous render but had been invalidated themselves and therefore were already on the queue. To resolve this the call to "detach" widgets has been moved from request idle callback to be sync when processing renders. When a node it removed, `onDetach` is called which removes all references such as an injector that would otherwise invalidate the detached widget and also removes the instance from the `instanceMap` so that it will not get rendered again.

Also when processing nodes from higher in the dnode tree, there was a possibility that an incorrect reference (to the old node) could be used as the render process was traversing down the tree of the parent stored at the point of time it was rendered. If the lower component had rendered itself since the reference the node had in it's tree would be outdated. This changes `update` children to always look for a node from the `instanceMap` as that will always be the latest version of the widget and used this for processing removal.
