### PR TITLE
Update focus mixin

### DIFF
--- a/src/mixins/Focus.ts
+++ b/src/mixins/Focus.ts
@@ -1,14 +1,17 @@
 import { Constructor } from './../interfaces';
 import { WidgetBase } from './../WidgetBase';
+import { DNode, VNode, WNode } from '../interfaces';
+import { decorate, isWNode, isVNode } from '../d';
 import { diffProperty } from './../decorators/diffProperty';
+import { afterRender } from './../decorators/afterRender';
 
 export interface FocusProperties {
 	focus?: (() => boolean);
 }
 
 export interface FocusMixin {
-	focus: () => void;
-	shouldFocus: () => boolean;
+	focus: (key: string) => void;
+	focusKey?: string | number;
 	properties: FocusProperties;
 }
 
@@ -23,23 +26,61 @@ function diffFocus(previousProperty: Function, newProperty: Function) {
 export function FocusMixin<T extends Constructor<WidgetBase<FocusProperties>>>(Base: T): T & Constructor<FocusMixin> {
 	abstract class Focus extends Base {
 		public abstract properties: FocusProperties;
+		public focusKey: string | number;
 
 		private _currentToken = 0;
 
 		private _previousToken = 0;
+
+		private _currentFocusKey: string | number;
+
+		private _shouldFocusChild() {
+			return this._currentFocusKey && this._shouldFocus();
+		}
+
+		private _shouldFocusSelf() {
+			return this.properties.focus && this.focusKey !== undefined;
+		}
 
 		@diffProperty('focus', diffFocus)
 		protected isFocusedReaction() {
 			this._currentToken++;
 		}
 
-		public shouldFocus = () => {
+		@afterRender()
+		protected updateFocusProperties(result: DNode | DNode[]): DNode | DNode[] {
+			if (!this._shouldFocusChild() && !this._shouldFocusSelf()) {
+				return result;
+			}
+
+			decorate(result, {
+				modifier: (node, breaker) => {
+					if (this._shouldFocusSelf() && node.properties.key === this.focusKey) {
+						node.properties = { ...node.properties, focus: this.properties.focus };
+					} else if (node.properties.key === this._currentFocusKey) {
+						node.properties = { ...node.properties, focus: () => true };
+					}
+					breaker();
+				},
+				predicate: (node: DNode): node is VNode | WNode => {
+					if (!isVNode(node) && !isWNode(node)) {
+						return false;
+					}
+					const { key } = node.properties;
+					return key === this._currentFocusKey || (!!this.focusKey && key === this.focusKey);
+				}
+			});
+			return result;
+		}
+
+		private _shouldFocus = () => {
 			const result = this._currentToken !== this._previousToken;
 			this._previousToken = this._currentToken;
 			return result;
 		};
 
-		public focus() {
+		public focus(key: string | number) {
+			this._currentFocusKey = key;
 			this._currentToken++;
 			this.invalidate();
 		}

--- a/tests/unit/mixins/Focus.ts
+++ b/tests/unit/mixins/Focus.ts
@@ -1,39 +1,176 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
+import { stub } from 'sinon';
+import { v, w } from '../../../src/d';
 import { WidgetBase } from '../../../src/WidgetBase';
 import Focus from '../../../src/mixins/Focus';
 
-class Foo extends Focus(WidgetBase) {}
-
 describe('Focus Mixin', () => {
-	it('should allow once focus when focus property returns true', () => {
-		const widget = new Foo();
-		widget.__setProperties__({ focus: () => true });
-		assert.isTrue(widget.shouldFocus());
-		assert.isFalse(widget.shouldFocus());
-		widget.focus();
-		assert.isTrue(widget.shouldFocus());
-		assert.isFalse(widget.shouldFocus());
+	describe('this.focus()', () => {
+		it('should allow focus once per this.focus()', () => {
+			class Focusable extends Focus(WidgetBase) {
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
+
+			const widget = new Focusable();
+			widget.focus('button');
+
+			let result = widget.__render__();
+			assert.isFunction((result as any).properties!.focus);
+
+			widget.invalidate();
+			result = widget.__render__();
+			assert.isUndefined((result as any).properties!.focus);
+		});
+
+		it('should not focus without a key', () => {
+			class Focusable extends Focus(WidgetBase) {
+				render() {
+					return v('button', {});
+				}
+			}
+
+			const widget = new Focusable();
+			widget.focus('button');
+
+			let result = widget.__render__();
+			assert.isUndefined((result as any).properties!.focus);
+		});
+
+		it('should not focus incorrect key', () => {
+			class Focusable extends Focus(WidgetBase) {
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
+
+			const widget = new Focusable();
+			widget.focus('btn');
+
+			let result = widget.__render__();
+			assert.isUndefined((result as any).properties!.focus);
+		});
+
+		it('can call focus twice', () => {
+			class Focusable extends Focus(WidgetBase) {
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
+
+			const widget = new Focusable();
+			widget.focus('button');
+
+			let result = widget.__render__();
+			assert.isFunction((result as any).properties!.focus);
+
+			widget.invalidate();
+			widget.focus('button');
+			result = widget.__render__();
+			assert.isFunction((result as any).properties!.focus);
+		});
+
+		it('should set focus on child widgets', () => {
+			class Child extends Focus(WidgetBase) {}
+
+			class Parent extends Focus(WidgetBase) {
+				render() {
+					return w(Child, { key: 'child' });
+				}
+			}
+
+			const widget = new Parent();
+			widget.focus('child');
+			let result = widget.__render__();
+			assert.strictEqual((result as any).properties!.key, 'child');
+			assert.isFunction((result as any).properties!.focus);
+		});
 	});
 
-	it('should not focus when focus property returns false', () => {
-		const widget = new Foo();
-		widget.__setProperties__({ focus: () => false });
-		assert.isFalse(widget.shouldFocus());
-		widget.focus();
-		assert.isTrue(widget.shouldFocus());
-		assert.isFalse(widget.shouldFocus());
-		widget.__setProperties__({ focus: () => true });
-		assert.isTrue(widget.shouldFocus());
-		assert.isFalse(widget.shouldFocus());
-	});
+	describe('properties.focus', () => {
+		it('should pass focus property to child', () => {
+			class Focusable extends Focus(WidgetBase) {
+				focusKey = 'button';
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
 
-	it('should not focus when is not passed', () => {
-		const widget = new Foo();
-		widget.__setProperties__({});
-		assert.isFalse(widget.shouldFocus());
-		widget.focus();
-		assert.isTrue(widget.shouldFocus());
-		assert.isFalse(widget.shouldFocus());
+			const focusStub = stub().returns(true);
+			const widget = new Focusable();
+			widget.__setProperties__({ focus: focusStub });
+
+			let result = widget.__render__();
+			assert.isTrue((result as any).properties!.focus());
+		});
+
+		it('should not pass focus property with no focusKey', () => {
+			class Focusable extends Focus(WidgetBase) {
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
+
+			const widget = new Focusable();
+			widget.__setProperties__({ focus: true });
+
+			let result = widget.__render__();
+			assert.isUndefined((result as any).properties!.focus);
+		});
+
+		it('should not pass focus property with incorrect focusKey', () => {
+			class Focusable extends Focus(WidgetBase) {
+				focusKey = 'btn';
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
+
+			const widget = new Focusable();
+			widget.__setProperties__({ focus: true });
+
+			let result = widget.__render__();
+			assert.isUndefined((result as any).properties!.focus);
+		});
+
+		it('should always pass focus property to child', () => {
+			class Focusable extends Focus(WidgetBase) {
+				focusKey = 'button';
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
+
+			const widget = new Focusable();
+			widget.__setProperties__({ focus: true });
+
+			let result = widget.__render__();
+			assert.isTrue((result as any).properties!.focus);
+
+			widget.invalidate();
+			result = widget.__render__();
+			assert.isTrue((result as any).properties!.focus);
+		});
+
+		it('should diff focus function', () => {
+			class Focusable extends Focus(WidgetBase) {
+				focusKey = 'button';
+				render() {
+					return v('button', { key: 'button' });
+				}
+			}
+
+			const widget = new Focusable();
+			widget.__setProperties__({ focus: () => true });
+
+			let result = widget.__render__();
+			assert.isTrue((result as any).properties!.focus());
+
+			widget.__setProperties__({ focus: () => false });
+			result = widget.__render__();
+			assert.isUndefined((result as any).properties!.focus);
+		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Makes it possible to call focus in a more intuitive way, with `this.focus('key')`. It also handles having `properties.focus` set by a parent, allowing you to call `this.focus('widgetChild')` on children that use the FocusMixin.
