### PR TITLE
Call observer.disconnect() in a closure to prevent invalid invocation

### DIFF
--- a/src/meta/Intersection.ts
+++ b/src/meta/Intersection.ts
@@ -78,7 +78,7 @@ export class Intersection extends Base {
 		const details = { observer, entries, ...options };
 
 		this._details.set(JSON.stringify(options), details);
-		this.own(createHandle(observer.disconnect));
+		this.own(createHandle(() => observer.disconnect()));
 		return details;
 	}
 


### PR DESCRIPTION
Resolves #953

**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #953 
