### PR TITLE
Preventing default on drag events

### DIFF
--- a/src/meta/Drag.ts
+++ b/src/meta/Drag.ts
@@ -182,6 +182,9 @@ class DragController {
 			state.dragResults.start = deepAssign({}, state.start);
 			state.dragResults.isDragging = true;
 			state.invalidate();
+
+			event.preventDefault();
+			event.stopPropagation();
 		} // else, we are ignoring the event
 	};
 
@@ -198,6 +201,9 @@ class DragController {
 			state.dragResults.start = deepAssign({}, state.start);
 		}
 		state.invalidate();
+
+		event.preventDefault();
+		event.stopPropagation();
 	};
 
 	private _onDragStop = (event: PointerEvent) => {
@@ -215,6 +221,9 @@ class DragController {
 		state.dragResults.isDragging = false;
 		state.invalidate();
 		this._dragging = undefined;
+
+		event.preventDefault();
+		event.stopPropagation();
 	};
 
 	constructor() {

--- a/tests/support/sendEvent.ts
+++ b/tests/support/sendEvent.ts
@@ -2,6 +2,7 @@ import has, { add as hasAdd } from '@dojo/core/has';
 import { deepAssign } from '@dojo/core/lang';
 import global from '@dojo/shim/global';
 import { assign } from '@dojo/shim/object';
+import { spy } from 'sinon';
 
 hasAdd('customevent-constructor', () => {
 	try {
@@ -96,7 +97,7 @@ export default function sendEvent<I extends EventInit>(
 	target: Element,
 	type: string,
 	options?: SendEventOptions<I>
-): void {
+): Event {
 	function dispatchEvent(target: Element, event: Event) {
 		let error: Error | undefined;
 
@@ -136,6 +137,9 @@ export default function sendEvent<I extends EventInit>(
 	} catch (e) {
 		/* swallowing assignment errors when trying to overwrite native event properties */
 	}
+
+	spy(event, 'stopPropagation');
+
 	if (selector) {
 		const selectorTarget = target.querySelector(selector);
 		if (selectorTarget) {
@@ -146,4 +150,6 @@ export default function sendEvent<I extends EventInit>(
 	} else {
 		dispatchEvent(target, event);
 	}
+
+	return event;
 }

--- a/tests/unit/meta/Drag.ts
+++ b/tests/unit/meta/Drag.ts
@@ -1,12 +1,13 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
+import { SinonSpy } from 'sinon';
+import { v } from '../../../src/d';
+import Drag, { DragResults } from '../../../src/meta/Drag';
+import { ProjectorMixin } from '../../../src/mixins/Projector';
+import { ThemedMixin } from '../../../src/mixins/Themed';
+import { WidgetBase } from '../../../src/WidgetBase';
 import sendEvent from '../../support/sendEvent';
 import { createResolvers } from './../../support/util';
-import { v } from '../../../src/d';
-import { ProjectorMixin } from '../../../src/mixins/Projector';
-import Drag, { DragResults } from '../../../src/meta/Drag';
-import { WidgetBase } from '../../../src/WidgetBase';
-import { ThemedMixin } from '../../../src/mixins/Themed';
 
 const resolvers = createResolvers();
 
@@ -127,7 +128,7 @@ registerSuite('support/meta/Drag', {
 			resolvers.resolve();
 			resolvers.resolve();
 
-			sendEvent(div.firstChild as Element, 'pointerdown', {
+			const downEvent = sendEvent(div.firstChild as Element, 'pointerdown', {
 				eventInit: {
 					bubbles: true,
 					isPrimary: true,
@@ -143,9 +144,12 @@ registerSuite('support/meta/Drag', {
 				}
 			});
 
+			assert.isTrue(downEvent.defaultPrevented);
+			assert.isTrue((downEvent.stopPropagation as SinonSpy).called);
+
 			resolvers.resolve();
 
-			sendEvent(div.firstChild as Element, 'pointermove', {
+			const moveEvent = sendEvent(div.firstChild as Element, 'pointermove', {
 				eventInit: {
 					bubbles: true,
 					clientX: 110,
@@ -159,9 +163,12 @@ registerSuite('support/meta/Drag', {
 				}
 			});
 
+			assert.isTrue(moveEvent.defaultPrevented);
+			assert.isTrue((moveEvent.stopPropagation as SinonSpy).called);
+
 			resolvers.resolve();
 
-			sendEvent(div.firstChild as Element, 'pointerup', {
+			const upEvent = sendEvent(div.firstChild as Element, 'pointerup', {
 				eventInit: {
 					bubbles: true,
 					clientX: 105,
@@ -174,6 +181,9 @@ registerSuite('support/meta/Drag', {
 					screenY: 1050
 				}
 			});
+
+			assert.isTrue(upEvent.defaultPrevented);
+			assert.isTrue((upEvent.stopPropagation as SinonSpy).called);
 
 			resolvers.resolve();
 
@@ -528,7 +538,7 @@ registerSuite('support/meta/Drag', {
 			resolvers.resolve();
 			resolvers.resolve();
 
-			sendEvent(div.firstChild as Element, 'pointermove', {
+			const moveEvent = sendEvent(div.firstChild as Element, 'pointermove', {
 				eventInit: {
 					bubbles: true,
 					clientX: 115,
@@ -542,9 +552,12 @@ registerSuite('support/meta/Drag', {
 				}
 			});
 
+			assert.isFalse(moveEvent.defaultPrevented);
+			assert.isFalse((moveEvent.stopPropagation as SinonSpy).called);
+
 			resolvers.resolve();
 
-			sendEvent(div.firstChild as Element, 'pointerup', {
+			const upEvent = sendEvent(div.firstChild as Element, 'pointerup', {
 				eventInit: {
 					bubbles: true,
 					clientX: 120,
@@ -557,6 +570,9 @@ registerSuite('support/meta/Drag', {
 					screenY: 1050
 				}
 			});
+
+			assert.isFalse(upEvent.defaultPrevented);
+			assert.isFalse((upEvent.stopPropagation as SinonSpy).called);
 
 			resolvers.resolve();
 
@@ -735,7 +751,7 @@ registerSuite('support/meta/Drag', {
 			resolvers.resolve();
 			resolvers.resolve();
 
-			sendEvent(div.firstChild!.firstChild as Element, 'pointerdown', {
+			const downEvent = sendEvent(div.firstChild!.firstChild as Element, 'pointerdown', {
 				eventInit: {
 					bubbles: true,
 					isPrimary: true,
@@ -751,9 +767,12 @@ registerSuite('support/meta/Drag', {
 				}
 			});
 
+			assert.isFalse(downEvent.defaultPrevented);
+			assert.isFalse((downEvent.stopPropagation as SinonSpy).called);
+
 			resolvers.resolve();
 
-			sendEvent(div.firstChild!.firstChild as Element, 'pointermove', {
+			const moveEvent = sendEvent(div.firstChild!.firstChild as Element, 'pointermove', {
 				eventInit: {
 					bubbles: true,
 					clientX: 110,
@@ -767,9 +786,12 @@ registerSuite('support/meta/Drag', {
 				}
 			});
 
+			assert.isFalse(moveEvent.defaultPrevented);
+			assert.isFalse((moveEvent.stopPropagation as SinonSpy).called);
+
 			resolvers.resolve();
 
-			sendEvent(div.firstChild!.firstChild as Element, 'pointerup', {
+			const upEvent = sendEvent(div.firstChild!.firstChild as Element, 'pointerup', {
 				eventInit: {
 					bubbles: true,
 					clientX: 105,
@@ -782,6 +804,9 @@ registerSuite('support/meta/Drag', {
 					screenY: 1050
 				}
 			});
+
+			assert.isFalse(upEvent.defaultPrevented);
+			assert.isFalse((upEvent.stopPropagation as SinonSpy).called);
 
 			resolvers.resolve();
 


### PR DESCRIPTION
Currently when you drag, the pointer events just pass right through. This can cause text on the page to become highlighted during a drag operation.