### PR TITLE
Feature: Focus Mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,27 +708,27 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 					// VNode child.
 					w(FocusInputChild, {
 						key: 0,
-						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						focus: this._focusedInputKey === 0 ? this.shouldFocus : undefined,
 						onFocus: () => this._onFocus(0)
 					}),
 					w(FocusInputChild, {
 						key: 1,
-						focus: this._focusedInputKey === 1 && this.shouldFocus,
+						focus: this._focusedInputKey === 1 ? this.shouldFocus : undefined,
 						onFocus: () => this._onFocus(1)
 					}),
 					w(FocusInputChild, {
 						key: 2,
-						focus: this._focusedInputKey === 2 && this.shouldFocus,
+						focus: this._focusedInputKey === 2 ? this.shouldFocus : undefined,
 						onFocus: () => this._onFocus(2)
 					}),
 					w(FocusInputChild, {
 						key: 3,
-						focus: this._focusedInputKey === 3 && this.shouldFocus,
+						focus: this._focusedInputKey === 3 ? this.shouldFocus : undefined,
 						onFocus: () => this._onFocus(3)
 					}),
 					v('input', {
 						key: 4,
-						focus: this._focusedInputKey === 4 && this.shouldFocus,
+						focus: this._focusedInputKey === 4 ? this.shouldFocus : undefined,
 						onfocus: () => this._onFocus(4)
 					})
 				]);

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 				return v('div', [
 					v('button', { onclick: this._previous }, ['Previous']),
 					v('button', { onclick: this._next }, ['Next']),
-					// `this.shouldFocus is passed to the child that requires focus based on
+					// `this.shouldFocus` is passed to the child that requires focus based on
 					// some widget logic. If the child is a widget it can then deal with that
 					// however is necessary. It may have internal logic of it's own and pass
 					// it's own `this.shouldFocus` down further or could apply directly to a
@@ -713,28 +713,30 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 					}),
 					w(FocusInputChild, {
 						key: 1,
-						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						focus: this._focusedInputKey === 1 && this.shouldFocus,
 						onFocus: () => this._onFocus(1)
 					}),
 					w(FocusInputChild, {
 						key: 2,
-						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						focus: this._focusedInputKey === 2 && this.shouldFocus,
 						onFocus: () => this._onFocus(2)
 					}),
 					w(FocusInputChild, {
 						key: 3,
-						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						focus: this._focusedInputKey === 3 && this.shouldFocus,
 						onFocus: () => this._onFocus(3)
 					}),
 					v('input', {
 						key: 4,
-						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						focus: this._focusedInputKey === 4 && this.shouldFocus,
 						onfocus: () => this._onFocus(4)
 					})
 				]);
 			}
 		}
 ```
+
+Link to the example on [codesandbox.io](https://codesandbox.io/s/ox5y97vqz5).
 
 ### Advanced Properties
 

--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 
 		class FocusInputChild extends Focus(WidgetBase)<FocusInputChildProperties> {
 			protected render() {
-				// the child widgets `this.shouldFocus` is passed directly to the input nodes focus property
+				// the child widget's `this.shouldFocus` is passed directly to the input nodes focus property
 				return v('input', { onfocus: this.properties.onFocus, focus: this.shouldFocus });
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ This section provides some details on more advanced Dojo 2 functionality and con
 
 Handling focus is an important aspect in any application and can often be tricky to do correctly. To help with this issue @dojo/widget-core provides a primitive mechanism built into the VDOM system that enables users to focus a virtual dom node once it has been appended to the DOM. This uses a special property called `focus` on the `VNodeProperties` interface that can be passed when using `v()`. The `focus` property is either a `boolean` or a function that returns a `boolean`.
 
-When using passing a function focus will called when `true` is returned without comparing the value of the previous result, however when passing a `boolean` focus will only be applied if the property is `true` and the previous property value was not.
+When passing a function, focus will called when `true` is returned without comparing the value of the previous result. However when passing a `boolean` focus will only be applied if the property is `true` and the previous property value was not.
 
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ widget-core is a library to create powerful, composable user interface widgets.
     - [Internationalization](#internationalization)
 - [Key Principles](#key-principles)
 - [Advanced Concepts](#advanced-concepts)
+    - [Handling Focus](#handling-focus)
     - [Advanced Properties](#advanced-properties)
     - [Registry](#registry)
     - [Decorator Lifecycle Hooks](#decorator-lifecycle-hooks)
@@ -628,6 +629,112 @@ These are some of the **important** principles to keep in mind when creating and
 ## Advanced Concepts
 
 This section provides some details on more advanced Dojo 2 functionality and configuration that may be required to build more complex widgets and applications.
+
+### Handling Focus
+
+Handling focus is an important aspect in any application and can often be tricky to handle correctly. To help with this issue @dojo/widget-core provides a primitive mechanism built into the VDOM system that enables users to focus a virtual dom node once it is appended to the DOM. This uses a special property `focus` in the `VNodeProperties` interface that can be passed when using `v()`. The `focus` property is either a `boolean` or a function that returns a `boolean`.
+
+When using passing a function focus will called when the `true` is returned without comparing the value of the previous result, however when passing a `boolean` focus will only be applied if the property is `true` and the previous property value was not.
+
+
+```ts
+// Call focus for the node on the only first render
+v('input', { type: 'text', focus: true })
+```
+
+```ts
+// Call focus for the node on every render
+v('input', { type: 'text', focus: () => true) })
+```
+
+This primitive is a base that enables building further abstractions to handle more complex behaviors, one of which is handling focus across the boundaries of encapsulated widgets. The `FocusMixin` is designed to provide support for these scenarios and should be used by widgets that want to provide `focus` to it's children or can accept `focus` from a parent widget.
+
+The mixin enhances a widgets API adding `focus` and `shouldFocus` methods, `shouldFocus` checks whether the widget is in a state to perform a focus action and will only return `true` once until the a widgets `focus` method has been called. This `shouldFocus` method is designed to be passed to child widgets or nodes as the value of the `focus` property.
+
+If passed to a widget it will be called as the properties are set on the child widget, meaning that any other usages of the parents `shouldFocus` method will result in a return value of `false`.
+
+An example usage controlling focus across child VNodes (DOM) and WNodes (widgets):
+
+```ts
+		interface FocusInputChildProperties {
+			onFocus: () => void;
+		}
+
+		class FocusInputChild extends Focus(WidgetBase)<FocusInputChildProperties> {
+			protected render() {
+				// the child widgets `this.shouldFocus` is passed directly to the input nodes focus property
+				return v('input', { onfocus: this.properties.onFocus, focus: this.shouldFocus });
+			}
+		}
+
+		class FocusParent extends Focus(WidgetBase) {
+			private _focusedInputKey = 0;
+
+			private _onFocus(key: number) {
+				this._focusedInputKey = key;
+				this.invalidate();
+			}
+
+			private _previous() {
+				if (this._focusedInputKey === 0) {
+					this._focusedInputKey = 4;
+				} else {
+					this._focusedInputKey--;
+				}
+				// calling focus resets the widget so that `this.shouldFocus`
+				// will return true on it's next use
+				this.focus();
+			}
+
+			private _next() {
+				if (this._focusedInputKey === 4) {
+					this._focusedInputKey = 0;
+				} else {
+					this._focusedInputKey++;
+				}
+				// calling focus resets the widget so that `this.shouldFocus`
+				// will return true on it's next use
+				this.focus();
+			}
+
+			protected render() {
+				return v('div', [
+					v('button', { onclick: this._previous }, ['Previous']),
+					v('button', { onclick: this._next }, ['Next']),
+					// `this.shouldFocus is passed to the child that requires focus based on
+					// some widget logic. If the child is a widget it can then deal with that
+					// however is necessary. It may have internal logic of it's own and pass
+					// it's own `this.shouldFocus` down further or could apply directly to a
+					// VNode child.
+					w(FocusInputChild, {
+						key: 0,
+						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						onFocus: () => this._onFocus(0)
+					}),
+					w(FocusInputChild, {
+						key: 1,
+						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						onFocus: () => this._onFocus(1)
+					}),
+					w(FocusInputChild, {
+						key: 2,
+						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						onFocus: () => this._onFocus(2)
+					}),
+					w(FocusInputChild, {
+						key: 3,
+						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						onFocus: () => this._onFocus(3)
+					}),
+					v('input', {
+						key: 4,
+						focus: this._focusedInputKey === 0 && this.shouldFocus,
+						onfocus: () => this._onFocus(4)
+					})
+				]);
+			}
+		}
+```
 
 ### Advanced Properties
 

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ v('input', { type: 'text', focus: true })
 v('input', { type: 'text', focus: () => true) })
 ```
 
-This primitive is a base that enables building further abstractions to handle more complex behaviors, one of which is handling focus across the boundaries of encapsulated widgets. The `FocusMixin` is designed to provide support for these scenarios and should be used by widgets that want to provide `focus` to it's children or can accept `focus` from a parent widget.
+This primitive is a base that enables building further abstractions to handle more complex behaviors, one of which is handling focus across the boundaries of encapsulated widgets. The `FocusMixin` is designed to provide support for these scenarios and should be used by widgets that want to provide `focus` to its children or can accept `focus` from a parent widget.
 
 The mixin enhances a widgets API adding `focus` and `shouldFocus` methods, `shouldFocus` checks whether the widget is in a state to perform a focus action and will only return `true` once until the the widget's `focus` method has been called. This `shouldFocus` method is designed to be passed to child widgets or nodes as the value of the `focus` property.
 
@@ -682,7 +682,7 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 					this._focusedInputKey--;
 				}
 				// calling focus resets the widget so that `this.shouldFocus`
-				// will return true on it's next use
+				// will return true on its next use
 				this.focus();
 			}
 
@@ -693,7 +693,7 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 					this._focusedInputKey++;
 				}
 				// calling focus resets the widget so that `this.shouldFocus`
-				// will return true on it's next use
+				// will return true on its next use
 				this.focus();
 			}
 
@@ -703,8 +703,8 @@ An example usage controlling focus across child VNodes (DOM) and WNodes (widgets
 					v('button', { onclick: this._next }, ['Next']),
 					// `this.shouldFocus` is passed to the child that requires focus based on
 					// some widget logic. If the child is a widget it can then deal with that
-					// however is necessary. It may have internal logic of it's own and pass
-					// it's own `this.shouldFocus` down further or could apply directly to a
+					// however is necessary. The widget may also have internal logic and pass
+					// its own `this.shouldFocus` down further or could apply directly to a
 					// VNode child.
 					w(FocusInputChild, {
 						key: 0,

--- a/README.md
+++ b/README.md
@@ -647,9 +647,9 @@ v('input', { type: 'text', focus: true })
 v('input', { type: 'text', focus: () => true) })
 ```
 
-This primitive is a base that enables building further abstractions to handle more complex behaviors, one of which is handling focus across the boundaries of encapsulated widgets. The `FocusMixin` is designed to provide support for these scenarios and should be used by widgets that want to provide `focus` to its children or can accept `focus` from a parent widget.
+This primitive is a base that enables further abstractions to be built to handle more complex behaviors. One of these is handling focus across the boundaries of encapsulated widgets. The `FocusMixin` should be used by widgets to provide `focus` to their children or to accept `focus` from a parent widget.
 
-The mixin enhances a widgets API adding `focus` and `shouldFocus` methods, `shouldFocus` checks whether the widget is in a state to perform a focus action and will only return `true` once until the the widget's `focus` method has been called. This `shouldFocus` method is designed to be passed to child widgets or nodes as the value of the `focus` property.
+The `FocusMixin` adds `focus` and `shouldFocus` to a widget's API. `shouldFocus` checks if the widget is in a state to perform a focus action and will only return `true` once until the widget's `focus` method has been called again. This `shouldFocus` method is designed to be passed to child widgets or nodes are the value of their `focus` property.
 
 When `shouldFocus` is passed to a widget it will be called as the properties are set on the child widget, meaning that any other usages of the parent's `shouldFocus` method will result in a return value of `false`.
 

--- a/README.md
+++ b/README.md
@@ -632,9 +632,9 @@ This section provides some details on more advanced Dojo 2 functionality and con
 
 ### Handling Focus
 
-Handling focus is an important aspect in any application and can often be tricky to handle correctly. To help with this issue @dojo/widget-core provides a primitive mechanism built into the VDOM system that enables users to focus a virtual dom node once it is appended to the DOM. This uses a special property `focus` in the `VNodeProperties` interface that can be passed when using `v()`. The `focus` property is either a `boolean` or a function that returns a `boolean`.
+Handling focus is an important aspect in any application and can often be tricky to do correctly. To help with this issue @dojo/widget-core provides a primitive mechanism built into the VDOM system that enables users to focus a virtual dom node once it has been appended to the DOM. This uses a special property called `focus` on the `VNodeProperties` interface that can be passed when using `v()`. The `focus` property is either a `boolean` or a function that returns a `boolean`.
 
-When using passing a function focus will called when the `true` is returned without comparing the value of the previous result, however when passing a `boolean` focus will only be applied if the property is `true` and the previous property value was not.
+When using passing a function focus will called when `true` is returned without comparing the value of the previous result, however when passing a `boolean` focus will only be applied if the property is `true` and the previous property value was not.
 
 
 ```ts
@@ -649,9 +649,9 @@ v('input', { type: 'text', focus: () => true) })
 
 This primitive is a base that enables building further abstractions to handle more complex behaviors, one of which is handling focus across the boundaries of encapsulated widgets. The `FocusMixin` is designed to provide support for these scenarios and should be used by widgets that want to provide `focus` to it's children or can accept `focus` from a parent widget.
 
-The mixin enhances a widgets API adding `focus` and `shouldFocus` methods, `shouldFocus` checks whether the widget is in a state to perform a focus action and will only return `true` once until the a widgets `focus` method has been called. This `shouldFocus` method is designed to be passed to child widgets or nodes as the value of the `focus` property.
+The mixin enhances a widgets API adding `focus` and `shouldFocus` methods, `shouldFocus` checks whether the widget is in a state to perform a focus action and will only return `true` once until the the widget's `focus` method has been called. This `shouldFocus` method is designed to be passed to child widgets or nodes as the value of the `focus` property.
 
-If passed to a widget it will be called as the properties are set on the child widget, meaning that any other usages of the parents `shouldFocus` method will result in a return value of `false`.
+When `shouldFocus` is passed to a widget it will be called as the properties are set on the child widget, meaning that any other usages of the parent's `shouldFocus` method will result in a return value of `false`.
 
 An example usage controlling focus across child VNodes (DOM) and WNodes (widgets):
 

--- a/src/mixins/Focus.ts
+++ b/src/mixins/Focus.ts
@@ -4,12 +4,12 @@ import { diffProperty } from '../decorators/diffProperty';
 
 export interface FocusMixin {
 	focus: () => void;
-	shouldFocus: () => void;
+	shouldFocus: () => boolean;
 	properties: FocusProperties;
 }
 
 export interface FocusProperties {
-	focus?: () => void | boolean;
+	focus?: () => boolean;
 }
 
 function diffFocus(previousProperty: Function, newProperty: Function) {
@@ -46,3 +46,5 @@ export function FocusMixin<T extends Constructor<WidgetBase<FocusProperties>>>(B
 	}
 	return Focus;
 }
+
+export default FocusMixin;

--- a/src/mixins/Focus.ts
+++ b/src/mixins/Focus.ts
@@ -2,14 +2,14 @@ import { Constructor } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
 import { diffProperty } from '../decorators/diffProperty';
 
+export interface FocusProperties {
+	focus?: (() => boolean) | boolean;
+}
+
 export interface FocusMixin {
 	focus: () => void;
 	shouldFocus: () => boolean;
 	properties: FocusProperties;
-}
-
-export interface FocusProperties {
-	focus?: () => boolean;
 }
 
 function diffFocus(previousProperty: Function, newProperty: Function) {

--- a/src/mixins/Focus.ts
+++ b/src/mixins/Focus.ts
@@ -1,0 +1,48 @@
+import { Constructor } from './../interfaces';
+import { WidgetBase } from './../WidgetBase';
+import { diffProperty } from '../decorators/diffProperty';
+
+export interface FocusMixin {
+	focus: () => void;
+	shouldFocus: () => void;
+	properties: FocusProperties;
+}
+
+export interface FocusProperties {
+	focus?: () => void | boolean;
+}
+
+function diffFocus(previousProperty: Function, newProperty: Function) {
+	const result = newProperty && newProperty();
+	return {
+		changed: result,
+		value: newProperty
+	};
+}
+
+export function FocusMixin<T extends Constructor<WidgetBase<FocusProperties>>>(Base: T): T & Constructor<FocusMixin> {
+	abstract class Focus extends Base {
+		public abstract properties: FocusProperties;
+
+		private _currentToken = 0;
+
+		private _previousToken = 0;
+
+		@diffProperty('focus', diffFocus)
+		protected isFocusedReaction() {
+			this._currentToken++;
+		}
+
+		public shouldFocus = () => {
+			const result = this._currentToken !== this._previousToken;
+			this._previousToken = this._currentToken;
+			return result;
+		};
+
+		public focus() {
+			this._currentToken++;
+			this.invalidate();
+		}
+	}
+	return Focus;
+}

--- a/src/mixins/Focus.ts
+++ b/src/mixins/Focus.ts
@@ -1,6 +1,6 @@
 import { Constructor } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
-import { diffProperty } from '../decorators/diffProperty';
+import { diffProperty } from './../decorators/diffProperty';
 
 export interface FocusProperties {
 	focus?: (() => boolean) | boolean;

--- a/src/mixins/Focus.ts
+++ b/src/mixins/Focus.ts
@@ -3,7 +3,7 @@ import { WidgetBase } from './../WidgetBase';
 import { diffProperty } from './../decorators/diffProperty';
 
 export interface FocusProperties {
-	focus?: (() => boolean) | boolean;
+	focus?: (() => boolean);
 }
 
 export interface FocusMixin {

--- a/tests/unit/mixins/Focus.ts
+++ b/tests/unit/mixins/Focus.ts
@@ -1,0 +1,39 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { WidgetBase } from '../../../src/WidgetBase';
+import Focus from '../../../src/mixins/Focus';
+
+class Foo extends Focus(WidgetBase) {}
+
+describe('Focus Mixin', () => {
+	it('should allow once focus when focus property returns true', () => {
+		const widget = new Foo();
+		widget.__setProperties__({ focus: () => true });
+		assert.isTrue(widget.shouldFocus());
+		assert.isFalse(widget.shouldFocus());
+		widget.focus();
+		assert.isTrue(widget.shouldFocus());
+		assert.isFalse(widget.shouldFocus());
+	});
+
+	it('should not focus when focus property returns false', () => {
+		const widget = new Foo();
+		widget.__setProperties__({ focus: () => false });
+		assert.isFalse(widget.shouldFocus());
+		widget.focus();
+		assert.isTrue(widget.shouldFocus());
+		assert.isFalse(widget.shouldFocus());
+		widget.__setProperties__({ focus: () => true });
+		assert.isTrue(widget.shouldFocus());
+		assert.isFalse(widget.shouldFocus());
+	});
+
+	it('should not focus when is not passed', () => {
+		const widget = new Foo();
+		widget.__setProperties__({});
+		assert.isFalse(widget.shouldFocus());
+		widget.focus();
+		assert.isTrue(widget.shouldFocus());
+		assert.isFalse(widget.shouldFocus());
+	});
+});

--- a/tests/unit/mixins/all.ts
+++ b/tests/unit/mixins/all.ts
@@ -1,3 +1,4 @@
+import './Focus';
 import './Themed';
 import './Projector';
 import './I18n';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

`FocusMixin` builds on the primitive `focus` functionality provided by `vdom` and enables management of focus across widget boundaries.

The `FocusMixin` provides a function called `shouldFocus` that manages when a widget or their child widgets can apply focus, `shouldFocus` will only return `true` the first time it is called until `focus` is called again on the widget.
