### PR TITLE
Allow Resize meta to take no arguments which just invalidates on Resize

### DIFF
--- a/src/meta/Resize.ts
+++ b/src/meta/Resize.ts
@@ -38,7 +38,10 @@ export type PredicateResponses<T = PredicateFunctions> = { [id in keyof T]: bool
 export class Resize extends Base {
 	private _details = new Map<string | number, PredicateResponses>();
 
-	public get<T extends PredicateFunctions>(key: string | number, predicates: T): PredicateResponses<T> {
+	public get<T extends PredicateFunctions>(
+		key: string | number,
+		predicates = {} as PredicateFunctions
+	): PredicateResponses<T> {
 		const node = this.getNode(key);
 
 		if (!node) {
@@ -52,20 +55,24 @@ export class Resize extends Base {
 		if (!this._details.has(key)) {
 			this._details.set(key, {});
 			const resizeObserver = new ResizeObserver(([entry]) => {
-				const { contentRect } = entry;
-				const previousDetails = this._details.get(key);
 				let predicateChanged = false;
-				let predicateResponses: PredicateResponses = {};
+				if (Object.keys(predicates).length) {
+					const { contentRect } = entry;
+					const previousDetails = this._details.get(key);
+					let predicateResponses: PredicateResponses = {};
 
-				for (let predicateId in predicates) {
-					const response = predicates[predicateId](contentRect);
-					predicateResponses[predicateId] = response;
-					if (!predicateChanged && response !== previousDetails![predicateId]) {
-						predicateChanged = true;
+					for (let predicateId in predicates) {
+						const response = predicates[predicateId](contentRect);
+						predicateResponses[predicateId] = response;
+						if (!predicateChanged && response !== previousDetails![predicateId]) {
+							predicateChanged = true;
+						}
 					}
-				}
 
-				this._details.set(key, predicateResponses);
+					this._details.set(key, predicateResponses);
+				} else {
+					predicateChanged = true;
+				}
 				predicateChanged && this.invalidate();
 			});
 			resizeObserver.observe(node);

--- a/tests/unit/meta/Resize.ts
+++ b/tests/unit/meta/Resize.ts
@@ -130,6 +130,27 @@ registerSuite('meta - Resize', {
 
 			assert.isTrue(invalidate.calledTwice);
 			assert.isTrue(predicates.isFoo);
+		},
+		'Will invalidate given no predicates'() {
+			const nodeHandler = new NodeHandler();
+			const invalidate = stub();
+			const element = document.createElement('div');
+			document.body.appendChild(element);
+			nodeHandler.add(element, 'foo');
+
+			const resize = new Resize({
+				invalidate,
+				nodeHandler,
+				bind: bindInstance
+			});
+
+			const contentRect: Partial<ContentRect> = {
+				width: 10
+			};
+
+			resize.get('foo');
+			resizeCallback([{ contentRect }]);
+			assert.isTrue(invalidate.called);
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Allows the ResizeObserver to not have to take a predicate, which means that you can do
```ts
this.meta(Resize).get('root');
```
and this will invalidate any time a resize occurs on the element. it would've been nice if this was the default scenario and we could actually return the `contentRect`, but that would be a breaking change to the return interface.
