### PR TITLE
Fix the algorithm for determining the position to insert new DOM nodes

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -73,7 +73,7 @@
 				{ "browserName": "chrome", "platform": "WINDOWS" },
 				{ "browserName": "firefox", "os": "Windows", "os_version": "10", "browser_version": "58.0" },
 				{ "browserName": "safari", "version": "10", "platform": "MAC" },
-				{ "browserName": "iPhone", "version": "9.1" }
+				{ "browserName": "iPhone", "os_version": "10.3", "device": "iPhone 7", "realMobile": "true" }
 			]
 		},
 		"saucelabs": {

--- a/intern.json
+++ b/intern.json
@@ -73,7 +73,7 @@
 				{ "browserName": "chrome", "platform": "WINDOWS" },
 				{ "browserName": "firefox", "os": "Windows", "os_version": "10", "browser_version": "58.0" },
 				{ "browserName": "safari", "version": "10", "platform": "MAC" },
-				{ "browserName": "iPhone", "os_version": "10.3", "device": "iPhone 7", "realMobile": "true" }
+				{ "browserName": "iPhone", "os_version": "11.0", "device": "iPhone 8", "realMobile": "true" }
 			]
 		},
 		"saucelabs": {

--- a/intern.json
+++ b/intern.json
@@ -72,8 +72,7 @@
 				{ "browserName": "internet explorer", "version": "11" },
 				{ "browserName": "chrome", "platform": "WINDOWS" },
 				{ "browserName": "firefox", "os": "Windows", "os_version": "10", "browser_version": "58.0" },
-				{ "browserName": "safari", "version": "10", "platform": "MAC" },
-				{ "browserName": "iPhone", "os_version": "11.0", "device": "iPhone 8", "realMobile": "true" }
+				{ "browserName": "safari", "version": "10", "platform": "MAC" }
 			]
 		},
 		"saucelabs": {

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -668,6 +668,9 @@ function updateChildren(
 						}
 					} else {
 						if (insertBefore.domNode) {
+							if (insertBefore.domNode.parentElement !== parentVNode.domNode) {
+								break;
+							}
 							insertBeforeDomNode = insertBefore.domNode;
 							break;
 						}

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -104,6 +104,7 @@ interface ProjectorState {
 export const widgetInstanceMap = new WeakMap<any, WidgetData>();
 
 const instanceMap = new WeakMap<DefaultWidgetBaseInterface, InstanceMapData>();
+const nextSiblingMap = new WeakMap<DefaultWidgetBaseInterface, InternalDNode[]>();
 const projectorStateMap = new WeakMap<DefaultWidgetBaseInterface, ProjectorState>();
 
 function same(dnode1: InternalDNode, dnode2: InternalDNode) {
@@ -639,7 +640,8 @@ function updateChildren(
 					projectionOptions,
 					parentVNode,
 					parentInstance,
-					oldChildren.slice(oldIndex)
+					oldChildren.slice(oldIndex),
+					newChildren.slice(newIndex)
 				) || textUpdated;
 			continue;
 		}
@@ -680,7 +682,7 @@ function updateChildren(
 			createDom(
 				newChild,
 				parentVNode,
-				oldChildren.slice(oldIndex + 1),
+				newChildren.slice(newIndex + 1),
 				insertBeforeDomNode,
 				projectionOptions,
 				parentInstance
@@ -765,6 +767,7 @@ function addChildren(
 
 	for (let i = 0; i < children.length; i++) {
 		const child = children[i];
+		const nextSiblings = children.slice(i + 1);
 
 		if (isVNode(child)) {
 			if (projectorState.merge && childNodes) {
@@ -776,9 +779,9 @@ function addChildren(
 					}
 				}
 			}
-			createDom(child, parentVNode, [], insertBefore, projectionOptions, parentInstance);
+			createDom(child, parentVNode, nextSiblings, insertBefore, projectionOptions, parentInstance);
 		} else {
-			createDom(child, parentVNode, [], insertBefore, projectionOptions, parentInstance, childNodes);
+			createDom(child, parentVNode, nextSiblings, insertBefore, projectionOptions, parentInstance, childNodes);
 		}
 		nodeAdded(child, transitions);
 	}
@@ -816,7 +819,7 @@ function initPropertiesAndChildren(
 function createDom(
 	dnode: InternalDNode,
 	parentVNode: InternalVNode,
-	siblings: InternalDNode[],
+	nextSiblings: InternalDNode[],
 	insertBefore: Node | undefined,
 	projectionOptions: ProjectionOptions,
 	parentInstance: DefaultWidgetBaseInterface,
@@ -836,6 +839,7 @@ function createDom(
 		}
 		const instance = new widgetConstructor();
 		dnode.instance = instance;
+		nextSiblingMap.set(instance, nextSiblings);
 		const instanceData = widgetInstanceMap.get(instance)!;
 		instanceData.invalidate = () => {
 			instanceData.dirty = true;
@@ -915,7 +919,8 @@ function updateDom(
 	projectionOptions: ProjectionOptions,
 	parentVNode: InternalVNode,
 	parentInstance: DefaultWidgetBaseInterface,
-	siblings: InternalDNode[]
+	oldNextSiblings: InternalDNode[],
+	nextSiblings: InternalDNode[]
 ) {
 	if (isWNode(dnode)) {
 		const { instance } = previous;
@@ -926,12 +931,13 @@ function updateDom(
 		instance.__setCoreProperties__(dnode.coreProperties);
 		instance.__setChildren__(dnode.children);
 		instance.__setProperties__(dnode.properties);
+		nextSiblingMap.set(instance, nextSiblings);
 		dnode.instance = instance;
 		if (instanceData.dirty === true) {
 			const rendered = instance.__render__();
 			instanceData.rendering = false;
 			dnode.rendered = filterAndDecorateChildren(rendered, instance);
-			updateChildren(parentVNode, siblings, previousRendered, dnode.rendered, instance, projectionOptions);
+			updateChildren(parentVNode, oldNextSiblings, previousRendered, dnode.rendered, instance, projectionOptions);
 		} else {
 			instanceData.rendering = false;
 			dnode.rendered = previousRendered;
@@ -961,8 +967,14 @@ function updateDom(
 				const children = filterAndDecorateChildren(dnode.children, parentInstance);
 				dnode.children = children;
 				updated =
-					updateChildren(dnode, siblings, previous.children, children, parentInstance, projectionOptions) ||
-					updated;
+					updateChildren(
+						dnode,
+						oldNextSiblings,
+						previous.children,
+						children,
+						parentInstance,
+						projectionOptions
+					) || updated;
 			}
 
 			const previousProperties = buildPreviousProperties(domNode, previous, dnode);
@@ -1091,37 +1103,15 @@ function render(projectionOptions: ProjectionOptions) {
 			previouslyRendered.push(instance);
 			const { parentVNode, dnode } = instanceMap.get(instance)!;
 			const instanceData = widgetInstanceMap.get(instance)!;
-			let siblings: InternalDNode[] = [];
-			if (parentVNode.children) {
-				let searchChildren: InternalDNode[] = [parentVNode];
-				while (searchChildren.length) {
-					let searchChild = searchChildren.shift();
-					let children: InternalDNode[] = [];
-					if (isWNode(searchChild)) {
-						const item = instanceMap.get(searchChild.instance);
-						if (item) {
-							children = item.dnode.rendered;
-						}
-					} else if (isVNode(searchChild) && searchChild.children) {
-						children = searchChild.children;
-					}
-					if (children.length) {
-						const index = findIndexOfChild(children, dnode, 0);
-						if (index !== -1) {
-							siblings = children.slice(index + 1);
-							break;
-						}
-						searchChildren = [...children, ...searchChildren];
-					}
-				}
-			}
+			const nextSiblings = nextSiblingMap.get(instance)!;
 			updateDom(
 				dnode,
 				toInternalWNode(instance, instanceData),
 				projectionOptions,
 				parentVNode,
 				instance,
-				siblings
+				nextSiblings,
+				nextSiblings
 			);
 		}
 	}
@@ -1159,7 +1149,7 @@ export const dom = {
 				scheduleRender(finalProjectorOptions);
 			}
 		};
-		updateDom(node, node, finalProjectorOptions, parentVNode, instance, []);
+		updateDom(node, node, finalProjectorOptions, parentVNode, instance, [], []);
 		projectorState.afterRenderCallbacks.push(() => {
 			instanceData.onAttach();
 		});

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -1093,8 +1093,27 @@ function render(projectionOptions: ProjectionOptions) {
 			const instanceData = widgetInstanceMap.get(instance)!;
 			let siblings: InternalDNode[] = [];
 			if (parentVNode.children) {
-				const index = findIndexOfChild(parentVNode.children, dnode, 0);
-				siblings = parentVNode.children.slice(index + 1);
+				let searchChildren: InternalDNode[] = [parentVNode];
+				while (searchChildren.length) {
+					let searchChild = searchChildren.shift();
+					let children: InternalDNode[] = [];
+					if (isWNode(searchChild)) {
+						const item = instanceMap.get(searchChild.instance);
+						if (item) {
+							children = item.dnode.rendered;
+						}
+					} else if (isVNode(searchChild) && searchChild.children) {
+						children = searchChild.children;
+					}
+					if (children.length) {
+						const index = findIndexOfChild(children, dnode, 0);
+						if (index !== -1) {
+							siblings = children.slice(index + 1);
+							break;
+						}
+						searchChildren = [...children, ...searchChildren];
+					}
+				}
 			}
 			updateDom(
 				dnode,

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -934,6 +934,144 @@ describe('vdom', () => {
 			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'one');
 		});
 
+		it('only pass siblings if the node found exists in the list', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+				}
+			}
+			let showBar = false;
+			let invalidateBar: any;
+			class Bar extends WidgetBase {
+				constructor() {
+					super();
+					invalidateBar = this.invalidate.bind(this);
+				}
+				render() {
+					return showBar ? [v('div', { key: '3' }, ['three']), w(Qux, {})] : null;
+				}
+			}
+
+			let showQux = false;
+			let invalidateQux: any;
+			class Qux extends WidgetBase {
+				constructor() {
+					super();
+					invalidateQux = this.invalidate.bind(this);
+				}
+				render() {
+					return showQux ? v('div', { key: '3' }, ['four']) : null;
+				}
+			}
+
+			const widget = new Foo();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0];
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			showBar = true;
+			invalidateBar();
+			showQux = true;
+			invalidateQux();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'four');
+		});
+
+		it('Should insert a new DNode at the beginning when returning an array in the correct position', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+				}
+			}
+			let showBar = false;
+			let invalidateBar: any;
+			class Bar extends WidgetBase {
+				constructor() {
+					super();
+					invalidateBar = this.invalidate.bind(this);
+				}
+				render() {
+					return showBar ? [w(Qux, {}), v('div', { key: '3' }, ['three'])] : null;
+				}
+			}
+
+			let showQux = false;
+			let invalidateQux: any;
+			class Qux extends WidgetBase {
+				constructor() {
+					super();
+					invalidateQux = this.invalidate.bind(this);
+				}
+				render() {
+					return showQux ? v('div', { key: '3' }, ['four']) : null;
+				}
+			}
+
+			const widget = new Foo();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0];
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			showBar = true;
+			invalidateBar();
+			showQux = true;
+			invalidateQux();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'four');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'three');
+		});
+
+		it('Should insert a new DNode at the middle when returning an array in the correct position', () => {
+			class Foo extends WidgetBase {
+				render() {
+					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+				}
+			}
+			let showBar = false;
+			let invalidateBar: any;
+			class Bar extends WidgetBase {
+				constructor() {
+					super();
+					invalidateBar = this.invalidate.bind(this);
+				}
+				render() {
+					return showBar
+						? [v('div', { key: '3' }, ['three']), w(Qux, {}), v('div', { key: '3' }, ['five'])]
+						: null;
+				}
+			}
+
+			let showQux = false;
+			let invalidateQux: any;
+			class Qux extends WidgetBase {
+				constructor() {
+					super();
+					invalidateQux = this.invalidate.bind(this);
+				}
+				render() {
+					return showQux ? v('div', { key: '3' }, ['four']) : null;
+				}
+			}
+
+			const widget = new Foo();
+			const projection = dom.create(widget, { sync: true });
+			const root = projection.domNode.childNodes[0];
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			showBar = true;
+			invalidateBar();
+			showQux = true;
+			invalidateQux();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'four');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'five');
+		});
+
 		it('should update an array of nodes to single node', () => {
 			class Foo extends WidgetBase {
 				private _array = false;

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -4290,7 +4290,7 @@ describe('vdom', () => {
 		});
 	});
 
-	describe('i18n Mixin', () => {
+	it('i18n Mixin', () => {
 		class MyWidget extends I18nMixin(WidgetBase) {
 			render() {
 				return v('span');

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -982,7 +982,7 @@ describe('vdom', () => {
 		it('Should insert a new DNode at the beginning when returning an array in the correct position', () => {
 			class Foo extends WidgetBase {
 				render() {
-					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+					return v('div', [v('div', { key: '1' }, ['one']), v('div', { key: '2' }, ['two']), w(Bar, {})]);
 				}
 			}
 			let showBar = false;
@@ -1005,7 +1005,7 @@ describe('vdom', () => {
 					invalidateQux = this.invalidate.bind(this);
 				}
 				render() {
-					return showQux ? v('div', { key: '3' }, ['four']) : null;
+					return showQux ? v('div', { key: '4' }, ['four']) : null;
 				}
 			}
 
@@ -1027,7 +1027,7 @@ describe('vdom', () => {
 		it('Should insert a new DNode at the middle when returning an array in the correct position', () => {
 			class Foo extends WidgetBase {
 				render() {
-					return v('div', [v('div', { key: '3' }, ['one']), v('div', { key: '3' }, ['two']), w(Bar, {})]);
+					return v('div', [v('div', { key: '1' }, ['one']), v('div', { key: '2' }, ['two']), w(Bar, {})]);
 				}
 			}
 			let showBar = false;
@@ -1039,7 +1039,7 @@ describe('vdom', () => {
 				}
 				render() {
 					return showBar
-						? [v('div', { key: '3' }, ['three']), w(Qux, {}), v('div', { key: '3' }, ['five'])]
+						? [v('div', { key: '3' }, ['three']), w(Qux, {}), v('div', { key: '5' }, ['five'])]
 						: null;
 				}
 			}
@@ -1052,7 +1052,7 @@ describe('vdom', () => {
 					invalidateQux = this.invalidate.bind(this);
 				}
 				render() {
-					return showQux ? v('div', { key: '3' }, ['four']) : null;
+					return showQux ? v('div', { key: '4' }, ['four']) : null;
 				}
 			}
 
@@ -1063,13 +1063,17 @@ describe('vdom', () => {
 			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
 			showBar = true;
 			invalidateBar();
+			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
+			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'five');
 			showQux = true;
 			invalidateQux();
 			assert.strictEqual((root.childNodes[0].childNodes[0] as Text).data, 'one');
 			assert.strictEqual((root.childNodes[1].childNodes[0] as Text).data, 'two');
-			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'three');
-			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'four');
-			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'five');
+			assert.strictEqual((root.childNodes[2].childNodes[0] as Text).data, 'three');
+			assert.strictEqual((root.childNodes[3].childNodes[0] as Text).data, 'four');
+			assert.strictEqual((root.childNodes[4].childNodes[0] as Text).data, 'five');
 		});
 
 		it('should update an array of nodes to single node', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Optimistically store the array of "next" siblings for a widget instance to ensure that the correct node can be calculated to insert nodes before. The insert before logic iterates through these siblings and uses the first `domNode` located before hitting a `domNode`, if no candidate is found then the node will simply be appended to the parent.

Resolves #930 
