### PR TITLE
Ensure the correct DNode it used when calculating insertBefore DOM Node

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -658,10 +658,11 @@ function updateChildren(
 			if (child) {
 				let insertBeforeChildren = [child];
 				while (insertBeforeChildren.length) {
-					const insertBefore = insertBeforeChildren.shift()!;
+					let insertBefore = insertBeforeChildren.shift()!;
 					if (isWNode(insertBefore)) {
-						if (insertBefore.rendered) {
-							insertBeforeChildren.push(...insertBefore.rendered);
+						const item = instanceMap.get(insertBefore.instance);
+						if (item && item.dnode.rendered) {
+							insertBeforeChildren.push(...item.dnode.rendered);
 						}
 					} else {
 						if (insertBefore.domNode) {

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -658,7 +658,7 @@ function updateChildren(
 			if (child) {
 				let insertBeforeChildren = [child];
 				while (insertBeforeChildren.length) {
-					let insertBefore = insertBeforeChildren.shift()!;
+					const insertBefore = insertBeforeChildren.shift()!;
 					if (isWNode(insertBefore)) {
 						const item = instanceMap.get(insertBefore.instance);
 						if (item && item.dnode.rendered) {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -728,6 +728,60 @@ describe('vdom', () => {
 			assert.strictEqual(root.childNodes[0].childNodes[0].data, 'hello 3');
 		});
 
+		it('should only insert before nodes that are not orphaned when returning from an array', () => {
+			class VeryParent extends WidgetBase {
+				render() {
+					return v('div', [w(Parent, {}), w(ChildOne, {})]);
+				}
+			}
+
+			let parentInvalidate: any;
+			class Parent extends WidgetBase {
+				private items: DNode[] = [w(ChildOne, { key: '1' }), w(ChildOne, { key: '2' })];
+				constructor() {
+					super();
+					parentInvalidate = this.swap.bind(this);
+				}
+				render() {
+					return this.items;
+				}
+
+				swap() {
+					this.items = [w(ChildOne, { key: '1' }), w(ChildOne, { key: '2' }), v('div', ['New'])];
+					this.invalidate();
+				}
+			}
+
+			let hide = false;
+			class ChildOne extends WidgetBase {
+				render() {
+					return w(ChildTwo, {});
+				}
+			}
+
+			let invalidateTwo: any;
+			class ChildTwo extends WidgetBase {
+				constructor() {
+					super();
+					invalidateTwo = this.invalidate.bind(this);
+				}
+				render() {
+					return hide ? null : v('div', ['Two']);
+				}
+			}
+
+			const widget = new VeryParent();
+			dom.create(widget);
+			resolvers.resolve();
+			invalidateTwo();
+			resolvers.resolve();
+			hide = true;
+			invalidateTwo();
+			resolvers.resolve();
+			parentInvalidate();
+			resolvers.resolve();
+		});
+
 		it('Should not render widgets that have been detached', () => {
 			class ChildOne extends WidgetBase {
 				render() {

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -731,7 +731,7 @@ describe('vdom', () => {
 		it('should only insert before nodes that are not orphaned when returning from an array', () => {
 			class VeryParent extends WidgetBase {
 				render() {
-					return v('div', [w(Parent, {}), w(ChildOne, {})]);
+					return v('div', [w(Parent, {}), w(ChildOne, {}), v('div', ['insert before me'])]);
 				}
 			}
 
@@ -771,7 +771,8 @@ describe('vdom', () => {
 			}
 
 			const widget = new VeryParent();
-			dom.create(widget);
+			const projection = dom.create(widget);
+			const root = projection.domNode.childNodes[0] as any;
 			resolvers.resolve();
 			invalidateTwo();
 			resolvers.resolve();
@@ -780,6 +781,9 @@ describe('vdom', () => {
 			resolvers.resolve();
 			parentInvalidate();
 			resolvers.resolve();
+			assert.lengthOf(root.childNodes, 4);
+			assert.strictEqual(root.childNodes[2].childNodes[0].data, 'New');
+			assert.strictEqual(root.childNodes[3].childNodes[0].data, 'insert before me');
 		});
 
 		it('Should not render widgets that have been detached', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

When calculating insert before, ensure that the correct WNode reference is used from the instanceMap. If a widget has had subtree rendered that removes the DOM node then the children reference of the parent will not be the latest version of the WNode and will possibly contain orphaned domNodes.
