### PR TITLE
Extend the support for DOM Node operations in vdom

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -85,7 +85,7 @@ export type SupportedClassName = string | null | undefined;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
-export type NodeOpFunction = () => boolean;
+export type NodeOperationFunction = () => boolean;
 
 export type DiffType = 'none' | 'dom' | 'vdom';
 
@@ -218,22 +218,22 @@ export interface VNodeProperties {
 	/**
 	 * determines if the node should be focused
 	 */
-	readonly focus?: boolean | NodeOpFunction;
+	readonly focus?: boolean | NodeOperationFunction;
 
 	/**
 	 * determines is the element needs to be clicked
 	 */
-	readonly click?: boolean | NodeOpFunction;
+	readonly click?: boolean | NodeOperationFunction;
 
 	/**
 	 * determines if the node should be scrolled to
 	 */
-	readonly scrollIntoView?: boolean | NodeOpFunction;
+	readonly scrollIntoView?: boolean | NodeOperationFunction;
 
 	/**
 	 * determines if the node should be blurred
 	 */
-	readonly blur?: boolean | NodeOpFunction;
+	readonly blur?: boolean | NodeOperationFunction;
 
 	/**
 	 * Everything that is not explicitly listed (properties and attributes that are either uncommon or custom).

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -85,7 +85,7 @@ export type SupportedClassName = string | null | undefined;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
-export type NodeOperationFunction = () => boolean;
+export type NodeOperationPredicate = () => boolean;
 
 export type DiffType = 'none' | 'dom' | 'vdom';
 
@@ -218,22 +218,22 @@ export interface VNodeProperties {
 	/**
 	 * determines if the node should be focused
 	 */
-	readonly focus?: boolean | NodeOperationFunction;
+	readonly focus?: boolean | NodeOperationPredicate;
 
 	/**
 	 * determines is the element needs to be clicked
 	 */
-	readonly click?: boolean | NodeOperationFunction;
+	readonly click?: boolean | NodeOperationPredicate;
 
 	/**
 	 * determines if the node should be scrolled to
 	 */
-	readonly scrollIntoView?: boolean | NodeOperationFunction;
+	readonly scrollIntoView?: boolean | NodeOperationPredicate;
 
 	/**
 	 * determines if the node should be blurred
 	 */
-	readonly blur?: boolean | NodeOperationFunction;
+	readonly blur?: boolean | NodeOperationPredicate;
 
 	/**
 	 * Everything that is not explicitly listed (properties and attributes that are either uncommon or custom).

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -85,7 +85,7 @@ export type SupportedClassName = string | null | undefined;
 
 export type DeferredVirtualProperties = (inserted: boolean) => VNodeProperties;
 
-export type FocusFunction = () => boolean;
+export type NodeOpFunction = () => boolean;
 
 export type DiffType = 'none' | 'dom' | 'vdom';
 
@@ -218,7 +218,22 @@ export interface VNodeProperties {
 	/**
 	 * determines if the node should be focused
 	 */
-	readonly focus?: boolean | FocusFunction;
+	readonly focus?: boolean | NodeOpFunction;
+
+	/**
+	 * determines is the element needs to be clicked
+	 */
+	readonly click?: boolean | NodeOpFunction;
+
+	/**
+	 * determines if the node should be scrolled to
+	 */
+	readonly scrollIntoView?: boolean | NodeOpFunction;
+
+	/**
+	 * determines if the node should be blurred
+	 */
+	readonly blur?: boolean | NodeOpFunction;
 
 	/**
 	 * Everything that is not explicitly listed (properties and attributes that are either uncommon or custom).

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -24,7 +24,7 @@ const NAMESPACE_XLINK = NAMESPACE_W3 + '1999/xlink';
 
 const emptyArray: (InternalWNode | InternalVNode)[] = [];
 
-const nodeOps = ['focus', 'blur', 'scrollIntoView', 'click'];
+const nodeOperations = ['focus', 'blur', 'scrollIntoView', 'click'];
 
 export type RenderResult = DNode<any> | DNode<any>[];
 
@@ -248,7 +248,7 @@ function buildPreviousProperties(domNode: any, previous: InternalVNode, current:
 	return newProperties;
 }
 
-function nodeOp(
+function nodeOperation(
 	propName: string,
 	propValue: any,
 	previousValue: any,
@@ -376,8 +376,8 @@ function updateProperties(
 					addClasses(domNode, currentClasses[i]);
 				}
 			}
-		} else if (nodeOps.indexOf(propName) !== -1) {
-			nodeOp(propName, propValue, previousValue, domNode, projectionOptions);
+		} else if (nodeOperations.indexOf(propName) !== -1) {
+			nodeOperation(propName, propValue, previousValue, domNode, projectionOptions);
 		} else if (propName === 'styles') {
 			const styleNames = Object.keys(propValue);
 			const styleCount = styleNames.length;

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -24,6 +24,8 @@ const NAMESPACE_XLINK = NAMESPACE_W3 + '1999/xlink';
 
 const emptyArray: (InternalWNode | InternalVNode)[] = [];
 
+const nodeOps = ['focus', 'blur', 'scrollIntoView', 'click'];
+
 export type RenderResult = DNode<any> | DNode<any>[];
 
 interface InstanceMapData {
@@ -246,7 +248,13 @@ function buildPreviousProperties(domNode: any, previous: InternalVNode, current:
 	return newProperties;
 }
 
-function focusNode(propValue: any, previousValue: any, domNode: Element, projectionOptions: ProjectionOptions): void {
+function nodeOp(
+	propName: string,
+	propValue: any,
+	previousValue: any,
+	domNode: Element,
+	projectionOptions: ProjectionOptions
+): void {
 	let result;
 	if (typeof propValue === 'function') {
 		result = propValue();
@@ -256,7 +264,7 @@ function focusNode(propValue: any, previousValue: any, domNode: Element, project
 	if (result === true) {
 		const projectorState = projectorStateMap.get(projectionOptions.projectorInstance)!;
 		projectorState.deferredRenderCallbacks.push(() => {
-			(domNode as HTMLElement).focus();
+			(domNode as any)[propName]();
 		});
 	}
 }
@@ -368,8 +376,8 @@ function updateProperties(
 					addClasses(domNode, currentClasses[i]);
 				}
 			}
-		} else if (propName === 'focus') {
-			focusNode(propValue, previousValue, domNode, projectionOptions);
+		} else if (nodeOps.indexOf(propName) !== -1) {
+			nodeOp(propName, propValue, previousValue, domNode, projectionOptions);
 		} else if (propName === 'styles') {
 			const styleNames = Object.keys(propValue);
 			const styleCount = styleNames.length;

--- a/tests/unit/vdom.ts
+++ b/tests/unit/vdom.ts
@@ -4331,6 +4331,229 @@ describe('vdom', () => {
 		});
 	});
 
+	describe('blur', () => {
+		it('blur is only called once when set to true', () => {
+			const widget = getWidget(
+				v('input', {
+					blur: true
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const blurSpy = spy(input, 'blur');
+			resolvers.resolve();
+			assert.isTrue(blurSpy.calledOnce);
+			widget.renderResult = v('input', { blur: true });
+			assert.isTrue(blurSpy.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('blur is called when blur property is set to true from false', () => {
+			const widget = getWidget(
+				v('input', {
+					blur: false
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const blurSpy = spy(input, 'blur');
+			resolvers.resolve();
+			assert.isTrue(blurSpy.notCalled);
+			widget.renderResult = v('input', { blur: true });
+			resolvers.resolve();
+			assert.isTrue(blurSpy.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('Should blur if function for blur returns true', () => {
+			const shouldBlur = () => {
+				return true;
+			};
+			const widget = getWidget(
+				v('input', {
+					blur: shouldBlur
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const blurSpy = spy(input, 'blur');
+			resolvers.resolve();
+			assert.isTrue(blurSpy.calledOnce);
+			widget.renderResult = v('input', { blur: shouldBlur });
+			resolvers.resolve();
+			assert.isTrue(blurSpy.calledTwice);
+			document.body.removeChild(input);
+		});
+
+		it('Should never blur if function for blur returns false', () => {
+			const shouldBlur = () => false;
+			const widget = getWidget(
+				v('input', {
+					blur: shouldBlur
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const blurSpy = spy(input, 'blur');
+			resolvers.resolve();
+			assert.isTrue(blurSpy.notCalled);
+			widget.renderResult = v('input', { blur: shouldBlur });
+			resolvers.resolve();
+			assert.isTrue(blurSpy.notCalled);
+			document.body.removeChild(input);
+		});
+	});
+
+	describe('scrollIntoView', () => {
+		it('scrollIntoView is only called once when set to true', () => {
+			const widget = getWidget(
+				v('input', {
+					scrollIntoView: true
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const scrollIntoViewStub = stub();
+			input.scrollIntoView = scrollIntoViewStub;
+			resolvers.resolve();
+			assert.isTrue(scrollIntoViewStub.calledOnce);
+			widget.renderResult = v('input', { scrollIntoView: true });
+			assert.isTrue(scrollIntoViewStub.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('scrollIntoView is called when scrollIntoView property is set to true from false', () => {
+			const widget = getWidget(
+				v('input', {
+					scrollIntoView: false
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const scrollIntoViewStub = stub();
+			input.scrollIntoView = scrollIntoViewStub;
+			resolvers.resolve();
+			assert.isTrue(scrollIntoViewStub.notCalled);
+			widget.renderResult = v('input', { scrollIntoView: true });
+			resolvers.resolve();
+			assert.isTrue(scrollIntoViewStub.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('Should scrollIntoView if function for scrollIntoView returns true', () => {
+			const shouldScroll = () => {
+				return true;
+			};
+			const widget = getWidget(
+				v('input', {
+					scrollIntoView: shouldScroll
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const scrollIntoViewStub = stub();
+			input.scrollIntoView = scrollIntoViewStub;
+			resolvers.resolve();
+			assert.isTrue(scrollIntoViewStub.calledOnce);
+			widget.renderResult = v('input', { scrollIntoView: shouldScroll });
+			resolvers.resolve();
+			assert.isTrue(scrollIntoViewStub.calledTwice);
+			document.body.removeChild(input);
+		});
+
+		it('Should never scrollIntoView if function for scrollIntoView returns false', () => {
+			const shouldScroll = () => false;
+			const widget = getWidget(
+				v('input', {
+					scrollIntoView: shouldScroll
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const scrollIntoViewStub = stub();
+			input.scrollIntoView = scrollIntoViewStub;
+			resolvers.resolve();
+			assert.isTrue(scrollIntoViewStub.notCalled);
+			widget.renderResult = v('input', { scrollIntoView: shouldScroll });
+			resolvers.resolve();
+			assert.isTrue(scrollIntoViewStub.notCalled);
+			document.body.removeChild(input);
+		});
+	});
+
+	describe('click', () => {
+		it('click is only called once when set to true', () => {
+			const widget = getWidget(
+				v('input', {
+					click: true
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const clickSpy = spy(input, 'click');
+			resolvers.resolve();
+			assert.isTrue(clickSpy.calledOnce);
+			widget.renderResult = v('input', { click: true });
+			assert.isTrue(clickSpy.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('click is called when click property is set to true from false', () => {
+			const widget = getWidget(
+				v('input', {
+					click: false
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const clickSpy = spy(input, 'click');
+			resolvers.resolve();
+			assert.isTrue(clickSpy.notCalled);
+			widget.renderResult = v('input', { click: true });
+			resolvers.resolve();
+			assert.isTrue(clickSpy.calledOnce);
+			document.body.removeChild(input);
+		});
+
+		it('Should click if function for click returns true', () => {
+			const shouldClick = () => {
+				return true;
+			};
+			const widget = getWidget(
+				v('input', {
+					click: shouldClick
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const clickSpy = spy(input, 'click');
+			resolvers.resolve();
+			assert.isTrue(clickSpy.calledOnce);
+			widget.renderResult = v('input', { click: shouldClick });
+			resolvers.resolve();
+			assert.isTrue(clickSpy.calledTwice);
+			document.body.removeChild(input);
+		});
+
+		it('Should never click if function for click returns false', () => {
+			const shouldClick = () => false;
+			const widget = getWidget(
+				v('input', {
+					click: shouldClick
+				})
+			);
+			const projection = dom.append(document.body, widget);
+			const input = projection.domNode.lastChild as HTMLElement;
+			const clickSpy = spy(input, 'click');
+			resolvers.resolve();
+			assert.isTrue(clickSpy.notCalled);
+			widget.renderResult = v('input', { click: shouldClick });
+			resolvers.resolve();
+			assert.isTrue(clickSpy.notCalled);
+			document.body.removeChild(input);
+		});
+	});
+
 	it('i18n Mixin', () => {
 		class MyWidget extends I18nMixin(WidgetBase) {
 			render() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Expands the existing vdom support for `focus` to support `blur`, `scrollIntoView` and `click`

