### PR TITLE
Ensure meta after renders are called when a widget uses the afterRender decorator

### DIFF
--- a/src/WidgetBase.ts
+++ b/src/WidgetBase.ts
@@ -457,7 +457,7 @@ export class WidgetBase<P = WidgetProperties, C extends DNode = DNode> implement
 		const afterRenders = this.getDecorator('afterRender');
 
 		if (afterRenders.length > 0) {
-			return afterRenders.reduce((dNode: DNode | DNode[], afterRenderFunction: AfterRender) => {
+			dNode = afterRenders.reduce((dNode: DNode | DNode[], afterRenderFunction: AfterRender) => {
 				return afterRenderFunction.call(this, dNode);
 			}, dNode);
 		}

--- a/tests/unit/WidgetBase.ts
+++ b/tests/unit/WidgetBase.ts
@@ -12,6 +12,7 @@ import { Registry } from './../../src/Registry';
 import { Base } from './../../src/meta/Base';
 import { NodeEventType } from './../../src/NodeHandler';
 import { widgetInstanceMap } from './../../src/vdom';
+import { afterRender } from '../../src/decorators/afterRender';
 
 interface TestProperties {
 	foo?: string;
@@ -416,6 +417,29 @@ describe('WidgetBase', () => {
 			const cachedDecorators = widget.callGetDecorator('test-decorator');
 			assert.lengthOf(cachedDecorators, 1);
 			assert.strictEqual(cachedDecorators, decorators);
+		});
+
+		it('should run meta after renders even when a widget has afterRender decorator', () => {
+			let metaAfterRenderCalled = false;
+			class MetaWithAfterRender extends TestMeta {
+				afterRender() {
+					metaAfterRenderCalled = true;
+				}
+			}
+
+			class TestWidget extends WidgetBase {
+				@afterRender()
+				protected afterRenders() {}
+
+				protected render() {
+					this.meta(MetaWithAfterRender).get('');
+					return null;
+				}
+			}
+
+			const widget = new TestWidget();
+			widget.__render__();
+			assert.isTrue(metaAfterRenderCalled);
 		});
 
 		it('decorators applied to subclasses are not applied to base classes', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Do not return when there are afterRender decorators on a widget.

Resolves #934 
