### PR TITLE
Improve mechanism to find siblings on render

### DIFF
--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -1093,8 +1093,27 @@ function render(projectionOptions: ProjectionOptions) {
 			const instanceData = widgetInstanceMap.get(instance)!;
 			let siblings: InternalDNode[] = [];
 			if (parentVNode.children) {
-				const index = findIndexOfChild(parentVNode.children, dnode, 0);
-				siblings = parentVNode.children.slice(index + 1);
+				let searchChildren: InternalDNode[] = [parentVNode];
+				while (searchChildren.length) {
+					let searchChild = searchChildren.shift();
+					let children: InternalDNode[] = [];
+					if (isWNode(searchChild)) {
+						const item = instanceMap.get(searchChild.instance);
+						if (item) {
+							children = item.dnode.rendered;
+						}
+					} else if (isVNode(searchChild) && searchChild.children) {
+						children = searchChild.children;
+					}
+					if (children.length) {
+						const index = findIndexOfChild(children, dnode, 0);
+						if (index !== -1) {
+							siblings = children.slice(index + 1);
+							break;
+						}
+						searchChildren = [...children, ...searchChildren];
+					}
+				}
 			}
 			updateDom(
 				dnode,

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -934,6 +934,144 @@ describe('vdom', () => {
 			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'one');
 		});
 
+		it('only pass siblings if the node found exists in the list', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+				}
+			}
+			let showBar = false;
+			let invalidateBar: any;
+			class Bar extends WidgetBase {
+				constructor() {
+					super();
+					invalidateBar = this.invalidate.bind(this);
+				}
+				render() {
+					return showBar ? [v('div', { key: '3' }, ['three']), w(Qux, {})] : null;
+				}
+			}
+
+			let showQux = false;
+			let invalidateQux: any;
+			class Qux extends WidgetBase {
+				constructor() {
+					super();
+					invalidateQux = this.invalidate.bind(this);
+				}
+				render() {
+					return showQux ? v('div', { key: '3' }, ['four']) : null;
+				}
+			}
+
+			const widget = new Foo();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0];
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			showBar = true;
+			invalidateBar();
+			showQux = true;
+			invalidateQux();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'four');
+		});
+
+		it('Should insert a new DNode at the beginning when returning an array in the correct position', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+				}
+			}
+			let showBar = false;
+			let invalidateBar: any;
+			class Bar extends WidgetBase {
+				constructor() {
+					super();
+					invalidateBar = this.invalidate.bind(this);
+				}
+				render() {
+					return showBar ? [w(Qux, {}), v('div', { key: '3' }, ['three'])] : null;
+				}
+			}
+
+			let showQux = false;
+			let invalidateQux: any;
+			class Qux extends WidgetBase {
+				constructor() {
+					super();
+					invalidateQux = this.invalidate.bind(this);
+				}
+				render() {
+					return showQux ? v('div', { key: '3' }, ['four']) : null;
+				}
+			}
+
+			const widget = new Foo();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0];
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			showBar = true;
+			invalidateBar();
+			showQux = true;
+			invalidateQux();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'four');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'three');
+		});
+
+		it('Should insert a new DNode at the middle when returning an array in the correct position', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+				}
+			}
+			let showBar = false;
+			let invalidateBar: any;
+			class Bar extends WidgetBase {
+				constructor() {
+					super();
+					invalidateBar = this.invalidate.bind(this);
+				}
+				render() {
+					return showBar
+						? [v('div', { key: '3' }, ['three']), w(Qux, {}), v('div', { key: '3' }, ['five'])]
+						: null;
+				}
+			}
+
+			let showQux = false;
+			let invalidateQux: any;
+			class Qux extends WidgetBase {
+				constructor() {
+					super();
+					invalidateQux = this.invalidate.bind(this);
+				}
+				render() {
+					return showQux ? v('div', { key: '3' }, ['four']) : null;
+				}
+			}
+
+			const widget = new Foo();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0];
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			showBar = true;
+			invalidateBar();
+			showQux = true;
+			invalidateQux();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'four');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'five');
+		});
+
 		it('should update an array of nodes to single node', () => {
 			class Foo extends WidgetBase {
 				private _array = false;

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -982,7 +982,7 @@ describe('vdom', () => {
 		it('Should insert a new DNode at the beginning when returning an array in the correct position', () => {
 			class Foo extends WidgetBase {
 				render() {
-					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+					return v('div', [v('div', { key: '1' }, ['one']), v('div', { key: '2' }, ['two']), w(Bar, {})]);
 				}
 			}
 			let showBar = false;
@@ -1005,7 +1005,7 @@ describe('vdom', () => {
 					invalidateQux = this.invalidate.bind(this);
 				}
 				render() {
-					return showQux ? v('div', { key: '3' }, ['four']) : null;
+					return showQux ? v('div', { key: '4' }, ['four']) : null;
 				}
 			}
 
@@ -1027,7 +1027,7 @@ describe('vdom', () => {
 		it('Should insert a new DNode at the middle when returning an array in the correct position', () => {
 			class Foo extends WidgetBase {
 				render() {
-					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+					return v('div', [v('div', { key: '1' }, ['one']), v('div', { key: '2' }, ['two']), w(Bar, {})]);
 				}
 			}
 			let showBar = false;
@@ -1039,7 +1039,7 @@ describe('vdom', () => {
 				}
 				render() {
 					return showBar
-						? [v('div', { key: '3' }, ['three']), w(Qux, {}), v('div', { key: '3' }, ['five'])]
+						? [v('div', { key: '3' }, ['three']), w(Qux, {}), v('div', { key: '5' }, ['five'])]
 						: null;
 				}
 			}
@@ -1052,7 +1052,7 @@ describe('vdom', () => {
 					invalidateQux = this.invalidate.bind(this);
 				}
 				render() {
-					return showQux ? v('div', { key: '3' }, ['four']) : null;
+					return showQux ? v('div', { key: '4' }, ['four']) : null;
 				}
 			}
 
@@ -1063,13 +1063,17 @@ describe('vdom', () => {
 			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
 			showBar = true;
 			invalidateBar();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'five');
 			showQux = true;
 			invalidateQux();
 			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
 			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
-			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'three');
-			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'four');
-			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'five');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'four');
+			assert.strictEqual((root.childNodes[4].childNodes[0] as Text).data, 'five');
 		});
 
 		it('should update an array of nodes to single node', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Update the algorithm for finding a widgets siblings on re-render. It needs to search through the siblings and their children to identify the correct location to insert nodes when returning arrays from a widgets render function.

Finding the position of a WNode that is being rendered amongst it’s siblings ensures that the `insertBefore` position can be correctly calculated and new nodes that are added to widgets returning an array are attached at the correct location in the DOM.

Resolves #930 
