### PR TITLE
Default to auto diff for diffProperty

### DIFF
--- a/src/decorators/diffProperty.ts
+++ b/src/decorators/diffProperty.ts
@@ -1,5 +1,6 @@
 import { handleDecorator } from './handleDecorator';
 import { DiffPropertyFunction } from './../interfaces';
+import { auto } from './../diff';
 
 /**
  * Decorator that can be used to register a function as a specific property diff
@@ -8,7 +9,11 @@ import { DiffPropertyFunction } from './../interfaces';
  * @param diffType      The diff type, default is DiffType.AUTO.
  * @param diffFunction  A diff function to run if diffType if DiffType.CUSTOM
  */
-export function diffProperty(propertyName: string, diffFunction: DiffPropertyFunction, reactionFunction?: Function) {
+export function diffProperty(
+	propertyName: string,
+	diffFunction: DiffPropertyFunction = auto,
+	reactionFunction?: Function
+) {
 	return handleDecorator((target, propertyKey) => {
 		target.addDecorator(`diffProperty:${propertyName}`, diffFunction.bind(null));
 		target.addDecorator('registeredDiffProperty', propertyName);

--- a/tests/unit/decorators/diffProperty.ts
+++ b/tests/unit/decorators/diffProperty.ts
@@ -34,6 +34,25 @@ registerSuite('decorators/diffProperty', {
 			testWidget.__setProperties__({ id: '', foo: 'bar' });
 			assert.equal(callCount, 1);
 		},
+		'diff property with default diff'() {
+			let callCount = 0;
+
+			class TestWidget extends WidgetBase<TestProperties> {
+				@diffProperty('foo')
+				protected reaction() {
+					callCount++;
+				}
+			}
+
+			const testWidget = new TestWidget();
+
+			testWidget.__setProperties__({ id: '', foo: 'bar' });
+			assert.equal(callCount, 1);
+			testWidget.__setProperties__({ id: '', foo: 'bar' });
+			assert.equal(callCount, 1);
+			testWidget.__setProperties__({ id: '', foo: 'foo' });
+			assert.equal(callCount, 2);
+		},
 		'diff with reaction': {
 			'reaction does not execute if no registered properties are changed'() {
 				let callCount = 0;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Default the diff on `diffProperty` to `auto`
