### PR TITLE
Updating Dimensions meta to include client dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,10 @@ The following fields are provided:
 
 | Property         | Source                                |
 | -----------------| ------------------------------------- |
+| `client.left`    | `node.clientLeft`                     |
+| `client.top`     | `node.clientTop`                      |
+| `client.width`   | `node.clientWidth`                    |
+| `client.height   | `node.clientHeight`                   |
 | `position.bottom`| `node.getBoundingClientRect().bottom` |
 | `position.left`  | `node.getBoundingClientRect().left`   |
 | `position.right` | `node.getBoundingClientRect().right`  |
@@ -1115,6 +1119,7 @@ The following fields are provided:
 | `offset.top`     | `node.offsetTop`                      |
 | `offset.width`   | `node.offsetWidth`                    |
 | `offset.height`  | `node.offsetHeight`                   |
+
 
 If the node has not yet been rendered, all values will contain `0`. If you need more information about whether or not the node has been rendered you can use the `has` method:
 

--- a/src/meta/Dimensions.ts
+++ b/src/meta/Dimensions.ts
@@ -21,9 +21,16 @@ export interface DimensionResults {
 	offset: TopLeft & Size;
 	size: Size;
 	scroll: TopLeft & Size;
+	client: TopLeft & Size;
 }
 
 const defaultDimensions = {
+	client: {
+		height: 0,
+		left: 0,
+		top: 0,
+		width: 0
+	},
 	offset: {
 		height: 0,
 		left: 0,
@@ -59,6 +66,12 @@ export class Dimensions extends Base {
 		const boundingDimensions = node.getBoundingClientRect();
 
 		return {
+			client: {
+				height: node.clientHeight,
+				left: node.clientLeft,
+				top: node.clientTop,
+				width: node.clientWidth
+			},
 			offset: {
 				height: node.offsetHeight,
 				left: node.offsetLeft,

--- a/tests/unit/meta/Dimensions.ts
+++ b/tests/unit/meta/Dimensions.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import global from '@dojo/shim/global';
-import { stub, spy } from 'sinon';
+import { spy, stub } from 'sinon';
 import Dimensions from '../../../src/meta/Dimensions';
 import NodeHandler from '../../../src/NodeHandler';
 import WidgetBase from '../../../src/WidgetBase';
@@ -9,6 +9,12 @@ import WidgetBase from '../../../src/WidgetBase';
 let rAF: any;
 const bindInstance = new WidgetBase();
 const defaultDimensions = {
+	client: {
+		height: 0,
+		left: 0,
+		top: 0,
+		width: 0
+	},
 	offset: {
 		height: 0,
 		left: 0,
@@ -120,6 +126,7 @@ registerSuite('meta - Dimensions', {
 		'Will return element dimensions if node is loaded'() {
 			const nodeHandler = new NodeHandler();
 
+			const client = { clientLeft: 1, clientTop: 2, clientWidth: 3, clientHeight: 4 };
 			const offset = { offsetHeight: 10, offsetLeft: 10, offsetTop: 10, offsetWidth: 10 };
 			const scroll = { scrollHeight: 10, scrollLeft: 10, scrollTop: 10, scrollWidth: 10 };
 			const position = { bottom: 10, left: 10, right: 10, top: 10 };
@@ -128,6 +135,7 @@ registerSuite('meta - Dimensions', {
 			const element = {
 				...offset,
 				...scroll,
+				...client,
 				getBoundingClientRect: stub().returns({
 					...position,
 					...size
@@ -146,7 +154,8 @@ registerSuite('meta - Dimensions', {
 				offset: { height: 10, left: 10, top: 10, width: 10 },
 				scroll: { height: 10, left: 10, top: 10, width: 10 },
 				position,
-				size
+				size,
+				client: { height: 4, left: 1, top: 2, width: 3 }
 			});
 		}
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

I recently came across a need for `clientWidth` but realized that the `Dimensions` meta does not return it. This simply adds `clientLeft`, `clientTop`, `clientWidth`, and `clientHeight` to the results returned by the `Dimensions` meta.
