### PR TITLE
Dropped 's' from Animations link to point to the right section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,7 +1172,7 @@ class List extends WidgetBase {
 
 #### Animations
 
-See the [Animations](#animations) section more information.
+See the [Animation](#animation) section more information.
 
 #### Drag
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Small typo which pointed you to the wrong animation section.
