### PR TITLE
Ensure that latest version of rendered node is used when destroying

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -532,7 +532,7 @@ function nodeAdded(dnode: InternalDNode, transitions: TransitionStrategy) {
 function nodeToRemove(dnode: InternalDNode, transitions: TransitionStrategy, projectionOptions: ProjectionOptions) {
 	if (isWNode(dnode)) {
 		const item = instanceMap.get(dnode.instance);
-		const rendered = item ? item.dnode.rendered || emptyArray : dnode.rendered || emptyArray;
+		const rendered = (item ? item.dnode.rendered : dnode.rendered) || emptyArray;
 		if (dnode.instance) {
 			const instanceData = widgetInstanceMap.get(dnode.instance)!;
 			instanceData.onDetach();

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -531,7 +531,8 @@ function nodeAdded(dnode: InternalDNode, transitions: TransitionStrategy) {
 
 function nodeToRemove(dnode: InternalDNode, transitions: TransitionStrategy, projectionOptions: ProjectionOptions) {
 	if (isWNode(dnode)) {
-		const rendered = dnode.rendered || emptyArray;
+		const item = instanceMap.get(dnode.instance);
+		const rendered = item ? item.dnode.rendered || emptyArray : dnode.rendered || emptyArray;
 		if (dnode.instance) {
 			const instanceData = widgetInstanceMap.get(dnode.instance)!;
 			instanceData.onDetach();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

When iterating through the children of a node being removed, for `WNode`s currently the rendered nodes are taken from the node passed to the function - with subtree rendering this node could be different to the latest rendered node, so means not all the nodes are destroyed as expected.

To resolve this issue, ensure that the latest version of the node is used from the `instanceMap`

Resolves https://github.com/dojo/routing/issues/139
