### PR TITLE
Fixes Svg(path, rect, ellipse, line) is not draggable

### DIFF
--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -153,9 +153,12 @@ class DragController {
 		if (this._nodeMap.has(target)) {
 			return { state: this._nodeMap.get(target)!, target };
 		}
-		if (target.parentElement) {
-			return this._getData(target.parentElement);
-		}
+		// IE 11 does not support parentElement for SVGElement, so in case of parentElement undefined
+        // checking for parentNode.
+        const parent = (target.parentElement || target.parentNode) as HTMLElement;
+        if (parent) {
+            return this._getData(parent);
+        }
 	}
 
 	private _onDragStart = (event: PointerEvent) => {


### PR DESCRIPTION
Bug:- SVG element is not able to drag in IE 11.

The following has been addressed in the PR:
Fixed the svg dragging issue in IE11. IE 11 does not support parentElement for SVGElement, so in case of parentElement undefined now checking for parentNode.
