### PR TITLE
fix incorrect equality check in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ class MyClass extends WidgetBase<MyClassProperties> {
 
     @beforeProperties()
     protected myBeforeProperties(properties: MyClassProperties): MyClassProperties {
-        if (properties.type = 'myType') {
+        if (properties.type === 'myType') {
             return { extraProperty: 'foo' };
         }
         return {};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

This is just a simple README fix.

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->