### PR TITLE
Ensures that the dnodes index is found when selecting siblings

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -1091,8 +1091,11 @@ function render(projectionOptions: ProjectionOptions) {
 			previouslyRendered.push(instance);
 			const { parentVNode, dnode } = instanceMap.get(instance)!;
 			const instanceData = widgetInstanceMap.get(instance)!;
-			const index = (parentVNode.children || []).indexOf(dnode);
-			const siblings = (parentVNode.children || []).slice(index + 1);
+			let siblings: InternalDNode[] = [];
+			if (parentVNode.children) {
+				const index = findIndexOfChild(parentVNode.children, dnode, 0);
+				siblings = parentVNode.children.slice(index + 1);
+			}
 			updateDom(
 				dnode,
 				toInternalWNode(instance, instanceData),

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -882,6 +882,58 @@ describe('vdom', () => {
 			assert.strictEqual(thirdTextNodeChild.data, '3');
 		});
 
+		it('should find node in array of siblings', () => {
+			let expand: any;
+			class Foo extends WidgetBase<any> {
+				private _expand = false;
+
+				doExpand() {
+					this._expand = !this._expand;
+					this.invalidate();
+				}
+
+				render() {
+					return this._expand
+						? [v('div', { key: '1' }, ['one']), v('div', { key: '2' }, ['two'])]
+						: [v('div', { key: '1' }, ['one'])];
+				}
+			}
+
+			class EnhancedFoo extends Foo {
+				constructor() {
+					super();
+					expand = this.doExpand.bind(this);
+				}
+			}
+
+			class Parent extends WidgetBase {
+				render() {
+					return v('div', [w(EnhancedFoo, {}), w(Foo, {})]);
+				}
+			}
+
+			const widget = new Parent();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0];
+			assert.lengthOf(root.childNodes, 2);
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'one');
+			expand();
+			assert.lengthOf(root.childNodes, 3);
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'one');
+			expand();
+			assert.lengthOf(root.childNodes, 2);
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'one');
+			expand();
+			assert.lengthOf(root.childNodes, 3);
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'one');
+		});
+
 		it('should update an array of nodes to single node', () => {
 			class Foo extends WidgetBase {
 				private _array = false;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Use `findIndexOfChild` to determine the index of a node amongst its siblings on a render.

Resolves #930 
