### PR TITLE
Inserting nodes when returning array from a widget

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -620,6 +620,7 @@ function updateChildren(
 	let newIndex = 0;
 	let i: number;
 	let textUpdated = false;
+	let endInsertBeforeNode: any = undefined;
 	while (newIndex < newChildrenLength) {
 		let oldChild = oldIndex < oldChildrenLength ? oldChildren[oldIndex] : undefined;
 		const newChild = newChildren[newIndex];
@@ -636,8 +637,13 @@ function updateChildren(
 
 		const findOldIndex = findIndexOfChild(oldChildren, newChild, oldIndex + 1);
 		const addChild = () => {
-			let insertBeforeDomNode: Element | Text | undefined = undefined;
+			let useNextSibling = false;
+			let insertBeforeDomNode: Node | undefined = undefined;
 			let child: InternalDNode = oldChildren[oldIndex];
+			if (!child && !endInsertBeforeNode) {
+				child = oldChildren[oldIndex - 1];
+				useNextSibling = true;
+			}
 			if (child) {
 				let nextIndex = oldIndex + 1;
 				let insertBeforeChildren = [child];
@@ -649,6 +655,11 @@ function updateChildren(
 						}
 					} else {
 						if (insertBefore.domNode) {
+							if (useNextSibling) {
+								insertBeforeDomNode = insertBefore.domNode.nextSibling || undefined;
+								endInsertBeforeNode = insertBeforeDomNode;
+								break;
+							}
 							insertBeforeDomNode = insertBefore.domNode;
 							break;
 						}
@@ -658,6 +669,8 @@ function updateChildren(
 						nextIndex++;
 					}
 				}
+			} else if (endInsertBeforeNode) {
+				insertBeforeDomNode = endInsertBeforeNode;
 			}
 
 			createDom(newChild, parentVNode, insertBeforeDomNode, projectionOptions, parentInstance);
@@ -725,7 +738,7 @@ function addChildren(
 	children: InternalDNode[] | undefined,
 	projectionOptions: ProjectionOptions,
 	parentInstance: DefaultWidgetBaseInterface,
-	insertBefore: Element | Text | undefined = undefined,
+	insertBefore: Node | undefined = undefined,
 	childNodes?: (Element | Text)[]
 ) {
 	if (children === undefined) {
@@ -792,7 +805,7 @@ function initPropertiesAndChildren(
 function createDom(
 	dnode: InternalDNode,
 	parentVNode: InternalVNode,
-	insertBefore: Element | Text | undefined,
+	insertBefore: Node | undefined,
 	projectionOptions: ProjectionOptions,
 	parentInstance: DefaultWidgetBaseInterface,
 	childNodes?: (Element | Text)[]

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -604,7 +604,7 @@ function checkDistinguishable(
 
 function updateChildren(
 	parentVNode: InternalVNode,
-	siblings: any,
+	siblings: InternalDNode[],
 	oldChildren: InternalDNode[],
 	newChildren: InternalDNode[],
 	parentInstance: DefaultWidgetBaseInterface,
@@ -814,7 +814,7 @@ function initPropertiesAndChildren(
 function createDom(
 	dnode: InternalDNode,
 	parentVNode: InternalVNode,
-	siblings: any,
+	siblings: InternalDNode[],
 	insertBefore: Node | undefined,
 	projectionOptions: ProjectionOptions,
 	parentInstance: DefaultWidgetBaseInterface,
@@ -913,7 +913,7 @@ function updateDom(
 	projectionOptions: ProjectionOptions,
 	parentVNode: InternalVNode,
 	parentInstance: DefaultWidgetBaseInterface,
-	siblings: any
+	siblings: InternalDNode[]
 ) {
 	if (isWNode(dnode)) {
 		const { instance } = previous;

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -1089,7 +1089,16 @@ function render(projectionOptions: ProjectionOptions) {
 			previouslyRendered.push(instance);
 			const { parentVNode, dnode } = instanceMap.get(instance)!;
 			const instanceData = widgetInstanceMap.get(instance)!;
-			updateDom(dnode, toInternalWNode(instance, instanceData), projectionOptions, parentVNode, instance, []);
+			const index = (parentVNode.children || []).indexOf(dnode);
+			const siblings = (parentVNode.children || []).slice(index + 1);
+			updateDom(
+				dnode,
+				toInternalWNode(instance, instanceData),
+				projectionOptions,
+				parentVNode,
+				instance,
+				siblings
+			);
 		}
 	}
 	runAfterRenderCallbacks(projectionOptions);

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -3106,6 +3106,61 @@ describe('vdom', () => {
 			assert.strictEqual((root.childNodes[5].childNodes[0] as Text).data, '6');
 		});
 
+		it('Can insert new nodes in last widget that returns an array from render when previously returns null', () => {
+			let addExtraNodes: any = undefined;
+
+			class A extends WidgetBase<any> {
+				render() {
+					if (this.properties.extra) {
+						return [
+							v('div', { key: '1' }, ['1']),
+							v('div', { key: '2' }, ['2']),
+							v('div', { key: '3' }, ['3'])
+						];
+					}
+					return [null];
+				}
+			}
+
+			class C extends WidgetBase {
+				render() {
+					return [
+						v('div', { key: '1' }, ['4']),
+						v('div', { key: '2' }, ['5']),
+						v('div', { key: '3' }, ['6'])
+					];
+				}
+			}
+
+			class B extends WidgetBase {
+				private _extraNodes = false;
+				private a = () => {
+					this._extraNodes = !this._extraNodes;
+					this.invalidate();
+				};
+				constructor() {
+					super();
+					addExtraNodes = this.a;
+				}
+				render() {
+					return v('div', [w(C, {}), w(A, { extra: this._extraNodes })]);
+				}
+			}
+			const widget = new B();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0] as Element;
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, '6');
+			addExtraNodes();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, '6');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, '1');
+			assert.strictEqual((root.childNodes[4].childNodes[0] as Text).data, '2');
+			assert.strictEqual((root.childNodes[5].childNodes[0] as Text).data, '3');
+		});
+
 		it('can update single text nodes', () => {
 			const widget = getWidget(v('span', ['']));
 			const projection = dom.create(widget, { sync: true });

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -2990,6 +2990,122 @@ describe('vdom', () => {
 			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, '1');
 		});
 
+		it('Can insert new nodes in a widget that returns an array from render when previously returns null', () => {
+			let addExtraNodes: any = undefined;
+
+			class A extends WidgetBase<any> {
+				render() {
+					if (this.properties.extra) {
+						return [
+							v('div', { key: '1' }, ['1']),
+							v('div', { key: '2' }, ['2']),
+							v('div', { key: '3' }, ['3'])
+						];
+					}
+					return [null];
+				}
+			}
+
+			class C extends WidgetBase {
+				render() {
+					return [
+						v('div', { key: '1' }, ['4']),
+						v('div', { key: '2' }, ['5']),
+						v('div', { key: '3' }, ['6'])
+					];
+				}
+			}
+
+			class B extends WidgetBase {
+				private _extraNodes = false;
+				private a = () => {
+					this._extraNodes = !this._extraNodes;
+					this.invalidate();
+				};
+				constructor() {
+					super();
+					addExtraNodes = this.a;
+				}
+				render() {
+					return v('div', [w(C, {}), w(A, { extra: this._extraNodes }), w(C, {})]);
+				}
+			}
+			const widget = new B();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0] as Element;
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, '6');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[4].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[5].childNodes[0] as Text).data, '6');
+			addExtraNodes();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, '6');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, '1');
+			assert.strictEqual((root.childNodes[4].childNodes[0] as Text).data, '2');
+			assert.strictEqual((root.childNodes[5].childNodes[0] as Text).data, '3');
+			assert.strictEqual((root.childNodes[6].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[7].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[8].childNodes[0] as Text).data, '6');
+		});
+
+		it('Can insert new nodes in first widget that returns an array from render when previously returns null', () => {
+			let addExtraNodes: any = undefined;
+
+			class A extends WidgetBase<any> {
+				render() {
+					if (this.properties.extra) {
+						return [
+							v('div', { key: '1' }, ['1']),
+							v('div', { key: '2' }, ['2']),
+							v('div', { key: '3' }, ['3'])
+						];
+					}
+					return [null];
+				}
+			}
+
+			class C extends WidgetBase {
+				render() {
+					return [
+						v('div', { key: '1' }, ['4']),
+						v('div', { key: '2' }, ['5']),
+						v('div', { key: '3' }, ['6'])
+					];
+				}
+			}
+
+			class B extends WidgetBase {
+				private _extraNodes = false;
+				private a = () => {
+					this._extraNodes = !this._extraNodes;
+					this.invalidate();
+				};
+				constructor() {
+					super();
+					addExtraNodes = this.a;
+				}
+				render() {
+					return v('div', [w(A, { extra: this._extraNodes }), w(C, {})]);
+				}
+			}
+			const widget = new B();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0] as Element;
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, '6');
+			addExtraNodes();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, '1');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, '2');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, '3');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, '4');
+			assert.strictEqual((root.childNodes[4].childNodes[0] as Text).data, '5');
+			assert.strictEqual((root.childNodes[5].childNodes[0] as Text).data, '6');
+		});
+
 		it('can update single text nodes', () => {
 			const widget = getWidget(v('span', ['']));
 			const projection = dom.create(widget, { sync: true });
@@ -3727,7 +3843,6 @@ describe('vdom', () => {
 				});
 				const node = (projection.domNode.childNodes[0] as Element).children[1];
 				widget.removeItem();
-				console.log(transitionStrategy.exit.called);
 				assert.isTrue(transitionStrategy.exit.calledWithExactly(node, match({}), 'exit', match({})));
 			});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

For a widget that returns an array of nodes adding additional nodes in a subsequent render results in the nodes being added to the end of the parent DOM element. The cause of this is that when rendering the widget it has no knowledge of the DOM nodes that have been rendered by it's siblings and therefore doesn't find a candidate when calculating the DOM node to insert before.

This change makes sibling information available such that the insert before DOM node can be correctly calculated.

Resolves #930 
