### PR TITLE
I18nMixin: render attributes only when set

### DIFF
--- a/src/mixins/I18n.ts
+++ b/src/mixins/I18n.ts
@@ -41,7 +41,7 @@ export interface I18nProperties extends LocaleData, WidgetProperties {
  */
 interface I18nVNodeProperties extends VNodeProperties {
 	dir: string;
-	lang: string | null;
+	lang: string;
 }
 
 export type LocalizedMessages<T extends Messages> = {
@@ -150,10 +150,7 @@ export function I18nMixin<T extends Constructor<WidgetBase<any>>>(Base: T): T & 
 			decorate(result, {
 				modifier: (node, breaker) => {
 					const { locale, rtl } = this.properties;
-					const properties: I18nVNodeProperties = {
-						dir: '',
-						lang: null
-					};
+					const properties: Partial<I18nVNodeProperties> = {};
 					if (typeof rtl === 'boolean') {
 						properties['dir'] = rtl ? 'rtl' : 'ltr';
 					}

--- a/tests/unit/mixins/I18n.ts
+++ b/tests/unit/mixins/I18n.ts
@@ -263,7 +263,7 @@ registerSuite('mixins/I18nMixin', {
 
 				const result = localized.__render__();
 				assert.isOk(result);
-				assert.isNull(result.properties!['lang']);
+				assert.isUndefined(result.properties!['lang']);
 			}
 		},
 
@@ -291,7 +291,7 @@ registerSuite('mixins/I18nMixin', {
 
 				const result = localized.__render__();
 				assert.isOk(result);
-				assert.strictEqual(result.properties.dir, '');
+				assert.isUndefined(result.properties.dir);
 			},
 
 			'The `dir` attribute is added to the first VNode in the render'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #904 

Update the I18nMixin to render the `dir` and `lang` attributes only when they are explicitly set.

Tested both with a fresh `dojo create` app and with [todo-mvc-kitchensink](https://github.com/dojo/examples/tree/master/todo-mvc-kitchensink).